### PR TITLE
fix: remove dead code and use Bumble native connect timeout

### DIFF
--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -54,7 +54,7 @@ class APIServer(ThreadingMixIn, HTTPServer):
 class RequestHandler(BaseHTTPRequestHandler):
     """HTTP request handler for BTManager API."""
 
-    def log_message(self, format, *args):
+    def log_message(self, _format, *args):
         """Suppress default stderr logging."""
         pass
 

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -13,7 +13,7 @@ import logging
 import os
 import subprocess
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from kindle_detect import detect_kindle
 
@@ -173,13 +173,6 @@ class Config:
 
         return None
 
-    @property
-    def kindle_defaults(self):
-        """Return detected Kindle hardware defaults, or None."""
-        if not hasattr(self, '_kindle_defaults'):
-                self._kindle_defaults = detect_kindle()
-        return self._kindle_defaults
-
     def _parse_protocol(self, protocol_str: str) -> Protocol:
         """Parse protocol string to Protocol enum."""
         if protocol_str in ('classic', 'br/edr', 'bredr'):
@@ -331,15 +324,6 @@ class Config:
         except Exception as e:
             logger.error(f"Failed to save device: {e}")
 
-    def get_device_config(self) -> Optional[tuple]:
-        """Load first device address, protocol, and name from devices.conf.
-
-        Returns:
-            Tuple of (address, protocol, name) or None if not configured
-        """
-        devices = self.get_all_devices()
-        return devices[0] if devices else None
-
     def get_all_devices(self) -> list:
         """Load all devices from devices.conf.
 
@@ -369,40 +353,6 @@ class Config:
                     devices.append((address, protocol, name))
 
         return devices
-
-    def is_device_allowed(self, address: str) -> tuple:
-        """Check if a device address is in the allowed list.
-
-        Args:
-            address: Device address to check (may have /P suffix from Bumble)
-
-        Returns:
-            Tuple of (allowed: bool, protocol: Protocol or None)
-        """
-        devices = self.get_all_devices()
-        if not devices:
-            return (False, None)
-
-        addr_norm = normalize_addr(address)
-
-        for dev_addr, protocol, _ in devices:
-            if dev_addr == '*':
-                return (True, protocol)
-            if addr_norm == dev_addr:
-                return (True, protocol)
-
-        return (False, None)
-
-
-def get_configured_protocols() -> set:
-    """Get the set of protocols configured in devices.conf.
-
-    Returns:
-        Set of Protocol enums (may contain BLE, CLASSIC, or both)
-    """
-    devices = config.get_all_devices()
-    return {d[1] for d in devices}
-
 
 def get_fallback_hid_descriptor() -> bytes:
     """Return a generic fallback HID report descriptor.

--- a/kindle_hid_passthrough/device_cache.py
+++ b/kindle_hid_passthrough/device_cache.py
@@ -11,7 +11,7 @@ Author: Lucas Zampieri <lzampier@redhat.com>
 import json
 import logging
 import os
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -142,24 +142,3 @@ class DeviceCache:
             except Exception as e:
                 logger.warning(f"Failed to clear all caches: {e}")
 
-    def list_cached_devices(self) -> List[str]:
-        """List all devices with cached data
-
-        Returns:
-            List of device addresses (formatted with colons)
-        """
-        devices = []
-        try:
-            for filename in os.listdir(self.cache_dir):
-                if filename.endswith('.json'):
-                    # Convert filename back to address format
-                    addr = filename[:-5].replace('_', ':')
-                    devices.append(addr)
-        except Exception as e:
-            logger.warning(f"Failed to list cached devices: {e}")
-
-        return devices
-
-
-# Backwards compatibility alias
-GATTCache = DeviceCache

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -12,7 +12,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import List, Optional
 
-from bumble.core import BT_BR_EDR_TRANSPORT, BT_LE_TRANSPORT, BT_HUMAN_INTERFACE_DEVICE_SERVICE, InvalidStateError
+from bumble.core import BT_BR_EDR_TRANSPORT, BT_LE_TRANSPORT, BT_HUMAN_INTERFACE_DEVICE_SERVICE, InvalidStateError, TimeoutError as BumbleTimeoutError
 from bumble.device import Device, Peer
 from bumble.gatt import (
     GATT_DEVICE_NAME_CHARACTERISTIC,
@@ -495,8 +495,9 @@ class HIDHost:
 
         target = Address(address)
         try:
-            self.connection = await asyncio.wait_for(
-                self.device.connect(target, own_address_type=OwnAddressType.PUBLIC),
+            self.connection = await self.device.connect(
+                target,
+                own_address_type=OwnAddressType.PUBLIC,
                 timeout=config.connect_timeout,
             )
         except Exception as e:
@@ -576,12 +577,13 @@ class HIDHost:
 
         try:
             target_address = Address(address, Address.PUBLIC_DEVICE_ADDRESS)
-            self.connection = await asyncio.wait_for(
-                self.device.connect(target_address, transport=BT_BR_EDR_TRANSPORT),
-                timeout=config.connect_timeout
+            self.connection = await self.device.connect(
+                target_address,
+                transport=BT_BR_EDR_TRANSPORT,
+                timeout=config.connect_timeout,
             )
             log.success(f"[Classic] Connected to {address}")
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, BumbleTimeoutError):
             log.error(f"[Classic] Connection timeout after {config.connect_timeout}s")
             return False
         except Exception as e:
@@ -774,9 +776,10 @@ class HIDHost:
         if not self.connection:
             log.info(f"[BLE] Reconnecting to {self.current_device_address}...")
             target = Address(self.current_device_address)
-            self.connection = await asyncio.wait_for(
-                self.device.connect(target, own_address_type=OwnAddressType.PUBLIC),
-                timeout=config.connect_timeout
+            self.connection = await self.device.connect(
+                target,
+                own_address_type=OwnAddressType.PUBLIC,
+                timeout=config.connect_timeout,
             )
             self.peer = Peer(self.connection)
             self.connection.on('disconnection', self._on_disconnection)
@@ -1255,9 +1258,10 @@ class HIDHost:
                 for attempt in range(1, max_attempts + 1):
                     try:
                         log.info(f"[BLE] Connecting to {found_device.address} (Attempt {attempt}/{max_attempts})...")
-                        self.connection = await asyncio.wait_for(
-                            self.device.connect(found_device.address, own_address_type=OwnAddressType.PUBLIC),
-                            timeout=config.connect_timeout
+                        self.connection = await self.device.connect(
+                            found_device.address,
+                            own_address_type=OwnAddressType.PUBLIC,
+                            timeout=config.connect_timeout,
                         )
 
                         if self._connection_future.done():

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -594,7 +594,7 @@ class HIDHost:
         # Track link key generation
         link_key_received = asyncio.Event()
 
-        def on_device_link_key(bd_addr, link_key, key_type):
+        def on_device_link_key(_bd_addr, link_key, key_type):
             log.success(f"[Classic] Link key received: type={key_type}")
             link_key_received.set()
 

--- a/kindle_hid_passthrough/kindle_detect.py
+++ b/kindle_hid_passthrough/kindle_detect.py
@@ -164,15 +164,3 @@ def detect_kindle(serial: str = None) -> Optional[KindleDefaults]:
     )
     log.info(f"Detected {name} (code 0x{device_code:X})")
     return defaults
-
-
-def get_default_transport() -> Optional[str]:
-    """Get the default HCI transport spec for this Kindle.
-
-    Returns:
-        Transport string like 'file:/dev/stpbt' or None if unknown.
-    """
-    defaults = detect_kindle()
-    if defaults and os.path.exists(defaults.device_path):
-        return f'file:{defaults.device_path}'
-    return None

--- a/kindle_hid_passthrough/logging_utils.py
+++ b/kindle_hid_passthrough/logging_utils.py
@@ -97,13 +97,6 @@ class HIDLogger:
         if self._console_output and self.logger.isEnabledFor(logging.DEBUG):
             print(color(formatted, 'cyan'))
 
-    def detail(self, msg: str):
-        """Log detail message without timestamp (cyan, indented)"""
-        self.logger.info(msg)
-
-        if self._console_output:
-            print(color(f"    {msg}", 'cyan'))
-
     def raw(self, msg: str):
         """Print raw message without formatting"""
         if self._console_output:

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -240,7 +240,7 @@ class Scanner:
             is_hid = False
             major_class_name = "Unknown"
             try:
-                _, major_class, minor_class = DeviceClass.split_class_of_device(class_of_device)
+                _, major_class, _minor_class = DeviceClass.split_class_of_device(class_of_device)
                 major_class_name = DeviceClass.major_device_class_name(major_class)
                 is_hid = major_class_name == "Peripheral"
             except Exception:

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -308,7 +308,7 @@ class UHIDDevice:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
         self.destroy()
         return False
 

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -10,9 +10,8 @@ Author: Lucas Zampieri <lzampier@redhat.com>
 
 import logging
 import os
-import select
 import struct
-from typing import Callable, Optional
+from typing import Optional
 
 __all__ = ['UHIDDevice', 'UHIDError', 'Bus']
 
@@ -22,28 +21,14 @@ logger = logging.getLogger(__name__)
 UHID_CREATE2 = 11
 UHID_DESTROY = 1
 UHID_INPUT2 = 12
-UHID_START = 2
-UHID_STOP = 3
-UHID_OPEN = 4
-UHID_CLOSE = 5
-UHID_OUTPUT = 6
-
 # Maximum sizes
 HID_MAX_DESCRIPTOR_SIZE = 4096
 UHID_DATA_MAX = 4096
 
-# Event struct size for reading
-UHID_EVENT_SIZE = 4 + 4380  # type + largest union member
-
 
 class Bus:
     """Bus types for HID devices."""
-    PCI = 0x01
-    ISAPNP = 0x02
-    USB = 0x03
-    HIL = 0x04
     BLUETOOTH = 0x05
-    VIRTUAL = 0x06
 
 
 class UHIDError(Exception):
@@ -113,14 +98,6 @@ class UHIDDevice:
 
         self._fd: Optional[int] = None
         self._created = False
-        self._started = False
-
-        # Callbacks for kernel events
-        self.on_start: Optional[Callable[[], None]] = None
-        self.on_stop: Optional[Callable[[], None]] = None
-        self.on_open: Optional[Callable[[], None]] = None
-        self.on_close: Optional[Callable[[], None]] = None
-        self.on_output: Optional[Callable[[bytes, int], None]] = None
 
         self._open_uhid()
         self._create_device()
@@ -226,79 +203,6 @@ class UHIDDevice:
         except OSError:
             pass
         self._fd = None
-
-    def poll_events(self, timeout: float = 0) -> bool:
-        """Poll for kernel events (OUTPUT reports, etc.).
-
-        Args:
-            timeout: Timeout in seconds (0 = non-blocking)
-
-        Returns:
-            True if an event was processed, False otherwise
-        """
-        if self._fd is None:
-            return False
-
-        readable, _, _ = select.select([self._fd], [], [], timeout)
-
-        if not readable:
-            return False
-
-        try:
-            data = os.read(self._fd, UHID_EVENT_SIZE)
-            if len(data) < 4:
-                return False
-
-            event_type = struct.unpack_from('< L', data)[0]
-            self._handle_event(event_type, data)
-            return True
-        except OSError:
-            return False
-
-    def _handle_event(self, event_type: int, data: bytes):
-        """Handle kernel event."""
-        if event_type == UHID_START:
-            self._started = True
-            logger.debug("UHID_START received")
-            if self.on_start:
-                self.on_start()
-
-        elif event_type == UHID_STOP:
-            self._started = False
-            logger.debug("UHID_STOP received")
-            if self.on_stop:
-                self.on_stop()
-
-        elif event_type == UHID_OPEN:
-            logger.debug("UHID_OPEN received")
-            if self.on_open:
-                self.on_open()
-
-        elif event_type == UHID_CLOSE:
-            logger.debug("UHID_CLOSE received")
-            if self.on_close:
-                self.on_close()
-
-        elif event_type == UHID_OUTPUT:
-            # Parse output report
-            # Format: data(4096s) size(H) rtype(B)
-            if len(data) >= 4 + UHID_DATA_MAX + 3:
-                output_data = data[4:4+UHID_DATA_MAX]
-                size, rtype = struct.unpack_from('< H B', data, 4 + UHID_DATA_MAX)
-                output_data = output_data[:size]
-                logger.debug(f"UHID_OUTPUT received: {output_data.hex()} (type={rtype})")
-                if self.on_output:
-                    self.on_output(output_data, rtype)
-
-    @property
-    def is_created(self) -> bool:
-        """Check if device is created."""
-        return self._created
-
-    @property
-    def is_started(self) -> bool:
-        """Check if device is started (kernel acknowledged)."""
-        return self._started
 
     @property
     def fd(self) -> Optional[int]:

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -174,7 +174,7 @@ class MockHandler(SimpleHTTPRequestHandler):
             result = os.path.join(result, p)
         return result
 
-    def log_message(self, format, *args):
+    def log_message(self, _format, *args):
         pass
 
 


### PR DESCRIPTION
Vulture flagged unused variables (100% confidence) and dead functions/methods (60% confidence, verified by grepping for callers). The 60% cleanup cascaded into removing the entire unused UHID kernel event handling system (poll_events, _handle_event, event constants, callbacks) since none of it was ever called.

Also fixed "Task was destroyed but it is pending" asyncio errors during BLE pairing by using Bumble's native Device.connect(timeout=) instead of wrapping it in asyncio.wait_for, which created dangling tasks.