### PR TITLE
feat: WAF UI redesign with performance improvements

### DIFF
--- a/illusion/BTManager/index.html
+++ b/illusion/BTManager/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
-    <title>HID Passthrough</title>
+    <title>BT Manager</title>
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -15,42 +15,92 @@
 
     <div id="messageBar" class="message-bar"></div>
 
-    <div class="status-panel">
-        <button id="btnToggleDaemon" class="toggle" aria-label="Toggle Daemon">
+    <!-- Bluetooth toggle row -->
+    <div class="toggle-row">
+        <span class="toggle-label">Bluetooth</span>
+        <button id="btnToggle" class="toggle" aria-label="Toggle Bluetooth">
             <span class="toggle-knob"></span>
         </button>
-        <div class="status-row">
-            <span class="status-label">Daemon: </span>
-            <span id="statusDaemon" class="status-value unknown">checking...</span>
+    </div>
+
+    <!-- Main content (hidden when BT off) -->
+    <div id="mainContent">
+        <!-- Connected devices section -->
+        <div id="connectedSection" style="display:none;">
+            <div class="section-label">Connected</div>
+            <div id="connectedList" class="device-list"></div>
         </div>
-        <div class="status-row">
-            <span class="status-label">Devices: </span>
-            <span id="statusDevices" class="status-value unknown">--</span>
+
+        <!-- Paired devices section -->
+        <div id="pairedSection" style="display:none;">
+            <div class="section-label">Paired</div>
+            <div id="pairedList" class="device-list"></div>
+        </div>
+
+        <!-- Scan button -->
+        <div class="scan-btn-wrap">
+            <button id="btnScan" class="btn btn-scan">Scan for Devices</button>
+        </div>
+
+        <!-- Available devices section (hidden until scan) -->
+        <div id="availableSection" style="display:none;">
+            <div class="section-label-row">
+                <span class="section-label">Available</span>
+                <span id="scanIndicator" class="scan-indicator">Scanning...</span>
+            </div>
+            <div id="availableList" class="device-list"></div>
         </div>
     </div>
 
-    <div class="section-header">Paired Devices</div>
-
-    <div id="deviceList" class="device-list device-list-scroll">
-        <div class="loading">Loading devices...</div>
+    <!-- Off state (shown when BT off) -->
+    <div id="offState" style="display:none;">
+        <div class="off-message">Bluetooth is off</div>
+        <div class="off-hint">Turn on to manage devices</div>
     </div>
 
-    <div class="btn-row">
-        <button id="btnScan" class="btn btn-half btn-start">Scan</button>
-        <button id="btnLogs" class="btn btn-half btn-stop">Debug</button>
-    </div>
-
-    <div class="scan-section">
-        <div id="scanStatus" class="scan-status" style="display:none;"></div>
-        <div id="scanResults" class="device-list"></div>
-    </div>
-
+    <!-- Footer -->
     <div id="footer" class="footer">
-        HID Passthrough
+        <span id="footerVersion">BT Manager</span> &middot; <span id="footerDebug" class="footer-link">Debug</span>
     </div>
 
-    <!-- Overlays (hidden by default) -->
+    <!-- Device detail overlay -->
+    <div id="deviceOverlay" class="device-overlay">
+        <div class="header">
+            <h1 id="detailName">Device</h1>
+            <button id="btnDetailClose" class="btn-close">&#x2715;</button>
+        </div>
+        <div class="detail-body">
+            <div class="detail-row">
+                <span class="detail-label">Status</span>
+                <span id="detailStatus" class="detail-value"></span>
+            </div>
+            <div class="detail-row">
+                <span class="detail-label">Protocol</span>
+                <span id="detailProtocol" class="detail-value"></span>
+            </div>
+            <div class="detail-row">
+                <span class="detail-label">Address</span>
+                <span id="detailAddress" class="detail-value detail-mono"></span>
+            </div>
+            <div id="detailHid" style="display:none;">
+                <div class="section-label">HID</div>
+                <div class="detail-row">
+                    <span class="detail-label">UHID Device</span>
+                    <span id="detailUhid" class="detail-value"></span>
+                </div>
+                <div class="detail-row">
+                    <span class="detail-label">Input</span>
+                    <span id="detailInputPaths" class="detail-value detail-mono"></span>
+                </div>
+            </div>
+            <div class="detail-actions">
+                <button id="btnDetailAction" class="btn btn-action">Connect</button>
+                <button id="btnDetailRemove" class="btn btn-danger">Remove Device</button>
+            </div>
+        </div>
+    </div>
 
+    <!-- Pair overlay (unchanged) -->
     <div id="pairOverlay" class="pair-overlay">
         <div class="log-header">
             <span class="log-title">Pairing</span>
@@ -65,6 +115,7 @@
         </div>
     </div>
 
+    <!-- Debug log overlay (unchanged) -->
     <div id="logOverlay" class="log-overlay">
         <div class="log-header">
             <span class="log-title">Debug</span>
@@ -85,6 +136,7 @@
         </div>
     </div>
 
+    <!-- Confirm dialog (unchanged) -->
     <div id="confirmOverlay" class="overlay">
         <div class="dialog">
             <p id="dialogMessage">Are you sure?</p>

--- a/illusion/BTManager/index.html
+++ b/illusion/BTManager/index.html
@@ -16,6 +16,9 @@
     <div id="messageBar" class="message-bar"></div>
 
     <div class="status-panel">
+        <button id="btnToggleDaemon" class="toggle" aria-label="Toggle Daemon">
+            <span class="toggle-knob"></span>
+        </button>
         <div class="status-row">
             <span class="status-label">Daemon: </span>
             <span id="statusDaemon" class="status-value unknown">checking...</span>
@@ -24,11 +27,6 @@
             <span class="status-label">Devices: </span>
             <span id="statusDevices" class="status-value unknown">--</span>
         </div>
-    </div>
-
-    <div class="btn-row">
-        <button id="btnStart" class="btn btn-half btn-start">Start Daemon</button>
-        <button id="btnStop" class="btn btn-half btn-stop">Stop Daemon</button>
     </div>
 
     <div class="section-header">Paired Devices</div>

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -19,7 +19,6 @@ var BTManager = (function() {
     var lastStatus = null;
     var lastStatusJson = "";
     var versionSet = false;
-    var daemonRunning = false;
     var isScanning = false;
     var isPairing = false;
     var scanPollTimer = null;
@@ -27,6 +26,11 @@ var BTManager = (function() {
     var logPollTimer = null;
     var logsVisible = false;
     var pairLogTimer = null;
+    var btOn = false;
+    var scanResultCount = 0;
+
+    // Currently viewed device in detail overlay
+    var detailDevice = null;
 
     // ---- XHR Helper ----
 
@@ -100,12 +104,6 @@ var BTManager = (function() {
         }, MESSAGE_TIMEOUT);
     }
 
-    function setStatus(id, text, className) {
-        var el = getEl(id);
-        el.innerHTML = text;
-        el.className = "status-value " + (className || "");
-    }
-
     function escapeHtml(str) {
         if (!str) return "";
         return str.replace(/&/g, "&amp;")
@@ -114,14 +112,62 @@ var BTManager = (function() {
                   .replace(/"/g, "&quot;");
     }
 
+    // ---- Toggle ----
+
+    function setToggleUI(on) {
+        btOn = on;
+        var toggle = getEl("btnToggle");
+        if (on) {
+            toggle.className = "toggle on";
+        } else {
+            toggle.className = "toggle";
+        }
+        getEl("mainContent").style.display = on ? "block" : "none";
+        getEl("offState").style.display = on ? "none" : "block";
+    }
+
+    function toggleBluetooth() {
+        if (btOn) {
+            showMessage("Turning off...", false);
+            request("/stop", function(data, err) {
+                if (err) {
+                    showMessage("Error: " + err, true);
+                    return;
+                }
+                if (data && data.ok) {
+                    setToggleUI(false);
+                    showMessage("Bluetooth off", false);
+                } else {
+                    showMessage(data && data.error ? data.error : "Failed", true);
+                }
+                lastStatusJson = "";
+                setTimeout(updateStatus, 1000);
+            });
+        } else {
+            showMessage("Turning on...", false);
+            request("/start", function(data, err) {
+                if (err) {
+                    showMessage("Error: " + err, true);
+                    return;
+                }
+                if (data && data.ok) {
+                    setToggleUI(true);
+                    showMessage("Bluetooth on", false);
+                } else {
+                    showMessage(data && data.error ? data.error : "Failed", true);
+                }
+                lastStatusJson = "";
+                setTimeout(updateStatus, 1500);
+            });
+        }
+    }
+
     // ---- Status Polling ----
 
     function updateStatus() {
         request("/status", function(data, err) {
             if (err) {
-                setStatus("statusDaemon", "unknown", "unknown");
-                setStatus("statusDevices", "--", "unknown");
-                renderDeviceList(null);
+                setToggleUI(false);
                 lastStatusJson = "";
                 return;
             }
@@ -130,28 +176,13 @@ var BTManager = (function() {
             if (json === lastStatusJson) return;
             lastStatusJson = json;
 
-            daemonRunning = data.daemon_running;
-            var toggleBtn = getEl("btnToggleDaemon");
+            var running = data.daemon_running || data.scanning || data.pairing;
+            setToggleUI(running);
 
-            if (data.scanning) {
-                setStatus("statusDaemon", "scanning...", "running");
-            } else if (data.pairing) {
-                setStatus("statusDaemon", "pairing...", "running");
-            } else if (daemonRunning) {
-                setStatus("statusDaemon", "running", "running");
-            } else {
-                setStatus("statusDaemon", "stopped", "stopped");
-            }
-
-            toggleBtn.className = daemonRunning ? "toggle on" : "toggle";
-
-            var count = data.devices ? data.devices.length : 0;
-            setStatus("statusDevices", count + " configured", "");
-
-            renderDeviceList(data.devices, data.connected_device || null);
+            renderDeviceLists(data.devices, data.connected_device || null);
 
             if (!versionSet && data.version) {
-                getEl("footer").innerHTML = "HID Passthrough v" + escapeHtml(data.version);
+                getEl("footerVersion").innerHTML = "v" + escapeHtml(data.version);
                 versionSet = true;
             }
 
@@ -159,128 +190,153 @@ var BTManager = (function() {
         });
     }
 
-    // ---- Device List ----
+    // ---- Device Lists (3-tier) ----
 
-    function renderDeviceList(devices, connectedAddr) {
-        var container = getEl("deviceList");
+    function renderDeviceLists(devices, connectedAddr) {
+        var connected = [];
+        var paired = [];
 
-        if (!devices || devices.length === 0) {
-            container.innerHTML = '<div class="device-empty">No devices configured</div>';
-            return;
+        if (devices) {
+            for (var i = 0; i < devices.length; i++) {
+                var dev = devices[i];
+                var isConn = connectedAddr && dev.address &&
+                    dev.address.toUpperCase() === connectedAddr.toUpperCase();
+                if (isConn) {
+                    connected.push(dev);
+                } else {
+                    paired.push(dev);
+                }
+            }
         }
 
+        // Connected section
+        var connSection = getEl("connectedSection");
+        var connList = getEl("connectedList");
+        if (connected.length > 0) {
+            connSection.style.display = "block";
+            connList.innerHTML = renderDeviceRows(connected, true);
+        } else {
+            connSection.style.display = "none";
+        }
+
+        // Paired section
+        var pairedSection = getEl("pairedSection");
+        var pairedList = getEl("pairedList");
+        if (paired.length > 0) {
+            pairedSection.style.display = "block";
+            pairedList.innerHTML = renderDeviceRows(paired, false);
+        } else {
+            pairedSection.style.display = "none";
+        }
+    }
+
+    function renderDeviceRows(devices, isConnected) {
         var html = "";
         for (var i = 0; i < devices.length; i++) {
             var dev = devices[i];
-            var addr = escapeHtml(dev.address || "unknown");
+            var addr = escapeHtml(dev.address || "");
             var proto = escapeHtml(dev.protocol || "");
-            var name = escapeHtml(dev.name || "");
-            var displayName = name || addr;
-            var isConnected = connectedAddr && dev.address &&
-                dev.address.toUpperCase() === connectedAddr.toUpperCase();
+            var name = escapeHtml(dev.name || "") || addr;
 
-            html += '<div class="device-item' + (isConnected ? ' device-connected' : '') + '">';
-            html += '<button class="device-remove" data-addr="' + escapeHtml(dev.address) + '">Remove</button>';
-            if (isConnected) {
-                html += '<button class="device-disconnect" data-addr="' + escapeHtml(dev.address) + '">Disconnect</button>';
-            } else {
-                html += '<button class="device-connect" data-addr="' + escapeHtml(dev.address) + '" data-proto="' + proto + '">Connect</button>';
-            }
-            html += '<div class="device-info">';
-            html += '<div class="device-name">' + displayName;
-            if (isConnected) {
-                html += ' <span class="device-status-tag">Connected</span>';
-            }
-            html += '</div>';
-            html += '<div>';
-            html += '<span class="device-addr">' + addr + '</span>';
-            if (proto) {
-                html += '<span class="device-proto">[' + proto + ']</span>';
-            }
-            html += '</div>';
-            html += '</div>';
+            html += '<div class="device-row" data-addr="' + addr + '" data-proto="' + proto + '" data-name="' + escapeHtml(dev.name || "") + '" data-connected="' + (isConnected ? '1' : '0') + '">';
+            html += '<span class="device-row-chevron">&#x276F;</span>';
+            html += '<div class="device-row-name' + (isConnected ? '' : ' idle') + '">' + name + '</div>';
+            html += '<div class="device-row-sub">' + proto.toUpperCase() + '</div>';
             html += '</div>';
         }
-
-        container.innerHTML = html;
+        return html;
     }
 
-    // ---- Actions ----
+    // ---- Device Detail Overlay ----
 
-    function toggleDaemon() {
-        var btn = getEl("btnToggleDaemon");
-        pressBtn(btn);
-        if (daemonRunning) {
-            showMessage("Stopping daemon...", false);
-            request("/stop", function(data, err) {
-                releaseBtn(btn);
+    function showDeviceDetail(addr, proto, name, isConnected) {
+        detailDevice = { addr: addr, proto: proto, name: name, connected: isConnected };
+        window.scrollTo(0, 0);
+
+        getEl("detailName").innerHTML = escapeHtml(name) || escapeHtml(addr);
+        getEl("detailStatus").innerHTML = isConnected ? "&#x25CF; Connected" : "&#x25CB; Not Connected";
+        getEl("detailProtocol").innerHTML = escapeHtml(proto).toUpperCase();
+        getEl("detailAddress").innerHTML = escapeHtml(addr);
+
+        var actionBtn = getEl("btnDetailAction");
+        if (isConnected) {
+            actionBtn.innerHTML = "Disconnect";
+        } else {
+            actionBtn.innerHTML = "Connect";
+        }
+
+        // HID info
+        var hidSection = getEl("detailHid");
+        hidSection.style.display = "none";
+
+        if (isConnected && lastStatus) {
+            var uhid = lastStatus.uhid_name;
+            var inputs = lastStatus.input_paths;
+            if (uhid || inputs) {
+                getEl("detailUhid").innerHTML = escapeHtml(uhid || "--");
+                getEl("detailInputPaths").innerHTML = inputs && inputs.length ? escapeHtml(inputs.join(", ")) : "--";
+                hidSection.style.display = "block";
+            }
+        }
+
+        getEl("deviceOverlay").className = "device-overlay visible";
+    }
+
+    function hideDeviceDetail() {
+        getEl("deviceOverlay").className = "device-overlay";
+        detailDevice = null;
+    }
+
+    function detailAction() {
+        if (!detailDevice) return;
+        if (detailDevice.connected) {
+            showMessage("Disconnecting...", false);
+            request("/disconnect?addr=" + encodeURIComponent(detailDevice.addr), function(data, err) {
                 if (err) {
                     showMessage("Error: " + err, true);
                     return;
                 }
                 if (data && data.ok) {
-                    showMessage("Daemon stopped", false);
+                    showMessage("Disconnected", false);
+                    hideDeviceDetail();
                 } else {
-                    showMessage(data && data.error ? data.error : "Failed to stop", true);
+                    showMessage(data && data.error ? data.error : "Failed", true);
                 }
                 lastStatusJson = "";
                 setTimeout(updateStatus, 1000);
             });
         } else {
-            showMessage("Starting daemon...", false);
-            request("/start", function(data, err) {
-                releaseBtn(btn);
+            showMessage("Connecting...", false);
+            var url = "/connect?addr=" + encodeURIComponent(detailDevice.addr);
+            if (detailDevice.proto) url += "&protocol=" + encodeURIComponent(detailDevice.proto);
+            request(url, function(data, err) {
                 if (err) {
                     showMessage("Error: " + err, true);
                     return;
                 }
                 if (data && data.ok) {
-                    showMessage("Daemon started", false);
+                    showMessage("Connecting...", false);
+                    hideDeviceDetail();
                 } else {
-                    showMessage(data && data.error ? data.error : "Failed to start", true);
+                    showMessage(data && data.error ? data.error : "Failed", true);
                 }
                 lastStatusJson = "";
-                setTimeout(updateStatus, 1500);
+                setTimeout(updateStatus, 2000);
             });
         }
     }
 
-    function connectDevice(addr, protocol) {
-        showMessage("Connecting to " + addr + "...", false);
-        var url = "/connect?addr=" + encodeURIComponent(addr);
-        if (protocol) url += "&protocol=" + encodeURIComponent(protocol);
-        request(url, function(data, err) {
-            if (err) {
-                showMessage("Error: " + err, true);
-                return;
-            }
-            if (data && data.ok) {
-                showMessage("Connecting...", false);
-            } else {
-                showMessage(data && data.error ? data.error : "Failed to connect", true);
-            }
-            setTimeout(updateStatus, 2000);
-        });
-    }
-
-    function disconnectDevice(addr) {
-        showMessage("Disconnecting " + addr + "...", false);
-        request("/disconnect?addr=" + encodeURIComponent(addr), function(data, err) {
-            if (err) {
-                showMessage("Error: " + err, true);
-                return;
-            }
-            if (data && data.ok) {
-                showMessage("Disconnected", false);
-            } else {
-                showMessage(data && data.error ? data.error : "Failed to disconnect", true);
-            }
-            setTimeout(updateStatus, 1000);
-        });
+    function detailRemove() {
+        if (!detailDevice) return;
+        confirmAddr = detailDevice.addr;
+        showConfirm(
+            "Remove device?<br/><span class=\"dialog-addr\">" + escapeHtml(detailDevice.addr) + "</span>",
+            "remove"
+        );
     }
 
     function removeDevice(addr) {
-        showMessage("Removing " + addr + "...", false);
+        showMessage("Removing...", false);
         request("/remove?addr=" + encodeURIComponent(addr), function(data, err) {
             releaseBtn("dialogConfirmBtn");
             if (err) {
@@ -288,58 +344,30 @@ var BTManager = (function() {
                 return;
             }
             if (data && data.ok) {
-                showMessage("Device removed: " + addr, false);
+                showMessage("Device removed", false);
+                hideDeviceDetail();
             } else {
-                showMessage(data && data.error ? data.error : "Failed to remove", true);
+                showMessage(data && data.error ? data.error : "Failed", true);
             }
+            lastStatusJson = "";
             setTimeout(updateStatus, 500);
         });
     }
 
-    function clearCache() {
-        showMessage("Clearing cache...", false);
-        request("/clear-cache", function(data, err) {
-            releaseBtn("dialogConfirmBtn");
-            if (err) {
-                showMessage("Error: " + err, true);
-                return;
-            }
-            if (data && data.ok) {
-                var msg = "Cache cleared";
-                if (data.files_removed) {
-                    msg += " (" + data.files_removed + " files)";
-                }
-                showMessage(msg, false);
-            } else {
-                showMessage(data && data.error ? data.error : "Failed to clear cache", true);
-            }
-        });
-    }
-
-    // ---- Quit ----
-
-    function quit() {
-        pressBtn("btnBack");
-        if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.back) {
-            kindle.appmgr.back();
-        }
-    }
-
-    // ---- Scan & Pair ----
+    // ---- Scan ----
 
     function startScan() {
         if (isScanning || isPairing) return;
         isScanning = true;
 
         var btn = getEl("btnScan");
-        pressBtn(btn);
-        btn.innerHTML = "Scanning...";
-        btn.disabled = true;
+        btn.innerHTML = "Stop Scan";
+        btn.className = "btn btn-scan scanning";
 
-        var statusEl = getEl("scanStatus");
-        statusEl.innerHTML = "Scanning for BLE &amp; Classic HID devices...";
-        statusEl.style.display = "block";
-        getEl("scanResults").innerHTML = "";
+        scanResultCount = 0;
+        getEl("availableSection").style.display = "block";
+        getEl("scanIndicator").innerHTML = "Scanning...";
+        getEl("availableList").innerHTML = "";
 
         request("/scan", function(data, err) {
             if (err) {
@@ -347,23 +375,37 @@ var BTManager = (function() {
                 resetScanUI();
                 return;
             }
-            // Start polling for results
             pollScanStatus();
         });
+    }
+
+    function stopScan() {
+        request("/scan-stop", function() {});
+        resetScanUI();
+        if (scanResultCount === 0) {
+            getEl("availableSection").style.display = "none";
+        }
+    }
+
+    function toggleScan() {
+        if (isScanning) {
+            stopScan();
+        } else {
+            startScan();
+        }
     }
 
     function pollScanStatus() {
         scanPollTimer = setTimeout(function() {
             request("/scan-status", function(data, err) {
                 if (err) {
-                    showMessage("Scan poll error: " + err, true);
+                    showMessage("Scan error: " + err, true);
                     resetScanUI();
                     return;
                 }
                 if (data && data.scanning) {
-                    // Still scanning - show results found so far
                     if (data.devices && data.devices.length > 0) {
-                        renderScanResults(data.devices);
+                        renderAvailableDevices(data.devices);
                     }
                     pollScanStatus();
                     return;
@@ -371,8 +413,10 @@ var BTManager = (function() {
                 // Scan complete
                 resetScanUI();
                 if (data && data.ok && data.devices) {
-                    renderScanResults(data.devices);
-                    if (data.devices.length === 0) {
+                    if (data.devices.length > 0) {
+                        renderAvailableDevices(data.devices);
+                    } else {
+                        getEl("availableSection").style.display = "none";
                         showMessage("No HID devices found", false);
                     }
                 } else {
@@ -385,18 +429,18 @@ var BTManager = (function() {
     function resetScanUI() {
         isScanning = false;
         var btn = getEl("btnScan");
-        releaseBtn(btn);
         btn.innerHTML = "Scan for Devices";
-        btn.disabled = false;
-        getEl("scanStatus").style.display = "none";
+        btn.className = "btn btn-scan";
+        getEl("scanIndicator").innerHTML = "";
         if (scanPollTimer) {
             clearTimeout(scanPollTimer);
             scanPollTimer = null;
         }
     }
 
-    function renderScanResults(devices) {
-        var container = getEl("scanResults");
+    function renderAvailableDevices(devices) {
+        var container = getEl("availableList");
+        scanResultCount = devices ? devices.length : 0;
         if (!devices || devices.length === 0) {
             container.innerHTML = '<div class="device-empty">No devices found</div>';
             return;
@@ -408,36 +452,27 @@ var BTManager = (function() {
             var addr = escapeHtml(dev.address || "");
             var name = escapeHtml(dev.name || "Unknown");
             var proto = escapeHtml(dev.protocol || "ble");
-            var rssi = dev.rssi !== undefined ? dev.rssi : "";
 
-            html += '<div class="scan-device-item">';
-            html += '<button class="btn-pair" data-addr="' + addr + '" data-proto="' + proto + '" data-name="' + name + '">';
-            html += 'Pair</button>';
-            html += '<div class="scan-device-info">';
-            html += '<div class="scan-device-name">' + name + '</div>';
-            html += '<div>';
-            html += '<span class="scan-device-meta">' + addr + ' [' + proto + ']</span>';
-            if (rssi !== "") {
-                html += '<span class="scan-device-rssi">RSSI: ' + rssi + '</span>';
-            }
-            html += '</div>';
-            html += '</div>';
+            html += '<div class="available-row">';
+            html += '<button class="btn-pair" data-addr="' + addr + '" data-proto="' + proto + '" data-name="' + name + '">Pair</button>';
+            html += '<div class="available-name">' + name + '</div>';
+            html += '<div class="available-sub">' + proto.toUpperCase() + '</div>';
             html += '</div>';
         }
 
         container.innerHTML = html;
     }
 
+    // ---- Pair (unchanged logic) ----
+
     function startPair(addr, protocol, name) {
         if (isPairing) return;
         if (isScanning) {
-            // Stop scan before pairing
             request("/scan-stop", function() {});
             resetScanUI();
         }
         isPairing = true;
 
-        // Show overlay with live logs (scroll to top so header/X visible)
         window.scrollTo(0, 0);
         getEl("pairMessage").innerHTML = "Pairing...";
         getEl("pairAddr").innerHTML = escapeHtml(addr);
@@ -461,21 +496,20 @@ var BTManager = (function() {
         pairPollTimer = setTimeout(function() {
             request("/pair-status", function(data, err) {
                 if (err) {
-                    showMessage("Pair poll error: " + err, true);
+                    showMessage("Pair error: " + err, true);
                     resetPairUI();
                     return;
                 }
                 if (data && data.pairing) {
-                    // Still pairing, update message and poll again
                     getEl("pairMessage").innerHTML = "Pairing in progress...";
                     pollPairStatus();
                     return;
                 }
-                // Pairing complete
                 resetPairUI();
                 if (data && data.ok) {
                     showMessage("Paired: " + (data.address || ""), false);
-                    getEl("scanResults").innerHTML = "";
+                    getEl("availableList").innerHTML = "";
+                    getEl("availableSection").style.display = "none";
                     updateStatus();
                 } else {
                     showMessage(data && data.error ? data.error : "Pairing failed", true);
@@ -518,7 +552,7 @@ var BTManager = (function() {
         });
     }
 
-    // ---- Log Viewer (fullscreen overlay) ----
+    // ---- Log Viewer (unchanged) ----
 
     function showLogs() {
         logsVisible = true;
@@ -563,24 +597,34 @@ var BTManager = (function() {
         });
     }
 
+    // ---- Cache ----
+
+    function clearCache() {
+        showMessage("Clearing cache...", false);
+        request("/clear-cache", function(data, err) {
+            releaseBtn("dialogConfirmBtn");
+            if (err) {
+                showMessage("Error: " + err, true);
+                return;
+            }
+            if (data && data.ok) {
+                var msg = "Cache cleared";
+                if (data.files_removed) {
+                    msg += " (" + data.files_removed + " files)";
+                }
+                showMessage(msg, false);
+            } else {
+                showMessage(data && data.error ? data.error : "Failed", true);
+            }
+        });
+    }
+
     // ---- Confirm Dialog ----
 
     function showConfirm(message, action) {
         getEl("dialogMessage").innerHTML = message;
         getEl("confirmOverlay").className = "overlay visible";
         confirmAction = action;
-    }
-
-    function confirmRemoveDevice(addr) {
-        confirmAddr = addr;
-        showConfirm(
-            "Remove device?<br/><span class=\"dialog-addr\">" + escapeHtml(addr) + "</span>",
-            "remove"
-        );
-    }
-
-    function confirmClearCache() {
-        showConfirm("Clear all cached HID descriptors?", "cache");
     }
 
     function confirmOk() {
@@ -601,6 +645,15 @@ var BTManager = (function() {
         confirmAddr = null;
     }
 
+    // ---- Quit ----
+
+    function quit() {
+        pressBtn("btnBack");
+        if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.back) {
+            kindle.appmgr.back();
+        }
+    }
+
     // ---- Event Binding ----
 
     function bindBtn(id, fn) {
@@ -610,14 +663,19 @@ var BTManager = (function() {
 
     function bindEvents() {
         bindBtn("btnBack", quit);
-        bindBtn("btnToggleDaemon", toggleDaemon);
-        bindBtn("btnScan", startScan);
+        bindBtn("btnToggle", toggleBluetooth);
+        bindBtn("btnScan", toggleScan);
+        bindBtn("footerDebug", showLogs);
+        bindBtn("btnDetailClose", hideDeviceDetail);
+        bindBtn("btnDetailAction", detailAction);
+        bindBtn("btnDetailRemove", detailRemove);
         bindBtn("btnPairClose", cancelPair);
-        bindBtn("btnLogs", showLogs);
         bindBtn("btnLogClose", hideLogs);
         bindBtn("btnLogUp", scrollLogsUp);
         bindBtn("btnLogDown", scrollLogsDown);
-        bindBtn("btnClearCache", confirmClearCache);
+        bindBtn("btnClearCache", function() {
+            showConfirm("Clear all cached HID descriptors?", "cache");
+        });
 
         // Clear placeholder on first tap for keyboard test area
         var testInput = getEl("keyboardTest");
@@ -634,26 +692,33 @@ var BTManager = (function() {
         bindBtn("dialogCancelBtn", confirmCancel);
         bindBtn("dialogConfirmBtn", confirmOk);
 
-        // Event delegation for dynamically created buttons
+        // Event delegation for dynamically created elements
         document.addEventListener("click", function(e) {
             var target = e.target;
             if (!target) return;
-            var addr, proto;
-            if (target.className && target.className.indexOf("device-disconnect") !== -1) {
-                addr = target.getAttribute("data-addr");
-                if (addr) disconnectDevice(addr);
-            } else if (target.className && target.className.indexOf("device-connect") !== -1) {
-                addr = target.getAttribute("data-addr");
-                proto = target.getAttribute("data-proto");
-                if (addr) connectDevice(addr, proto || "ble");
-            } else if (target.className && target.className.indexOf("device-remove") !== -1) {
-                addr = target.getAttribute("data-addr");
-                if (addr) confirmRemoveDevice(addr);
-            } else if (target.className && target.className.indexOf("btn-pair") !== -1) {
+            var addr, proto, name;
+
+            // Pair button in available list (check BEFORE device row walk-up)
+            if (target.className && target.className.indexOf("btn-pair") !== -1) {
                 addr = target.getAttribute("data-addr");
                 proto = target.getAttribute("data-proto");
-                var name = target.getAttribute("data-name");
+                name = target.getAttribute("data-name");
                 if (addr) startPair(addr, proto || "ble", name || "");
+                return;
+            }
+
+            // Device row tap -> detail overlay
+            var row = target;
+            while (row && row !== document) {
+                if (row.getAttribute && row.getAttribute("data-addr")) {
+                    addr = row.getAttribute("data-addr");
+                    proto = row.getAttribute("data-proto");
+                    name = row.getAttribute("data-name");
+                    var isConn = row.getAttribute("data-connected") === "1";
+                    showDeviceDetail(addr, proto, name, isConn);
+                    return;
+                }
+                row = row.parentNode;
             }
         }, false);
 
@@ -703,22 +768,17 @@ var BTManager = (function() {
         updateStatus();
         pollTimer = setInterval(updateStatus, POLL_INTERVAL);
 
-        // Block all page scrolling globally — Kindle WebKit 533 doesn't
-        // support position:fixed, so we prevent body scroll entirely.
-        // The log viewer scrolls internally via its own scroll buttons.
         document.addEventListener("touchmove", function(e) {
             e.preventDefault();
         }, false);
     }
 
-    // Start when DOM is ready
     if (document.readyState === "complete" || document.readyState === "interactive") {
         init();
     } else {
         document.addEventListener("DOMContentLoaded", init, false);
     }
 
-    // Public API (for debugging)
     return {
         refresh: updateStatus
     };

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -710,7 +710,7 @@ var BTManager = (function() {
             // Device row tap -> detail overlay
             var row = target;
             while (row && row !== document) {
-                if (row.getAttribute && row.getAttribute("data-addr")) {
+                if (row.className && row.className.indexOf("device-row") !== -1 && row.getAttribute("data-addr")) {
                     addr = row.getAttribute("data-addr");
                     proto = row.getAttribute("data-proto");
                     name = row.getAttribute("data-name");

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -17,6 +17,9 @@ var BTManager = (function() {
     var confirmAction = null;
     var confirmAddr = null;
     var lastStatus = null;
+    var lastStatusJson = "";
+    var versionSet = false;
+    var daemonRunning = false;
     var isScanning = false;
     var isPairing = false;
     var scanPollTimer = null;
@@ -119,26 +122,37 @@ var BTManager = (function() {
                 setStatus("statusDaemon", "unknown", "unknown");
                 setStatus("statusDevices", "--", "unknown");
                 renderDeviceList(null);
+                lastStatusJson = "";
                 return;
             }
+
+            var json = JSON.stringify(data);
+            if (json === lastStatusJson) return;
+            lastStatusJson = json;
+
+            daemonRunning = data.daemon_running;
+            var toggleBtn = getEl("btnToggleDaemon");
 
             if (data.scanning) {
                 setStatus("statusDaemon", "scanning...", "running");
             } else if (data.pairing) {
                 setStatus("statusDaemon", "pairing...", "running");
-            } else if (data.daemon_running) {
+            } else if (daemonRunning) {
                 setStatus("statusDaemon", "running", "running");
             } else {
                 setStatus("statusDaemon", "stopped", "stopped");
             }
+
+            toggleBtn.className = daemonRunning ? "toggle on" : "toggle";
 
             var count = data.devices ? data.devices.length : 0;
             setStatus("statusDevices", count + " configured", "");
 
             renderDeviceList(data.devices, data.connected_device || null);
 
-            if (data.version) {
+            if (!versionSet && data.version) {
                 getEl("footer").innerHTML = "HID Passthrough v" + escapeHtml(data.version);
+                versionSet = true;
             }
 
             lastStatus = data;
@@ -193,40 +207,42 @@ var BTManager = (function() {
 
     // ---- Actions ----
 
-    function startDaemon() {
-        pressBtn("btnStart");
-        showMessage("Starting daemon...", false);
-        request("/start", function(data, err) {
-            releaseBtn("btnStart");
-            if (err) {
-                showMessage("Error: " + err, true);
-                return;
-            }
-            if (data && data.ok) {
-                showMessage("Daemon started", false);
-            } else {
-                showMessage(data && data.error ? data.error : "Failed to start", true);
-            }
-            setTimeout(updateStatus, 1500);
-        });
-    }
-
-    function stopDaemon() {
-        pressBtn("btnStop");
-        showMessage("Stopping daemon...", false);
-        request("/stop", function(data, err) {
-            releaseBtn("btnStop");
-            if (err) {
-                showMessage("Error: " + err, true);
-                return;
-            }
-            if (data && data.ok) {
-                showMessage("Daemon stopped", false);
-            } else {
-                showMessage(data && data.error ? data.error : "Failed to stop", true);
-            }
-            setTimeout(updateStatus, 1000);
-        });
+    function toggleDaemon() {
+        var btn = getEl("btnToggleDaemon");
+        pressBtn(btn);
+        if (daemonRunning) {
+            showMessage("Stopping daemon...", false);
+            request("/stop", function(data, err) {
+                releaseBtn(btn);
+                if (err) {
+                    showMessage("Error: " + err, true);
+                    return;
+                }
+                if (data && data.ok) {
+                    showMessage("Daemon stopped", false);
+                } else {
+                    showMessage(data && data.error ? data.error : "Failed to stop", true);
+                }
+                lastStatusJson = "";
+                setTimeout(updateStatus, 1000);
+            });
+        } else {
+            showMessage("Starting daemon...", false);
+            request("/start", function(data, err) {
+                releaseBtn(btn);
+                if (err) {
+                    showMessage("Error: " + err, true);
+                    return;
+                }
+                if (data && data.ok) {
+                    showMessage("Daemon started", false);
+                } else {
+                    showMessage(data && data.error ? data.error : "Failed to start", true);
+                }
+                lastStatusJson = "";
+                setTimeout(updateStatus, 1500);
+            });
+        }
     }
 
     function connectDevice(addr, protocol) {
@@ -594,8 +610,7 @@ var BTManager = (function() {
 
     function bindEvents() {
         bindBtn("btnBack", quit);
-        bindBtn("btnStart", startDaemon);
-        bindBtn("btnStop", stopDaemon);
+        bindBtn("btnToggleDaemon", toggleDaemon);
         bindBtn("btnScan", startScan);
         bindBtn("btnPairClose", cancelPair);
         bindBtn("btnLogs", showLogs);

--- a/illusion/BTManager/style.css
+++ b/illusion/BTManager/style.css
@@ -26,13 +26,20 @@ html {
     height: 100%;
 }
 
-/* Header */
+/* ---- Header ---- */
+
 .header {
     position: relative;
     text-align: center;
     padding: 4px 0 10px 0;
     border-bottom: 3px solid #000;
-    margin-bottom: 8px;
+    margin-bottom: 0;
+}
+
+.header h1 {
+    font-size: 52px;
+    font-weight: bold;
+    margin: 0 0 4px 0;
 }
 
 .btn-close {
@@ -61,32 +68,23 @@ html {
     color: #fff;
 }
 
-.header h1 {
-    font-size: 52px;
+/* ---- Toggle Row ---- */
+
+.toggle-row {
+    padding: 16px 0;
+    border-bottom: 2px solid #000;
+    overflow: hidden;
+}
+
+.toggle-label {
+    font-size: 44px;
     font-weight: bold;
-    margin: 0 0 4px 0;
-}
-
-.header .subtitle {
-    font-size: 32px;
-    color: #000;
-}
-
-/* Status panel */
-.status-panel {
-    position: relative;
-    border: 3px solid #000;
-    padding: 10px 20px;
-    padding-right: 150px;
-    margin-bottom: 8px;
-    background: #f0f0f0;
+    float: left;
+    line-height: 60px;
 }
 
 .toggle {
-    position: absolute;
-    right: 12px;
-    top: 50%;
-    margin-top: -30px;
+    float: right;
     width: 120px;
     height: 60px;
     border: 4px solid #000;
@@ -96,6 +94,7 @@ html {
     padding: 4px;
     cursor: pointer;
     -webkit-appearance: none;
+    position: relative;
 }
 
 .toggle:active {
@@ -119,35 +118,126 @@ html {
     right: 4px;
 }
 
-.status-row {
-    padding: 6px 0;
-    font-size: 36px;
+/* ---- Section Labels ---- */
+
+.section-label {
+    font-size: 28px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    padding: 14px 0 6px 0;
+}
+
+.section-label-row {
+    overflow: hidden;
+    padding: 14px 0 6px 0;
+}
+
+.section-label-row .section-label {
+    float: left;
+    padding: 0;
+}
+
+.scan-indicator {
+    float: right;
+    font-size: 28px;
+    font-style: italic;
+    font-weight: normal;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+/* ---- Device Rows (main list) ---- */
+
+.device-list {
+    margin-bottom: 0;
+}
+
+.device-row {
+    padding: 14px 0;
+    border-top: 1px solid #000;
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.device-row:last-child {
+    border-bottom: 1px solid #000;
+}
+
+.device-row-name {
+    font-size: 40px;
+    font-weight: bold;
+    float: left;
+    max-width: 80%;
     overflow: hidden;
 }
 
-.status-label {
+.device-row-name.idle {
+    font-weight: normal;
+}
+
+.device-row-sub {
+    font-size: 30px;
+    clear: both;
+    padding-top: 2px;
+}
+
+.device-row-chevron {
+    float: right;
+    font-size: 56px;
+    line-height: 70px;
+}
+
+/* Available device rows (scan results) */
+.available-row {
+    padding: 14px 0;
+    border-top: 1px solid #000;
+    overflow: hidden;
+}
+
+.available-row:last-child {
+    border-bottom: 1px solid #000;
+}
+
+.available-name {
+    font-size: 40px;
+    float: left;
+    max-width: 65%;
+    overflow: hidden;
+}
+
+.available-sub {
+    font-size: 30px;
+    clear: both;
+    padding-top: 2px;
+}
+
+.btn-pair {
+    float: right;
+    min-width: 140px;
+    min-height: 70px;
+    padding: 12px 24px;
+    font-size: 34px;
     font-weight: bold;
-    display: inline;
-}
-
-.status-value {
-    display: inline;
-}
-
-.status-value.running {
-    font-weight: bold;
-}
-
-.status-value.stopped {
+    font-family: sans-serif;
+    border: 2px solid #000;
+    background: #fff;
     color: #000;
+    cursor: pointer;
+    text-align: center;
+    -webkit-appearance: none;
+    -webkit-border-radius: 4px;
+    border-radius: 4px;
 }
 
-.status-value.unknown {
-    color: #000;
-    font-style: italic;
+.btn-pair:active,
+.btn-pair.btn-active {
+    background: #000;
+    color: #fff;
 }
 
-/* Buttons */
+/* ---- Buttons ---- */
+
 .btn {
     display: block;
     width: 100%;
@@ -173,6 +263,20 @@ html {
     color: #fff;
 }
 
+.btn-scan {
+    margin-top: 16px;
+    margin-bottom: 8px;
+}
+
+.btn-scan.scanning {
+    background: #000;
+    color: #fff;
+}
+
+.btn-danger {
+    border-style: dashed;
+}
+
 .btn-start {
     background: #e0e0e0;
 }
@@ -181,135 +285,107 @@ html {
     background: #d0d0d0;
 }
 
-.btn-danger {
-    border-style: dashed;
-}
-
-.btn-small {
-    font-size: 36px;
-    min-height: 76px;
-    padding: 16px 20px;
-    width: auto;
-    display: inline-block;
-}
-
-/* Button row - side by side buttons */
-.btn-row {
-    overflow: hidden;
-    margin-bottom: 8px;
-}
-
-.btn-row .btn-half {
+.btn-half {
     float: left;
     width: 48%;
     margin-bottom: 0;
 }
 
-.btn-row .btn-half + .btn-half {
+.btn-half + .btn-half {
     float: right;
 }
 
-/* Section headers */
-.section-header {
-    font-size: 40px;
-    font-weight: bold;
-    padding: 8px 0 6px 0;
-    border-bottom: 2px solid #000;
-    margin-bottom: 8px;
+.scan-btn-wrap {
+    padding: 0;
 }
 
-/* Device list */
-.device-list {
-    margin-bottom: 8px;
-}
+/* ---- Device Detail Overlay ---- */
 
-.device-list-scroll {
-    max-height: 600px;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-}
-
-.device-item {
-    border: 2px solid #000;
-    padding: 16px 20px;
-    margin-bottom: 10px;
-    overflow: hidden;
-    -webkit-border-radius: 4px;
-    border-radius: 4px;
-}
-
-.device-connected {
-    background: #d0d0d0;
-    border-width: 4px;
-}
-
-.device-status-tag {
-    font-size: 28px;
-    font-weight: normal;
-    font-style: italic;
-}
-
-.device-info {
-    overflow: hidden;
-}
-
-.device-name {
-    font-weight: bold;
-    font-size: 40px;
-    margin-bottom: 4px;
-}
-
-.device-addr {
-    font-size: 32px;
-    font-family: monospace;
-    color: #000;
-}
-
-.device-proto {
-    font-size: 28px;
-    color: #000;
-    display: inline;
-    margin-left: 12px;
-}
-
-.device-remove,
-.device-disconnect,
-.device-connect {
-    float: right;
-    min-width: 140px;
-    min-height: 76px;
-    padding: 14px 24px;
-    font-size: 32px;
-    font-weight: bold;
-    font-family: sans-serif;
-    border: 3px solid #000;
+.device-overlay {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    min-height: 100%;
     background: #fff;
-    color: #000;
-    cursor: pointer;
+    z-index: 80;
+    padding: 8px 20px 20px 20px;
+}
+
+.device-overlay.visible {
+    display: block;
+}
+
+.detail-body {
+    padding: 16px 0;
+}
+
+.detail-row {
+    padding: 14px 0;
+    border-bottom: 1px solid #000;
+    overflow: hidden;
+}
+
+.detail-label {
+    font-weight: bold;
+    font-size: 40px;
+    float: left;
+}
+
+.detail-value {
+    font-size: 40px;
+    float: right;
+}
+
+.detail-mono {
+    font-family: monospace;
+    font-size: 34px;
+}
+
+.detail-actions {
+    padding-top: 30px;
+}
+
+.btn-action {
+    margin-bottom: 14px;
+}
+
+/* ---- Off State ---- */
+
+.off-message {
+    font-size: 44px;
     text-align: center;
-    margin-top: 4px;
-    -webkit-appearance: none;
-    -webkit-border-radius: 4px;
-    border-radius: 4px;
+    padding-top: 80px;
 }
 
-.device-disconnect,
-.device-connect {
-    background: #e0e0e0;
+.off-hint {
+    font-size: 34px;
+    text-align: center;
+    padding-top: 10px;
 }
 
-.device-remove + .device-disconnect,
-.device-remove + .device-connect {
-    margin-right: 12px;
+/* ---- Footer ---- */
+
+.footer {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    font-size: 28px;
+    color: #000;
+    padding: 12px 20px 8px 20px;
+    border-top: 2px solid #000;
+    background: #fff;
 }
 
-.device-remove:active,
-.device-remove.btn-active,
-.device-disconnect:active,
-.device-connect:active {
-    background: #000;
-    color: #fff;
+.footer-link {
+    text-decoration: underline;
+    cursor: pointer;
 }
+
+/* ---- Empty state ---- */
 
 .device-empty {
     font-size: 36px;
@@ -319,55 +395,8 @@ html {
     text-align: center;
 }
 
-/* Info box */
-.info-box {
-    border: 2px solid #000;
-    background: #f8f8f8;
-    padding: 16px 20px;
-    margin-bottom: 16px;
-    font-size: 32px;
-    line-height: 1.5;
-}
+/* ---- Message bar ---- */
 
-.info-box .info-title {
-    font-weight: bold;
-    font-size: 36px;
-    margin-bottom: 6px;
-}
-
-.info-box code {
-    font-family: monospace;
-    font-size: 28px;
-    background: #e8e8e8;
-    padding: 2px 6px;
-}
-
-/* Keyboard test input inside debug overlay */
-.keyboard-test-section {
-    padding: 8px 12px;
-    border-bottom: 2px solid #666;
-}
-
-.keyboard-test {
-    width: 100%;
-    min-height: 60px;
-    font-size: 32px;
-    padding: 12px;
-    border: 3px solid #000;
-    background: #fff;
-    color: #333;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-}
-
-/* Utility buttons section */
-.utility-section {
-    margin-top: 12px;
-    padding-top: 12px;
-    border-top: 2px solid #000;
-}
-
-/* Message / toast - floats at bottom, no layout shift */
 .message-bar {
     display: none;
     position: fixed;
@@ -392,7 +421,8 @@ html {
     border-top-style: dashed;
 }
 
-/* Confirm dialog overlay */
+/* ---- Confirm dialog overlay ---- */
+
 .overlay {
     display: none;
     position: fixed;
@@ -441,83 +471,8 @@ html {
     margin: 0 2%;
 }
 
-/* Loading indicator */
-.loading {
-    text-align: center;
-    font-size: 36px;
-    color: #000;
-    padding: 32px 0;
-}
+/* ---- Pair overlay ---- */
 
-/* Scan section */
-.scan-section {
-    margin-bottom: 16px;
-}
-
-.scan-status {
-    text-align: center;
-    font-size: 36px;
-    font-style: italic;
-    padding: 16px 0;
-}
-
-.scan-device-item {
-    border: 2px solid #000;
-    padding: 16px 20px;
-    margin-bottom: 10px;
-    overflow: hidden;
-    -webkit-border-radius: 4px;
-    border-radius: 4px;
-}
-
-.scan-device-info {
-    overflow: hidden;
-}
-
-.scan-device-name {
-    font-weight: bold;
-    font-size: 40px;
-    margin-bottom: 4px;
-}
-
-.scan-device-meta {
-    font-size: 32px;
-    font-family: monospace;
-    color: #000;
-}
-
-.scan-device-rssi {
-    font-size: 28px;
-    display: inline;
-    margin-left: 12px;
-}
-
-.btn-pair {
-    float: right;
-    min-width: 140px;
-    min-height: 76px;
-    padding: 14px 24px;
-    font-size: 32px;
-    font-weight: bold;
-    font-family: sans-serif;
-    border: 3px solid #000;
-    background: #e0e0e0;
-    color: #000;
-    cursor: pointer;
-    text-align: center;
-    margin-top: 4px;
-    -webkit-appearance: none;
-    -webkit-border-radius: 4px;
-    border-radius: 4px;
-}
-
-.btn-pair:active,
-.btn-pair.btn-active {
-    background: #000;
-    color: #fff;
-}
-
-/* Pair overlay */
 .pair-overlay {
     display: none;
     position: absolute;
@@ -560,10 +515,7 @@ html {
     height: 900px;
 }
 
-/* Log viewer - fullscreen overlay */
-.logs-section {
-    margin-bottom: 16px;
-}
+/* ---- Log overlay ---- */
 
 .log-overlay {
     display: none;
@@ -626,12 +578,27 @@ html {
     float: right;
 }
 
-/* Footer */
-.footer {
-    text-align: center;
-    font-size: 28px;
-    color: #000;
-    padding: 12px 0 8px 0;
+/* Keyboard test input inside debug overlay */
+.keyboard-test-section {
+    padding: 8px 12px;
+    border-bottom: 2px solid #666;
+}
+
+.keyboard-test {
+    width: 100%;
+    min-height: 60px;
+    font-size: 32px;
+    padding: 12px;
+    border: 3px solid #000;
+    background: #fff;
+    color: #333;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+/* Utility buttons section */
+.utility-section {
+    margin-top: 12px;
+    padding-top: 12px;
     border-top: 2px solid #000;
-    margin-top: 16px;
 }

--- a/illusion/BTManager/style.css
+++ b/illusion/BTManager/style.css
@@ -74,10 +74,49 @@ html {
 
 /* Status panel */
 .status-panel {
+    position: relative;
     border: 3px solid #000;
     padding: 10px 20px;
+    padding-right: 150px;
     margin-bottom: 8px;
     background: #f0f0f0;
+}
+
+.toggle {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    margin-top: -30px;
+    width: 120px;
+    height: 60px;
+    border: 4px solid #000;
+    -webkit-border-radius: 30px;
+    border-radius: 30px;
+    background: #fff;
+    padding: 4px;
+    cursor: pointer;
+    -webkit-appearance: none;
+}
+
+.toggle:active {
+    background: #e0e0e0;
+}
+
+.toggle-knob {
+    display: block;
+    width: 44px;
+    height: 44px;
+    -webkit-border-radius: 22px;
+    border-radius: 22px;
+    background: #000;
+    position: absolute;
+    top: 4px;
+    left: 4px;
+}
+
+.toggle.on .toggle-knob {
+    left: auto;
+    right: 4px;
 }
 
 .status-row {

--- a/illusion/BTManager/style.css
+++ b/illusion/BTManager/style.css
@@ -399,7 +399,7 @@ html {
 
 .message-bar {
     display: none;
-    position: fixed;
+    position: absolute;
     bottom: 0;
     left: 0;
     width: 100%;
@@ -425,7 +425,7 @@ html {
 
 .overlay {
     display: none;
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;

--- a/justfile
+++ b/justfile
@@ -42,7 +42,6 @@ deploy:
     ssh kindle "mkdir -p {{remote_dir}}/cache"
     @echo "Starting API server..."
     @just server
-    @sleep 8
     ssh kindle 'lipc-set-prop com.lab126.appmgrd start app://com.lzampier.btmanager'
     @echo "Deployment complete!"
 
@@ -170,7 +169,6 @@ _install-tarball tarball:
     ssh kindle "/usr/sbin/mntroot ro"
     @echo "Starting daemon..."
     ssh kindle "/sbin/initctl start hid-passthrough"
-    @sleep 8
     ssh kindle 'lipc-set-prop com.lab126.appmgrd start app://com.lzampier.btmanager'
     @echo "Install complete!"
 

--- a/justfile
+++ b/justfile
@@ -40,6 +40,8 @@ deploy:
     ssh kindle "rm -rf {{remote_dir}}/__pycache__"
     @echo "Creating cache directory..."
     ssh kindle "mkdir -p {{remote_dir}}/cache"
+    @echo "Clearing WAF cache..."
+    -ssh kindle "rm -rf /var/local/mesquite/com.lzampier.btmanager /var/local/mesquite/BTManager" 2>/dev/null
     @echo "Starting API server..."
     @just server
     ssh kindle 'lipc-set-prop com.lab126.appmgrd start app://com.lzampier.btmanager'

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -123,6 +123,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_disconnect()
             case '/logs':
                 self._handle_logs(param('lines'))
+            case '/device-info':
+                self._handle_device_info(param('addr'))
             case _:
                 self._send_json({"ok": False, "error": "Not found"})
 
@@ -146,6 +148,12 @@ class RequestHandler(BaseHTTPRequestHandler):
         }
         if status.get("connected_device"):
             resp["connected_device"] = status["connected_device"]
+            if status.get("uhid_name"):
+                resp["uhid_name"] = status["uhid_name"]
+            if status.get("input_paths"):
+                resp["input_paths"] = status["input_paths"]
+            if status.get("descriptor_size"):
+                resp["descriptor_size"] = status["descriptor_size"]
         self._send_json(resp)
 
     def _handle_start(self):
@@ -309,3 +317,18 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._send_json({"ok": True, "lines": short})
         except OSError as e:
             self._send_json({"ok": False, "error": str(e)})
+
+    def _handle_device_info(self, address):
+        if not address:
+            self._send_json({"ok": False, "error": "No address provided"})
+            return
+
+        addr = normalize_addr(address)
+        cache = DeviceCache(config.cache_dir).load(addr)
+        resp = {"ok": True, "address": addr, "cached": cache is not None}
+        if cache:
+            if cache.get("device_name"):
+                resp["device_name"] = cache["device_name"]
+            if cache.get("report_map"):
+                resp["descriptor_size"] = len(bytes.fromhex(cache["report_map"]))
+        self._send_json(resp)

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -11,6 +11,7 @@ Port 8321 on localhost.
 import json
 import os
 import socket
+import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from urllib.parse import parse_qs, urlparse
@@ -26,6 +27,7 @@ PORT = 8321
 
 _devices_cache = None
 _devices_mtime = 0
+_devices_lock = threading.Lock()
 
 
 def _build_devices_json():
@@ -37,20 +39,21 @@ def _build_devices_json():
     except OSError:
         mtime = 0
 
-    if _devices_cache is not None and mtime == _devices_mtime:
-        return _devices_cache
+    with _devices_lock:
+        if _devices_cache is not None and mtime == _devices_mtime:
+            return _devices_cache
 
-    devices = config.get_all_devices()
-    _devices_cache = [
-        {
-            "address": addr,
-            "protocol": proto.value,
-            **({"name": name} if name else {}),
-        }
-        for addr, proto, name in devices
-    ]
-    _devices_mtime = mtime
-    return _devices_cache
+        devices = config.get_all_devices()
+        _devices_cache = [
+            {
+                "address": addr,
+                "protocol": proto.value,
+                **({"name": name} if name else {}),
+            }
+            for addr, proto, name in devices
+        ]
+        _devices_mtime = mtime
+        return _devices_cache
 
 
 class APIServer(ThreadingMixIn, HTTPServer):
@@ -123,8 +126,6 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_disconnect()
             case '/logs':
                 self._handle_logs(param('lines'))
-            case '/device-info':
-                self._handle_device_info(param('addr'))
             case _:
                 self._send_json({"ok": False, "error": "Not found"})
 
@@ -318,17 +319,3 @@ class RequestHandler(BaseHTTPRequestHandler):
         except OSError as e:
             self._send_json({"ok": False, "error": str(e)})
 
-    def _handle_device_info(self, address):
-        if not address:
-            self._send_json({"ok": False, "error": "No address provided"})
-            return
-
-        addr = normalize_addr(address)
-        cache = DeviceCache(config.cache_dir).load(addr)
-        resp = {"ok": True, "address": addr, "cached": cache is not None}
-        if cache:
-            if cache.get("device_name"):
-                resp["device_name"] = cache["device_name"]
-            if cache.get("report_map"):
-                resp["descriptor_size"] = len(bytes.fromhex(cache["report_map"]))
-        self._send_json(resp)

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -24,10 +24,24 @@ __all__ = ['APIServer', 'RequestHandler', 'PORT']
 PORT = 8321
 
 
+_devices_cache = None
+_devices_mtime = 0
+
+
 def _build_devices_json():
-    """Parse devices.conf into a list of dicts."""
+    """Parse devices.conf into a list of dicts, cached by file mtime."""
+    global _devices_cache, _devices_mtime
+
+    try:
+        mtime = os.path.getmtime(config.devices_config_file)
+    except OSError:
+        mtime = 0
+
+    if _devices_cache is not None and mtime == _devices_mtime:
+        return _devices_cache
+
     devices = config.get_all_devices()
-    return [
+    _devices_cache = [
         {
             "address": addr,
             "protocol": proto.value,
@@ -35,6 +49,8 @@ def _build_devices_json():
         }
         for addr, proto, name in devices
     ]
+    _devices_mtime = mtime
+    return _devices_cache
 
 
 class APIServer(ThreadingMixIn, HTTPServer):

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -51,6 +51,12 @@ class DaemonController:
             status["connected_device"] = conn.get("address")
             status["connected_protocol"] = conn.get("protocol")
             status["connected_name"] = conn.get("name")
+            if conn.get("uhid_name"):
+                status["uhid_name"] = conn["uhid_name"]
+            if conn.get("input_paths"):
+                status["input_paths"] = conn["input_paths"]
+            if conn.get("descriptor_size"):
+                status["descriptor_size"] = conn["descriptor_size"]
 
         status["scanning"] = self.is_scanning
         status["pairing"] = self.is_pairing

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -43,12 +43,19 @@ class HIDDaemon:
     def connection_state(self) -> dict:
         """Current connection state for API."""
         if self.host and self.host._is_connection_alive() and not self._suspended:
-            return {
+            state = {
                 "connected": True,
                 "address": normalize_addr(self.host.current_device_address) if self.host.current_device_address else None,
                 "protocol": self.host.connected_protocol.value if self.host.connected_protocol else None,
                 "name": self.host.device_name,
             }
+            if self.host.uhid_device:
+                state["uhid_name"] = self.host.uhid_device.name
+                if self.host.uhid_device.input_paths:
+                    state["input_paths"] = self.host.uhid_device.input_paths
+            if self.host.report_map:
+                state["descriptor_size"] = len(self.host.report_map)
+            return state
         return {"connected": False}
 
     async def suspend(self):

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -7,7 +7,7 @@ Maintains connection with auto-reconnect.
 
 For use with init scripts / systemd.
 
-Author: Lucas Zampieri <lzampier@redhat.com>
+Author: Lucas Zampieri
 """
 
 import asyncio

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -1469,6 +1469,8 @@ class HIDHost:
                 product=0,
             )
             log.success(f"UHID device created: {name}")
+            asyncio.get_event_loop().call_later(
+                0.5, self.uhid_device.discover_input_paths)
         except Exception as e:
             log.error(f"Failed to create UHID device: {e}")
 

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -98,6 +98,7 @@ class UHIDDevice:
 
         self._fd: Optional[int] = None
         self._created = False
+        self.input_paths: list = []
 
         self._open_uhid()
         self._create_device()
@@ -146,12 +147,54 @@ class UHIDDevice:
             if written != len(event):
                 raise UHIDError(f"Incomplete write: {written} != {len(event)}")
             self._created = True
+            self._discover_input_paths()
             logger.info(f"Created UHID device: {self.name} "
                        f"(vendor=0x{self.vendor:04x}, product=0x{self.product:04x}, "
-                       f"rd_size={len(self.report_descriptor)})")
+                       f"rd_size={len(self.report_descriptor)}, "
+                       f"inputs={self.input_paths})")
 
         except OSError as e:
             raise UHIDError(f"Failed to create device: {e}")
+
+    def _discover_input_paths(self):
+        """Find /dev/input/eventX paths created by this UHID device.
+
+        Retries briefly since the kernel needs time to register the input
+        device after UHID_CREATE2.
+        """
+        import time
+        for attempt in range(5):
+            self.input_paths = self._parse_input_devices()
+            if self.input_paths:
+                return
+            time.sleep(0.1)
+
+    def _parse_input_devices(self):
+        """Parse /proc/bus/input/devices for entries matching this device name."""
+        paths = []
+        try:
+            with open('/proc/bus/input/devices', 'r') as f:
+                block = ""
+                for line in f:
+                    if line.strip() == "":
+                        if self.name in block:
+                            for bline in block.splitlines():
+                                if bline.startswith("H: Handlers="):
+                                    for tok in bline.split("=", 1)[1].split():
+                                        if tok.startswith("event"):
+                                            paths.append("/dev/input/" + tok)
+                        block = ""
+                    else:
+                        block += line
+                if self.name in block:
+                    for bline in block.splitlines():
+                        if bline.startswith("H: Handlers="):
+                            for tok in bline.split("=", 1)[1].split():
+                                if tok.startswith("event"):
+                                    paths.append("/dev/input/" + tok)
+        except OSError:
+            pass
+        return paths
 
     def send_input(self, data: bytes):
         """Send HID input report to the kernel.

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -5,7 +5,7 @@ UHID Handler
 Manages virtual HID devices via Linux UHID interface.
 Allows BLE/Classic HID devices to appear as native Linux input devices.
 
-Author: Lucas Zampieri <lzampier@redhat.com>
+Author: Lucas Zampieri
 """
 
 import logging
@@ -147,54 +147,34 @@ class UHIDDevice:
             if written != len(event):
                 raise UHIDError(f"Incomplete write: {written} != {len(event)}")
             self._created = True
-            self._discover_input_paths()
             logger.info(f"Created UHID device: {self.name} "
                        f"(vendor=0x{self.vendor:04x}, product=0x{self.product:04x}, "
-                       f"rd_size={len(self.report_descriptor)}, "
-                       f"inputs={self.input_paths})")
+                       f"rd_size={len(self.report_descriptor)})")
 
         except OSError as e:
             raise UHIDError(f"Failed to create device: {e}")
 
-    def _discover_input_paths(self):
-        """Find /dev/input/eventX paths created by this UHID device.
+    def discover_input_paths(self):
+        """Find /dev/input/eventX paths for this UHID device.
 
-        Retries briefly since the kernel needs time to register the input
-        device after UHID_CREATE2.
+        Parses /proc/bus/input/devices for entries matching this device's name.
+        Called externally after an async delay to give the kernel time to
+        register the input device after UHID_CREATE2.
         """
-        import time
-        for attempt in range(5):
-            self.input_paths = self._parse_input_devices()
-            if self.input_paths:
-                return
-            time.sleep(0.1)
-
-    def _parse_input_devices(self):
-        """Parse /proc/bus/input/devices for entries matching this device name."""
-        paths = []
+        self.input_paths = []
         try:
-            with open('/proc/bus/input/devices', 'r') as f:
-                block = ""
-                for line in f:
-                    if line.strip() == "":
-                        if self.name in block:
-                            for bline in block.splitlines():
-                                if bline.startswith("H: Handlers="):
-                                    for tok in bline.split("=", 1)[1].split():
-                                        if tok.startswith("event"):
-                                            paths.append("/dev/input/" + tok)
-                        block = ""
-                    else:
-                        block += line
-                if self.name in block:
-                    for bline in block.splitlines():
-                        if bline.startswith("H: Handlers="):
-                            for tok in bline.split("=", 1)[1].split():
-                                if tok.startswith("event"):
-                                    paths.append("/dev/input/" + tok)
+            content = open('/proc/bus/input/devices').read()
         except OSError:
-            pass
-        return paths
+            return
+
+        for block in content.split("\n\n"):
+            if self.name not in block:
+                continue
+            for line in block.splitlines():
+                if line.startswith("H: Handlers="):
+                    for tok in line.split("=", 1)[1].split():
+                        if tok.startswith("event"):
+                            self.input_paths.append("/dev/input/" + tok)
 
     def send_input(self, data: bytes):
         """Send HID input report to the kernel.


### PR DESCRIPTION
The WAF app was sluggish on the Kindle because every 3-second status poll rebuilt the entire DOM and re-read devices.conf from disk, triggering unnecessary e-ink refreshes even when nothing changed. The Start/Stop daemon buttons also took up a full row of screen space.

This redesign adopts the new layout from the UI prototype: Bluetooth toggle slider, 3-tier device list (connected/paired/available), device detail overlay with tap navigation, scan toggle, and a footer-pinned version line with Debug link. The detail overlay shows live HID info (UHID device name and /dev/input/eventX paths) when a device is connected.

On the performance side, status polls now skip DOM updates when the JSON response is unchanged, devices.conf reads are cached by mtime, and the version footer is set once at startup. Deploy also clears the Mesquite WAF cache automatically and no longer sleeps 8 seconds waiting for the daemon.