### PR TITLE
Upgrade bumble dependency to 0.0.222

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -22,7 +22,7 @@ RUN pip install --no-cache-dir \
     nuitka \
     ordered-set \
     zstandard \
-    bumble>=0.0.193 \
+    bumble>=0.0.222 \
     aiofiles>=23.0.0
 
 # Enable ccache for faster C compilation


### PR DESCRIPTION
## Summary
- Updates minimum bumble version from 0.0.193 to 0.0.222
- All existing imports verified compatible with the new version

## Test plan
- [x] Verified all bumble imports work with 0.0.222
- [x] Python syntax check passes
- [ ] Test on Kindle device