### PR TITLE
fix(ble): reconnect to bonded devices that rotate their address

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -51,9 +51,11 @@ class BLEMixin:
         await self.device.send_command(
             HCI_LE_Clear_Filter_Accept_List_Command(), check_result=True)
 
-        for addr_str in addresses:
+        known = {normalize_addr(a) for a in addresses} | self._keystore_addresses
+
+        for addr_str in sorted(known):
             target = Address(addr_str)
-            known_type = self._keystore_address_types.get(normalize_addr(addr_str))
+            known_type = self._keystore_address_types.get(addr_str)
             if known_type is not None:
                 entry_types = [known_type & 1]
             else:
@@ -66,8 +68,6 @@ class BLEMixin:
                     ), check_result=True)
 
         log.info(f"[BLE] Waiting for {len(addresses)} device(s) (accept list)")
-
-        known = {normalize_addr(a) for a in addresses} | self._keystore_addresses
 
         try:
             connection = None

--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -3,7 +3,7 @@
 
 import asyncio
 
-from bumble.core import BT_LE_TRANSPORT, InvalidStateError
+from bumble.core import AdvertisingData, BT_LE_TRANSPORT, InvalidStateError
 from bumble.device import Device, Peer
 from bumble.gatt import (
     GATT_DEVICE_NAME_CHARACTERISTIC,
@@ -33,6 +33,9 @@ HID_REPORT_TYPE_INPUT = 1
 class BLEMixin:
     """BLE methods for HIDHost."""
 
+    BLE_INIT_WINDOW = 18.0
+    BLE_SCAN_WINDOW = 8.0
+
     async def _run_ble_handler(self):
         """Handle BLE connections."""
         known_addresses = [dev.address for dev in self.ble_devices if dev.address != '*']
@@ -50,48 +53,41 @@ class BLEMixin:
 
         for addr_str in addresses:
             target = Address(addr_str)
-            await self.device.send_command(
-                HCI_LE_Add_Device_To_Filter_Accept_List_Command(
-                    address_type=target.address_type,
-                    address=target,
-                ), check_result=True)
+            known_type = self._keystore_address_types.get(normalize_addr(addr_str))
+            if known_type is not None:
+                entry_types = [known_type & 1]
+            else:
+                entry_types = [Address.PUBLIC_DEVICE_ADDRESS, Address.RANDOM_DEVICE_ADDRESS]
+            for entry_type in entry_types:
+                await self.device.send_command(
+                    HCI_LE_Add_Device_To_Filter_Accept_List_Command(
+                        address_type=entry_type,
+                        address=target,
+                    ), check_result=True)
 
         log.info(f"[BLE] Waiting for {len(addresses)} device(s) (accept list)")
 
-        pending = asyncio.get_running_loop().create_future()
-
-        def on_connection(connection):
-            if connection.transport == BT_LE_TRANSPORT and not pending.done():
-                pending.set_result(connection)
-
-        def on_failure(error):
-            if not pending.done():
-                pending.set_exception(error)
-
-        self.device.on(Device.EVENT_CONNECTION, on_connection)
-        self.device.on(Device.EVENT_CONNECTION_FAILURE, on_failure)
+        known = {normalize_addr(a) for a in addresses} | self._keystore_addresses
 
         try:
-            self.device.connect_own_address_type = OwnAddressType.PUBLIC
-            self.device.le_connecting = True
+            connection = None
 
-            await self.device.send_command(
-                HCI_LE_Create_Connection_Command(
-                    le_scan_interval=96,
-                    le_scan_window=96,
-                    initiator_filter_policy=1,
-                    peer_address_type=0,
-                    peer_address=Address.ANY,
-                    own_address_type=OwnAddressType.PUBLIC,
-                    connection_interval_min=12,
-                    connection_interval_max=24,
-                    max_latency=0,
-                    supervision_timeout=72,
-                    min_ce_length=0,
-                    max_ce_length=0,
-                ), check_result=True)
+            while connection is None and not self._connection_future.done():
+                matched_dev = None
+                match_kind = None
 
-            connection = await asyncio.shield(pending)
+                connection = await self._ble_initiate(self.BLE_INIT_WINDOW)
+                if connection is not None:
+                    break
+
+                match = await self._ble_scan_for_rotated(known, self.BLE_SCAN_WINDOW)
+                if match:
+                    target_address, matched_dev, match_kind = match
+                    connection = await self._ble_initiate(
+                        config.connect_timeout, peer=target_address)
+
+            if connection is None:
+                return
 
             if self._connection_future.done():
                 await connection.disconnect()
@@ -108,27 +104,152 @@ class BLEMixin:
 
             await self._ble_restore_or_pair()
 
+            if match_kind == 'name' and matched_dev is not None:
+                self._save_rotated_address(matched_dev, normalize_addr(addr_str))
+
             if not self._connection_future.done():
                 self._connection_future.set_result(connection)
 
         except asyncio.CancelledError:
-            try:
-                await self.device.send_command(
-                    HCI_LE_Create_Connection_Cancel_Command())
-            except Exception:
-                pass
             raise
         except Exception as e:
-            log.warning(f"[BLE] Accept list connection failed: {e}")
+            log.warning(f"[BLE] Connection failed: {e}")
+
+    async def _ble_initiate(self, window: float, peer: Address = None):
+        """Legacy create-connection to `peer`, or to the accept list when
+        None. Returns the connection, or None on window timeout."""
+        pending = asyncio.get_running_loop().create_future()
+
+        def on_connection(connection):
+            if connection.transport == BT_LE_TRANSPORT and not pending.done():
+                pending.set_result(connection)
+
+        def on_failure(error):
+            if getattr(error, 'transport', BT_LE_TRANSPORT) != BT_LE_TRANSPORT:
+                return
+            if not pending.done():
+                pending.set_exception(error)
+
+        def consume_exception(future):
+            if not future.cancelled():
+                future.exception()
+        pending.add_done_callback(consume_exception)
+
+        self.device.on(Device.EVENT_CONNECTION, on_connection)
+        self.device.on(Device.EVENT_CONNECTION_FAILURE, on_failure)
+
+        try:
+            self.device.connect_own_address_type = OwnAddressType.PUBLIC
+            self.device.le_connecting = True
+
+            await self.device.send_command(
+                HCI_LE_Create_Connection_Command(
+                    le_scan_interval=96,
+                    le_scan_window=96,
+                    initiator_filter_policy=0 if peer is not None else 1,
+                    peer_address_type=peer.address_type if peer is not None else 0,
+                    peer_address=peer if peer is not None else Address.ANY,
+                    own_address_type=OwnAddressType.PUBLIC,
+                    connection_interval_min=12,
+                    connection_interval_max=24,
+                    max_latency=0,
+                    supervision_timeout=72,
+                    min_ce_length=0,
+                    max_ce_length=0,
+                ), check_result=True)
+
             try:
-                await self.device.send_command(
-                    HCI_LE_Create_Connection_Cancel_Command())
-            except Exception:
-                pass
+                return await asyncio.wait_for(asyncio.shield(pending), timeout=window)
+            except asyncio.TimeoutError:
+                return None
+
         finally:
+            if not pending.done():
+                try:
+                    await self.device.send_command(
+                        HCI_LE_Create_Connection_Cancel_Command())
+                    await asyncio.wait_for(asyncio.shield(pending), timeout=1.0)
+                except Exception:
+                    pass
             self.device.le_connecting = False
             self.device.remove_listener(Device.EVENT_CONNECTION, on_connection)
             self.device.remove_listener(Device.EVENT_CONNECTION_FAILURE, on_failure)
+
+    async def _ble_scan_for_rotated(self, known: set, window: float):
+        """Scan for bonded devices advertising, including from a rotated
+        address. Returns (address, DeviceConfig or None, kind) or None."""
+        rotated = asyncio.get_running_loop().create_future()
+
+        def on_advertisement(advertisement):
+            if rotated.done():
+                return
+            match = self._match_rotated_ble_device(advertisement, known)
+            if match:
+                rotated.set_result((advertisement.address,) + match)
+
+        self.device.on('advertisement', on_advertisement)
+        scanning = False
+        try:
+            await self.device.start_scanning(
+                legacy=True,
+                own_address_type=OwnAddressType.PUBLIC,
+                filter_duplicates=True,
+            )
+            scanning = True
+            try:
+                return await asyncio.wait_for(rotated, timeout=window)
+            except asyncio.TimeoutError:
+                return None
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.warning(f"[BLE] Rotation scan failed: {e}")
+            return None
+        finally:
+            self.device.remove_listener('advertisement', on_advertisement)
+            if scanning:
+                try:
+                    await self.device.stop_scanning(legacy=True)
+                except Exception:
+                    pass
+
+    def _match_rotated_ble_device(self, advertisement, known: set):
+        """Match an advertisement by known address, IRK resolution, or
+        device name. Returns (DeviceConfig or None, kind) or None."""
+        address = advertisement.address
+        addr_norm = normalize_addr(str(address))
+        if addr_norm in known:
+            dev = next((d for d in self.ble_devices if d.address == addr_norm), None)
+            return (dev, 'known')
+
+        if address.is_resolvable and self.device.address_resolver:
+            resolved = self.device.address_resolver.resolve(address)
+            if resolved:
+                resolved_norm = normalize_addr(str(resolved))
+                if resolved_norm in known:
+                    dev = next((d for d in self.ble_devices if d.address == resolved_norm), None)
+                    log.info(f"[BLE] Resolved {addr_norm} to bonded device "
+                             f"{self._format_device(resolved_norm)}")
+                    return (dev, 'irk')
+
+        name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
+            advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME)
+        if isinstance(name, bytes):
+            name = name.decode('utf-8', errors='replace')
+        if name:
+            dev = next((d for d in self.ble_devices if d.name == name), None)
+            if dev:
+                log.info(f"[BLE] {name} advertising from new address {addr_norm}")
+                return (dev, 'name')
+
+        return None
+
+    def _save_rotated_address(self, dev, new_addr: str):
+        """Save the new address and drop the device's stale entries."""
+        config.add_device(new_addr, Protocol.BLE, dev.name)
+        for old in self.ble_devices:
+            if old.name == dev.name and old.address != new_addr:
+                config.remove_device(old.address)
 
     async def _run_ble_scan_handler(self, target_addresses: set):
         """Fallback BLE handler using active scanning for discovery."""

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -12,7 +12,7 @@ from bumble.gatt import (
     GATT_REPORT_CHARACTERISTIC,
     GATT_REPORT_MAP_CHARACTERISTIC,
 )
-from bumble.hci import Address, HCI_Write_Class_Of_Device_Command, HCI_Write_Local_Name_Command, OwnAddressType
+from bumble.hci import Address, HCI_LE_SET_PRIVACY_MODE_COMMAND, HCI_LE_Set_Privacy_Mode_Command, HCI_Write_Class_Of_Device_Command, HCI_Write_Local_Name_Command, OwnAddressType
 from bumble.hid import Host as BumbleHIDHost
 from bumble.sdp import Client as SDPClient
 
@@ -132,6 +132,10 @@ class HIDHost(ClassicMixin, BLEMixin):
         self.transport, self.device = await create_bumble_device(
             self.transport_spec, configure=configure)
 
+        if self.device.address_resolution_offload:
+            await self._set_device_privacy_modes()
+            log.info("Controller address resolution enabled")
+
         # Classic-specific setup
         if self.classic_devices:
             class_of_device = 0x000104  # Computer/Desktop
@@ -153,6 +157,22 @@ class HIDHost(ClassicMixin, BLEMixin):
         # Load keystore addresses
         await self._load_keystore_addresses()
 
+
+    async def _set_device_privacy_modes(self):
+        """Keep bonded peers visible when they advertise with their
+        identity address instead of an RPA."""
+        if not self.device.host.supports_command(HCI_LE_SET_PRIVACY_MODE_COMMAND):
+            return
+        for _, address in await self.keystore.get_resolving_keys():
+            try:
+                await self.device.send_command(
+                    HCI_LE_Set_Privacy_Mode_Command(
+                        peer_identity_address_type=address.address_type,
+                        peer_identity_address=address,
+                        privacy_mode=HCI_LE_Set_Privacy_Mode_Command.PrivacyMode.DEVICE_PRIVACY_MODE,
+                    ), check_result=True)
+            except Exception as e:
+                log.warning(f"Privacy mode for {address}: {e}")
 
     async def _load_keystore_addresses(self):
         """Load addresses from keystore for connection filtering."""

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -69,6 +69,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         self.classic_devices: List[DeviceConfig] = []
         self.ble_devices: List[DeviceConfig] = []
         self._keystore_addresses: set = set()
+        self._keystore_address_types: dict = {}
 
         self.keystore = create_keystore(config.pairing_keys_file)
         self.device_cache = DeviceCache(config.cache_dir)
@@ -156,6 +157,7 @@ class HIDHost(ClassicMixin, BLEMixin):
     async def _load_keystore_addresses(self):
         """Load addresses from keystore for connection filtering."""
         self._keystore_addresses = set()
+        self._keystore_address_types = {}
         if self.keystore:
             try:
                 keys = await self.keystore.get_all()
@@ -163,6 +165,9 @@ class HIDHost(ClassicMixin, BLEMixin):
                     for entry in keys:
                         addr = str(entry[0]) if isinstance(entry, (list, tuple)) else str(entry)
                         self._keystore_addresses.add(normalize_addr(addr))
+                        pairing_keys = entry[1] if isinstance(entry, (list, tuple)) and len(entry) > 1 else None
+                        if pairing_keys is not None and pairing_keys.address_type is not None:
+                            self._keystore_address_types[normalize_addr(addr)] = pairing_keys.address_type
                     log.info(f"Keystore has {len(self._keystore_addresses)} entries")
             except Exception as e:
                 log.warning(f"Failed to load keystore: {e}")

--- a/kindle_hid_passthrough/transport.py
+++ b/kindle_hid_passthrough/transport.py
@@ -5,7 +5,7 @@ import asyncio
 import os
 
 from bumble.device import Device
-from bumble.hci import HCI_Reset_Command
+from bumble.hci import HCI_LE_ADD_DEVICE_TO_RESOLVING_LIST_COMMAND, LeFeatureMask
 from bumble.transport import open_transport
 
 from config import config
@@ -88,7 +88,7 @@ async def create_bumble_device(transport_spec=None, configure=None):
         log.info("Sending HCI Reset...")
         try:
             await asyncio.wait_for(
-                device.host.send_command(HCI_Reset_Command()),
+                device.host.reset(),
                 timeout=config.hci_reset_timeout
             )
             log.success("HCI Reset successful")
@@ -96,6 +96,11 @@ async def create_bumble_device(transport_spec=None, configure=None):
         except asyncio.TimeoutError:
             log.error("HCI Reset timed out")
             raise
+
+        device.address_resolution_offload = (
+            device.host.supports_le_features(LeFeatureMask.LL_PRIVACY)
+            and device.host.supports_command(HCI_LE_ADD_DEVICE_TO_RESOLVING_LIST_COMMAND)
+        )
 
         await device.power_on()
         log.success(f"Device powered on: {device.public_address}")


### PR DESCRIPTION
Fixes #62

BLE auto-reconnect waited on the controller filter accept list with the addresses stored in devices.conf. Devices that rotate their address never match, so reconnect timed out forever and every manual reconnect added a duplicate devices.conf entry.

## What changed

Two layers, matching how mainstream stacks (BlueZ/Android/Zephyr) handle BLE Privacy:

1. **Controller address resolution (the standard path).** When the controller supports LL Privacy (the MT8112 does), the resolving list is programmed from the keystore IRKs and address resolution is enabled, so the accept list matches rotating RPAs in hardware with zero added latency. Bonded peers are put in device privacy mode so identity-address advertising isn't filtered (the same issue BlueZ patched in 2021). Accept-list entries now include keystore identity addresses and carry the address type recorded at pairing (they were always added as RANDOM before, which silently broke public-address devices).

2. **Scan fallback.** For controllers without LL Privacy, and for non-compliant devices like the reporter's IINE Gamebrick (rotates its "public" identity and distributes a junk IRK each pairing, so no IRK can ever resolve it), the wait now alternates: accept-list initiating window (18s), short legacy scan (8s). The scan matches by known address, host-side IRK resolution, or configured device name as last resort, then connects directly and re-pairs if needed. After a name-match re-pair the new address is saved and stale same-name entries plus their dead keys are pruned. No standard stack auto-reconnects such devices at all; the name match is deliberately a last-resort fallback.

Also fixed along the way: Classic page-timeout failure events killed the BLE wait (missing transport filter), and the "Future exception was never retrieved" log spam after connection-cancel.

## Controller quirks (MT8112, Kindle Basic 5)

- Cannot scan while in the initiating state (COMMAND_DISALLOWED), hence alternating windows.
- Refuses extended LE commands once a legacy one was issued in the session, so the reconnect path is all-legacy.
- Stays in the initiating state until the cancel's connection-complete event arrives; the cancel waits for it before scanning.

## Testing

- Probed the MT8112: LL Privacy feature bit set, all resolving-list commands supported, 64-entry accept list.
- On-device: resolving list + privacy mode programming succeeds, clean wait cycles with zero HCI errors, Classic handler unaffected.
- Matcher logic verified on-device with real bumble types: known address, name match from a rotated address, IRK/RPA resolution with a real ah() hash, and negative cases.
- End-to-end rotated reconnect needs a physical rotating device; asking the reporter to verify with the Gamebrick.