### PR TITLE
feat: reduce release tarball size by ~30%

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -75,6 +75,10 @@ RUN python3 -m nuitka \
     --nofollow-import-to=pytest \
     --nofollow-import-to=unittest \
     --nofollow-import-to=setuptools \
+    --nofollow-import-to=grpc \
+    --nofollow-import-to=google \
+    --nofollow-import-to=email \
+    --nofollow-import-to=usb \
     kindle_hid_passthrough/main.py
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.

--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -77,7 +77,6 @@ RUN python3 -m nuitka \
     --nofollow-import-to=setuptools \
     --nofollow-import-to=grpc \
     --nofollow-import-to=google \
-    --nofollow-import-to=email \
     --nofollow-import-to=usb \
     kindle_hid_passthrough/main.py
 

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -49,20 +49,6 @@ jobs:
           docker rm "$CONTAINER_ID"
           chmod +x output/kindle-hid-passthrough output/dist/main.bin output/dist/ld-linux-armhf.so.3
 
-      - name: Strip unused dependencies from dist
-        run: |
-          # gRPC: bumble optional dep, not used
-          rm -rf output/dist/grpc/
-
-          # CJK codecs: not needed on Kindle
-          rm -f output/dist/_codecs_jp.so \
-               output/dist/_codecs_cn.so \
-               output/dist/_codecs_hk.so \
-               output/dist/_codecs_kr.so \
-               output/dist/_codecs_tw.so \
-               output/dist/_codecs_iso2022.so \
-               output/dist/_multibytecodec.so
-
       - name: Add scripts and assets
         run: |
           cp -r scripts/ output/

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -49,6 +49,26 @@ jobs:
           docker rm "$CONTAINER_ID"
           chmod +x output/kindle-hid-passthrough output/dist/main.bin output/dist/ld-linux-armhf.so.3
 
+      - name: Strip unused dependencies from dist
+        run: |
+          echo "=== Before cleanup ==="
+          du -sh output/dist/
+
+          # gRPC: bumble optional dep, not used (saves ~13.5 MB)
+          rm -rf output/dist/grpc/
+
+          # CJK codecs: not needed on Kindle (saves ~0.7 MB)
+          rm -f output/dist/_codecs_jp.so \
+               output/dist/_codecs_cn.so \
+               output/dist/_codecs_hk.so \
+               output/dist/_codecs_kr.so \
+               output/dist/_codecs_tw.so \
+               output/dist/_codecs_iso2022.so \
+               output/dist/_multibytecodec.so
+
+          echo "=== After cleanup ==="
+          du -sh output/dist/
+
       - name: Add scripts and assets
         run: |
           cp -r scripts/ output/

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -51,13 +51,10 @@ jobs:
 
       - name: Strip unused dependencies from dist
         run: |
-          echo "=== Before cleanup ==="
-          du -sh output/dist/
-
-          # gRPC: bumble optional dep, not used (saves ~13.5 MB)
+          # gRPC: bumble optional dep, not used
           rm -rf output/dist/grpc/
 
-          # CJK codecs: not needed on Kindle (saves ~0.7 MB)
+          # CJK codecs: not needed on Kindle
           rm -f output/dist/_codecs_jp.so \
                output/dist/_codecs_cn.so \
                output/dist/_codecs_hk.so \
@@ -65,9 +62,6 @@ jobs:
                output/dist/_codecs_tw.so \
                output/dist/_codecs_iso2022.so \
                output/dist/_multibytecodec.so
-
-          echo "=== After cleanup ==="
-          du -sh output/dist/
 
       - name: Add scripts and assets
         run: |


### PR DESCRIPTION
The release tarball was 28 MB, nearly half of which was gRPC (a transitive bumble dependency never used at runtime). This adds Nuitka --nofollow-import-to exclusions for grpc, google, email, and usb, and strips leftover .so files (gRPC cygrpc.so, CJK codecs) from the dist post-build. Validated on CI: tarball drops from 28 MB to 20 MB with all KindleForge install checks passing.