### PR TITLE
use public address for ble pairing for consistent address between pairing and reconnection

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -16,7 +16,7 @@ import logging
 from typing import Optional, List, Dict
 
 from bumble.device import Device, Peer
-from bumble.hci import Address, HCI_Reset_Command
+from bumble.hci import Address, HCI_Reset_Command, OwnAddressType
 from bumble.gatt import (
     GATT_GENERIC_ACCESS_SERVICE,
     GATT_DEVICE_NAME_CHARACTERISTIC,
@@ -204,8 +204,11 @@ class BLEHIDHost:
         target = Address(address)
         try:
             self.connection = await asyncio.wait_for(
-                self.device.connect(target),
-                timeout=config.connect_timeout
+                self.device.connect(
+                    target,
+                    own_address_type=OwnAddressType.PUBLIC
+                ),
+                timeout=config.connect_timeout,
             )
         except Exception as e:
             log.error(f"Connection failed: {e}")
@@ -311,7 +314,7 @@ class BLEHIDHost:
         target = Address(target_address)
         try:
             self.connection = await asyncio.wait_for(
-                self.device.connect(target),
+                self.device.connect(target, own_address_type=OwnAddressType.PUBLIC),
                 timeout=config.connect_timeout
             )
         except asyncio.TimeoutError:


### PR DESCRIPTION
I was having issues with consistency with the address my host was sending to the client, this seems to have fixed that in my case.

May have to do with the fact that I am using bumble's built in `cryptography` package fallbacks (couldnt get cryptography module working on my kindle) 

<img width="877" height="348" alt="image" src="https://github.com/user-attachments/assets/7e0b0565-2553-43ba-8f77-41989e340b5e" />
