### PR TITLE
Add automatic Bluetooth hardware preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,18 @@ Pre-built ARM binaries are available from [GitHub Releases](https://github.com/z
 
    The release contains a `dist/` directory with a bundled Python runtime and all dependencies — no Python installation required on the Kindle.
 
-2. Set up the Bluetooth transport (required before first run):
-
+2. Pair your device and test:
    ```bash
-   # Load the BT kernel module
-   insmod /lib/modules/4.9.77-lab126/extra/wmt_cdev_bt.ko
-
-   # Kill Amazon's conflicting BT processes
-   killall bluetoothd vhci_stpbt_bridge
+   /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --pair
+   /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon
    ```
-   Without this, `/dev/stpbt` won't exist and the program will fail with `FileNotFoundError`.
 
+   Bluetooth hardware setup (kernel module loading, killing conflicting processes) is handled automatically on startup.
+
+3. (Optional) Install the upstart config for autostart:
+   ```bash
+   cp /mnt/us/kindle_hid_passthrough/hid-passthrough.upstart /etc/upstart/hid-passthrough.conf
+   ```
 
 ## Usage
 

--- a/kindle_hid_passthrough/bt_setup.py
+++ b/kindle_hid_passthrough/bt_setup.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Bluetooth hardware setup for Kindle.
+
+Ensures the BT kernel module is loaded and Amazon's conflicting
+BT processes are stopped before opening the HCI transport.
+
+Auto-detects kernel version and module paths. Override via config.ini:
+
+    [bluetooth]
+    module_patterns = wmt_cdev_bt.ko, bt_drv.ko
+    kill_processes = bluetoothd, vhci_stpbt_bridge
+    settle_time = 0.5
+
+"""
+
+import glob
+import os
+import subprocess
+import time
+
+from logging_utils import log
+
+# Known BT kernel module patterns across Kindle versions
+DEFAULT_MODULE_PATTERNS = [
+    'wmt_cdev_bt.ko',   # MediaTek (PW4/5, Kindle 10/11, Scribe)
+    'bt_drv.ko',         # Older Freescale/NXP Kindles
+]
+
+# Known Amazon BT processes that hold /dev/stpbt
+DEFAULT_KILL_PROCESSES = [
+    'bluetoothd',
+    'vhci_stpbt_bridge',
+]
+
+
+def _run(cmd, **kwargs):
+    """Run a command silently, return success."""
+    try:
+        r = subprocess.run(cmd, capture_output=True, timeout=10, **kwargs)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _find_bt_module(patterns=None):
+    """Find the BT kernel module path for the running kernel.
+
+    Returns:
+        Module path string, or None if not found.
+    """
+    patterns = patterns or DEFAULT_MODULE_PATTERNS
+
+    try:
+        uname = os.uname().release
+    except Exception:
+        return None
+
+    base = f'/lib/modules/{uname}/extra'
+
+    for pattern in patterns:
+        matches = glob.glob(f'{base}/{pattern}')
+        if matches:
+            return matches[0]
+        # Also check subdirectories
+        matches = glob.glob(f'{base}/**/{pattern}', recursive=True)
+        if matches:
+            return matches[0]
+
+    return None
+
+
+def _is_module_loaded(module_path):
+    """Check if a kernel module is already loaded."""
+    mod_name = os.path.basename(module_path).replace('.ko', '')
+    try:
+        with open('/proc/modules', 'r') as f:
+            for line in f:
+                if line.split()[0] == mod_name:
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def _kill_processes(names=None):
+    """Kill conflicting BT processes.
+
+    Returns:
+        Number of processes killed.
+    """
+    names = names or DEFAULT_KILL_PROCESSES
+    killed = 0
+    for name in names:
+        if _run(['killall', name]):
+            log.info(f"Killed {name}")
+            killed += 1
+    return killed
+
+
+def _is_device_free(device_path):
+    """Check if the BT device can be opened."""
+    try:
+        fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
+        os.close(fd)
+        return True
+    except OSError:
+        return False
+
+
+def prepare_bt(transport_spec=None, module_patterns=None,
+               kill_processes=None, settle_time=0.5):
+    """Prepare Bluetooth hardware for use.
+
+    1. Load BT kernel module if not already loaded
+    2. Kill Amazon's conflicting BT processes
+    3. Wait for device to settle
+
+    Args:
+        transport_spec: Transport string (e.g. 'file:/dev/stpbt') to
+                       extract device path. If None, uses /dev/stpbt.
+        module_patterns: List of module filename patterns to search for.
+        kill_processes: List of process names to kill.
+        settle_time: Seconds to wait after killing processes.
+
+    Returns:
+        True if BT device is ready.
+    """
+    # Extract device path from transport spec
+    device_path = '/dev/stpbt'
+    if transport_spec and transport_spec.startswith('file:'):
+        device_path = transport_spec[5:]
+
+    log.info("Preparing Bluetooth hardware...")
+
+    # Step 1: Load kernel module
+    module_path = _find_bt_module(module_patterns)
+    if module_path:
+        if _is_module_loaded(module_path):
+            log.info(f"BT module already loaded: {os.path.basename(module_path)}")
+        else:
+            log.info(f"Loading BT module: {module_path}")
+            if _run(['/sbin/insmod', module_path]):
+                log.info("BT module loaded")
+                time.sleep(0.5)  # wait for /dev node to appear
+            else:
+                log.warning(f"Failed to load {module_path} (may need root)")
+    else:
+        log.info("No BT kernel module found (may already be built-in)")
+
+    # Step 2: Check if device is available
+    if not os.path.exists(device_path):
+        log.warning(f"{device_path} does not exist")
+        return False
+
+    if _is_device_free(device_path):
+        log.info(f"{device_path} is available")
+        return True
+
+    # Step 3: Device is busy - kill conflicting processes
+    log.info(f"{device_path} is busy, stopping conflicting processes...")
+    killed = _kill_processes(kill_processes)
+
+    if killed > 0 and settle_time > 0:
+        time.sleep(settle_time)
+
+    # Step 4: Verify
+    if _is_device_free(device_path):
+        log.info(f"{device_path} is now available")
+        return True
+
+    # Last resort: try again with a longer wait
+    log.warning(f"{device_path} still busy, waiting 2s...")
+    time.sleep(2.0)
+
+    if _is_device_free(device_path):
+        log.info(f"{device_path} is now available")
+        return True
+
+    log.warning(f"{device_path} still busy after cleanup")
+    return False

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -87,6 +87,11 @@ class Config:
         self.connect_timeout = self._getint('connection', 'connect_timeout', 30)
         self.transport_timeout = self._getint('connection', 'transport_timeout', 30)
 
+        # Bluetooth hardware setup
+        self.bt_module_patterns = self._get_list('bluetooth', 'module_patterns', None)
+        self.bt_kill_processes = self._get_list('bluetooth', 'kill_processes', None)
+        self.bt_settle_time = float(self._get('bluetooth', 'settle_time', '0.5'))
+
         # Device identity
         self.device_name = self._get('device', 'name', 'Kindle-HID')
         self.device_address = self._get('device', 'address', 'F0:F0:F0:F0:F0:F0')
@@ -104,6 +109,14 @@ class Config:
     def _get(self, section: str, key: str, default: str) -> str:
         try:
             return self._parser.get(section, key)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            return default
+
+    def _get_list(self, section: str, key: str, default):
+        """Get a comma-separated list from config, or return default."""
+        try:
+            raw = self._parser.get(section, key)
+            return [s.strip() for s in raw.split(',') if s.strip()]
         except (configparser.NoSectionError, configparser.NoOptionError):
             return default
 

--- a/kindle_hid_passthrough/hid-passthrough-dev.upstart
+++ b/kindle_hid_passthrough/hid-passthrough-dev.upstart
@@ -9,16 +9,5 @@ respawn limit 5 60
 env KINDLE_HID_BASE=/mnt/us/kindle_hid_passthrough
 
 script
-    # Load Bluetooth kernel module if not loaded
-    if ! lsmod | grep -q wmt_cdev_bt; then
-        /sbin/insmod /lib/modules/4.9.77-lab126/extra/wmt_cdev_bt.ko || true
-        sleep 1
-    fi
-
-    # Kill any conflicting processes
-    killall bluetoothd 2>/dev/null || true
-    killall vhci_stpbt_bridge 2>/dev/null || true
-    sleep 1
-
     exec /mnt/us/python3.10-kindle/python3-wrapper.sh /mnt/us/kindle_hid_passthrough/daemon.py
 end script

--- a/kindle_hid_passthrough/hid-passthrough.upstart
+++ b/kindle_hid_passthrough/hid-passthrough.upstart
@@ -9,16 +9,5 @@ respawn limit 5 60
 env KINDLE_HID_BASE=/mnt/us/kindle_hid_passthrough
 
 script
-    # Load Bluetooth kernel module if not loaded
-    if ! lsmod | grep -q wmt_cdev_bt; then
-        /sbin/insmod /lib/modules/4.9.77-lab126/extra/wmt_cdev_bt.ko || true
-        sleep 1
-    fi
-
-    # Kill any conflicting processes
-    killall bluetoothd 2>/dev/null || true
-    killall vhci_stpbt_bridge 2>/dev/null || true
-    sleep 1
-
     exec /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon
 end script

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -40,6 +40,7 @@ from bumble.transport import open_transport
 from config import Protocol, __version__, config, get_fallback_hid_descriptor, normalize_addr
 from device_cache import DeviceCache
 from logging_utils import log
+from bt_setup import prepare_bt
 from uhid_handler import Bus, UHIDDevice, UHIDError
 
 __all__ = ['HIDHost']
@@ -181,6 +182,15 @@ class HIDHost:
     async def start(self):
         """Initialize the Bumble device with both protocols."""
         log.info(f"HID Host v{__version__}")
+
+        # Ensure BT hardware is available
+        prepare_bt(
+            transport_spec=self.transport_spec,
+            module_patterns=config.bt_module_patterns,
+            kill_processes=config.bt_kill_processes,
+            settle_time=config.bt_settle_time,
+        )
+
         log.info("Opening transport...")
 
         try:


### PR DESCRIPTION
## Summary
- Add `bt_setup.py` module that auto-detects and prepares BT hardware before transport open
- Auto-loads kernel module (`wmt_cdev_bt.ko` for MediaTek, `bt_drv.ko` for older Kindles)
- Kills conflicting Amazon processes (`bluetoothd`, `vhci_stpbt_bridge`) if device is busy
- Retries with backoff if device remains busy after cleanup
- All defaults overridable via `config.ini` `[bluetooth]` section

## Test plan
- [ ] Deploy to Kindle and verify BT module is auto-loaded on startup
- [ ] Verify conflicting processes are killed when /dev/stpbt is busy
- [ ] Verify clean startup when no conflicts exist (no unnecessary kills)
- [ ] Test config.ini overrides for module_patterns and kill_processes