### PR TITLE
chore: bump version to 3.3.0

### DIFF
--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -19,7 +19,7 @@ from kindle_detect import detect_kindle
 if TYPE_CHECKING:
     pass
 
-__version__ = "3.2.2"
+__version__ = "3.3.0"
 
 __all__ = ['config', 'Config', 'Protocol', 'get_fallback_hid_descriptor', 'normalize_addr', '__version__']
 


### PR DESCRIPTION
## Summary
- Bump version from 3.2.2 to 3.3.0 following BLE pairing and connection handoff improvements merged in #38