### PR TITLE
fix: strip digitizer collections from HID descriptors for UHID

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -47,7 +47,7 @@ from config import Protocol, config, get_fallback_hid_descriptor, get_version, n
 from device_cache import DeviceCache
 from logging_utils import log
 from bt_setup import prepare_bt
-from uhid_handler import Bus, UHIDDevice
+from uhid_handler import Bus, UHIDDevice, strip_digitizer_collections
 
 __all__ = ['HIDHost']
 
@@ -1461,9 +1461,10 @@ class HIDHost:
 
         try:
             name = self.device_name or "HID Device"
+            descriptor = strip_digitizer_collections(self.report_map)
             self.uhid_device = UHIDDevice(
                 name=name,
-                report_descriptor=self.report_map,
+                report_descriptor=descriptor,
                 bus=Bus.BLUETOOTH,
                 vendor=0,
                 product=0,

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -13,9 +13,64 @@ import os
 import struct
 from typing import Optional
 
-__all__ = ['UHIDDevice', 'UHIDError', 'Bus']
+__all__ = ['UHIDDevice', 'UHIDError', 'Bus', 'strip_digitizer_collections']
 
 logger = logging.getLogger(__name__)
+
+def strip_digitizer_collections(descriptor: bytes) -> bytes:
+    """Strip Digitizer (0x0D) top-level collections from a HID descriptor.
+
+    The Kindle kernel lacks CONFIG_HID_MULTITOUCH, so hid-core silently
+    drops the entire UHID device when the descriptor contains Digitizer
+    collections. Removing them lets hid-generic claim the rest.
+    """
+    kept = []
+    i = 0
+    usage_page = 0
+    seg_start = 0
+    depth = 0
+
+    while i < len(descriptor):
+        b = descriptor[i]
+        size = b & 0x03
+        if size == 3:
+            size = 4
+        item_type = (b >> 2) & 0x03
+        tag = (b >> 4) & 0x0F
+
+        if i + 1 + size > len(descriptor):
+            break
+
+        if size == 1:
+            val = descriptor[i + 1]
+        elif size == 2:
+            val = int.from_bytes(descriptor[i + 1:i + 3], 'little')
+        elif size == 4:
+            val = int.from_bytes(descriptor[i + 1:i + 5], 'little')
+        else:
+            val = 0
+
+        if item_type == 1 and tag == 0 and depth == 0:
+            usage_page = val
+        if item_type == 0 and tag == 10:
+            depth += 1
+        if item_type == 0 and tag == 12:
+            depth -= 1
+            if depth == 0:
+                end = i + 1 + size
+                if usage_page != 0x0D:
+                    kept.append(descriptor[seg_start:end])
+                seg_start = end
+
+        i += 1 + size
+
+    if not kept or len(kept) == len(descriptor):
+        return descriptor
+
+    result = b''.join(kept)
+    if result != descriptor:
+        logger.info(f"Stripped digitizer collection(s) ({len(descriptor)} -> {len(result)} bytes)")
+    return result
 
 # UHID constants from linux/uhid.h
 UHID_CREATE2 = 11


### PR DESCRIPTION
Some BLE devices (e.g. page-turner clickers like the E1 Control) include Digitizer/multitouch collections alongside Consumer Control in their HID report descriptors. The Kindle kernel (4.9.77-lab126) has CONFIG_HID_MULTITOUCH disabled, which causes hid-core to silently refuse to create any input device for the entire UHID device when it encounters these usages. The UHID_CREATE2 write succeeds but no /dev/input/eventX ever appears.

This adds a descriptor filter that strips top-level Application Collections using the Digitizer usage page (0x0D) before passing the descriptor to UHID. The Consumer Control collection (which is all page turners actually use) goes through fine and hid-generic claims it normally. Descriptors without digitizer collections pass through unchanged.

Reproduced and verified on a PW5 (same kernel): full E1 Control descriptor produces no input device, consumer-only descriptor works immediately.

Fixes #45