### PR TITLE
chore(ci): bump GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build ARMv7 binary with Docker
         run: |
@@ -68,7 +68,7 @@ jobs:
           ls -lh *.tar.gz
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: kindle-hid-passthrough-armv7
           path: |
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: kindle-hid-passthrough-armv7.tar.gz
         env:


### PR DESCRIPTION
GitHub is forcing all Node.js 20 actions to run on Node.js 24 starting June 2nd. This bumps all four actions in the build workflow to their latest Node 24 compatible releases (checkout v6, setup-buildx v4, upload-artifact v7, action-gh-release v2). No breaking API changes for our usage, just runtime upgrades.