### PR TITLE
Fix install script, BTManager API server not starting, and status bar not restoring on exit

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -52,6 +52,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          summary: false
+          record: false
 
       - name: Extract binaries
         run: |
@@ -122,9 +124,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: kindle-hid-passthrough-armv7
-          path: |
-            output/
-            *.tar.gz
+          path: kindle-hid-passthrough-armv7.tar.gz
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -649,7 +649,9 @@ var BTManager = (function() {
 
     function quit() {
         pressBtn("btnBack");
-        if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.back) {
+        if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.startApplication) {
+            kindle.appmgr.startApplication("com.lab126.booklet.home");
+        } else if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.back) {
             kindle.appmgr.back();
         }
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,26 @@
 #!/bin/sh
 
+installMainFiles()
+{
+  echo " -> Installing main program files"
+  mkdir -p /mnt/us/kindle_hid_passthrough/dist
+  mkdir -p /mnt/us/kindle_hid_passthrough/illusion/BTManager
+  mkdir -p /mnt/us/kindle_hid_passthrough/cache
+  cp -r dist/* /mnt/us/kindle_hid_passthrough/dist/
+  cp kindle-hid-passthrough /mnt/us/kindle_hid_passthrough/
+  cp libsyscall_wrapper.so /mnt/us/kindle_hid_passthrough/
+  cp config.ini /mnt/us/kindle_hid_passthrough/
+  chmod +x /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough
+  echo " -> Ready."
+}
+
 installAll()
 {
   echo ""
   echo "=== Full Install ==="
   installUdevRules
   installUpstart
+  installMainFiles
   installWAFApp
   echo ""
   echo "Installation complete. Open 'BT Manager' from the Kindle library."
@@ -52,10 +67,14 @@ setLayout()
 
 installWAFApp()
 {
-  if [ -f illusion/install-waf-app.sh ]; then
-    /bin/sh illusion/install-waf-app.sh
+  echo " -> Installing BTManager app"
+  cp -r illusion/BTManager/* /mnt/us/kindle_hid_passthrough/illusion/BTManager/
+  cp illusion/BTManager.sh /mnt/us/kindle_hid_passthrough/illusion/BTManager.sh
+  cp illusion/install-waf-app.sh /mnt/us/kindle_hid_passthrough/illusion/install-waf-app.sh
+  if [ -f /mnt/us/kindle_hid_passthrough/illusion/install-waf-app.sh ]; then
+    /bin/sh /mnt/us/kindle_hid_passthrough/illusion/install-waf-app.sh
   else
-    echo "ERROR: illusion/install-waf-app.sh not found"
+    echo "ERROR: /mnt/us/kindle_hid_passthrough/illusion/install-waf-app.sh not found"
   fi
 }
 


### PR DESCRIPTION
After downloading the v3.3.3 release zip, copying the folder to the Kindle,
and running `sh scripts/install.sh` via kterm, selecting option 1 (Install
everything) immediately failed with:

```
ERROR: App files not found at /mnt/us/kindle_hid_passthrough/illusion/BTManager
Make sure kindle_hid_passthrough is installed first.
```

The `install-waf-app.sh` script checks for files at
`/mnt/us/kindle_hid_passthrough/illusion/BTManager/`, but no step in the
install chain copies them there. After manually fixing that, BT Manager
opened but every button click returned `"HTTP 0"` — because
`kindle-hid-passthrough --daemon` spawns the Python HTTP API server via
`dist/main.bin` and `dist/ld-linux-armhf.so.3`, but `dist/` was never
deployed either. Finally, closing BT Manager hid the Kindle status bar
(time, battery, WiFi) until opening another app.

## Changes

### `scripts/install.sh`

- **New `installMainFiles()`** — copies the binary, `libsyscall_wrapper.so`,
  `config.ini`, and the entire `dist/` directory to
  `/mnt/us/kindle_hid_passthrough/`. Creates required directories.
- **`installAll()`** — now calls `installMainFiles()` before `installWAFApp()`.
- **`installWAFApp()`** — copies the illusion files (`BTManager/*`,
  `BTManager.sh`, `install-waf-app.sh`) to the target path before running
  the installer. Also fixes option 6 (standalone BTManager install).

### `illusion/BTManager/script.js`

- **`quit()`** — now calls
  `kindle.appmgr.startApplication("com.lab126.booklet.home")` which forces
  the framework to properly restore the Kindle status bar on exit. Falls
  back to `back()` if `startApplication` is unavailable. The Bluetooth
  daemon continues running as a separate background process and is
  unaffected.