### PR TITLE
build: enable LTO for Nuitka compilation

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -65,7 +65,7 @@ RUN printf '%s\n' \
 RUN python3 -m nuitka \
     --mode=standalone \
     --jobs=$(nproc) \
-    --lto=no \
+    --lto=yes \
     --show-progress \
     --output-dir=/build/nuitka-out \
     --include-package=kindle_hid_passthrough \


### PR DESCRIPTION
## Summary
- Enable Link-Time Optimization (`--lto=yes`) in the Nuitka build, replacing `--lto=no`
- Measured ~22% reduction in total scons time: 1493s baseline → 1169s with LTO (compile 345s + link 824s)
- LTO allows the compiler to optimize across translation units at link time, eliminating dead code and enabling cross-module inlining

## Test plan
- [x] CI build passes on `optimize/nuitka-lto` branch
- [ ] Verify binary runs correctly on Kindle
- [ ] Compare binary size vs non-LTO build