### PR TITLE
Use native ARM64 runner for faster builds

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Build ARMv7 binary with Docker
         run: |
           # Build using arm32v7 container - runs natively on ARM64
+          # --platform ensures correct 32-bit ARM image is pulled
           docker build \
+            --platform linux/arm/v7 \
             -f Dockerfile.arm \
             -t kindle-hid-passthrough-builder \
             .

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -31,11 +31,11 @@ ENV PATH="/usr/lib/ccache:${PATH}"
 # that occurs with large generated code (like bumble.hci module):
 # - -mword-relocations: enables word-sized relocations for ARM
 # - -ffunction-sections -fdata-sections: split code/data into smaller sections
-# - -O2: reduced optimization (O3 creates functions too large for ARM branches)
+# - -O1: minimal optimization (O2/O3 create functions too large for ARM branches)
 # CCFLAGS overrides Nuitka's default -O3 optimization level
 # The linker will use --gc-sections to remove unused sections
 ENV CFLAGS="-mword-relocations -ffunction-sections -fdata-sections"
-ENV CCFLAGS="-O2"
+ENV CCFLAGS="-O1"
 ENV LDFLAGS="-Wl,--gc-sections"
 
 # Set working directory


### PR DESCRIPTION
## Summary
- Switch from x86 QEMU emulation to native ARM64 GitHub runner (`ubuntu-24.04-arm`)
- Fix "conditional branch out of range" error with proper CFLAGS/CCFLAGS
- Remove QEMU and Docker Buildx setup (no longer needed)

## Changes
- **Runner**: `ubuntu-latest` → `ubuntu-24.04-arm` (native ARM64 with AArch32 EL0 support)
- **CCFLAGS**: Added `-O2` to override Nuitka's default `-O3` (fixes ARM branch range issue)
- **CFLAGS**: Added `-ffunction-sections -fdata-sections`
- **LDFLAGS**: Added `-Wl,--gc-sections`

## Expected Improvements
| Aspect | Before | After |
|--------|--------|-------|
| Build time | 3-4 hours | ~10-30 minutes |
| Reliability | Fragile (QEMU issues) | Stable (native execution) |

## Test plan
- [ ] CI workflow runs successfully on ARM64 runner
- [ ] Binary is 32-bit ARM (armv7l), not 64-bit
- [ ] Binary runs on Kindle device

🤖 Generated with [Claude Code](https://claude.ai/code)