### PR TITLE
build: enable LTO and -O3 for Nuitka compilation

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -40,7 +40,7 @@ COPY kindle_hid_passthrough/*.py /build/kindle_hid_passthrough/
 COPY kindle_hid_passthrough/config.ini /build/kindle_hid_passthrough/
 
 # ARM-specific compiler flags to fix branch range errors
-ENV CFLAGS="-mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
+ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
 ENV LDFLAGS="-Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
@@ -65,7 +65,7 @@ RUN printf '%s\n' \
 RUN python3 -m nuitka \
     --mode=standalone \
     --jobs=$(nproc) \
-    --lto=no \
+    --lto=yes \
     --show-progress \
     --output-dir=/build/nuitka-out \
     --include-package=kindle_hid_passthrough \


### PR DESCRIPTION
The Nuitka C compilation phase takes ~22 minutes and dominates the CI build. This enables LTO (`--lto=yes`) and adds `-O3` to CFLAGS to test whether aggressive optimization affects build time or binary size/performance. Currently LTO is explicitly disabled (`--lto=no`) with no documented reason.