### PR TITLE
fix: capture daemon stderr in the log, stop spawning stale binary from the WAF launcher

### DIFF
--- a/illusion/BTManager.sh
+++ b/illusion/BTManager.sh
@@ -58,7 +58,7 @@ EOF
 # ---- Start helper daemon ----
 
 start_helper() {
-    if pgrep -f "$LD_PROCESS" >/dev/null 2>&1; then
+    if pgrep -f "$LD_PROCESS" >/dev/null 2>&1 || pgrep -f 'main.py --daemon' >/dev/null 2>&1; then
         log_msg "Daemon already running"
         return
     fi

--- a/kindle_hid_passthrough/hid-passthrough-dev.upstart
+++ b/kindle_hid_passthrough/hid-passthrough-dev.upstart
@@ -11,5 +11,5 @@ env KINDLE_HID_BASE=/mnt/us/kindle_hid_passthrough
 console none
 
 script
-    exec /mnt/us/python3.10-kindle/python3-wrapper.sh /mnt/us/kindle_hid_passthrough/main.py --daemon >/dev/null 2>&1
+    exec /mnt/us/python3.10-kindle/python3-wrapper.sh /mnt/us/kindle_hid_passthrough/main.py --daemon >>/var/log/hid_passthrough.log 2>&1
 end script


### PR DESCRIPTION
Two small fixes that came out of debugging tonight's "daemon died and I can't see why" session.

**Upstart job no longer eats stderr.** The dev job ran the daemon with `>/dev/null 2>&1`, so every silent death left zero trace, the log just stops mid cycle. And since the WAF debug page fetches logs through the daemon's own API, a dead daemon means no logs anywhere. Stderr now appends to `/var/log/hid_passthrough.log`, so the next time it dies the traceback survives the respawn and shows up right in the debug page.

**start_helper stops resurrecting the stale release binary.** It only pgrep'd for the ld-linux process of the compiled binary, so on a dev install (running `main.py` under the bundled python) it always concluded nothing was running and spawned the old binary from a previous release install alongside the dev daemon. The two then fight over `/dev/stpbt`, and the eviction in bt_setup SIGKILLs whoever holds it. That is exactly what chopped an Xbox controller mid auth today: the v3.4.1 binary picked up the connection, got to the link key exchange, and the respawning dev daemon killed it. Now `main.py --daemon` counts as a running daemon.

Tested on the Basic 5: stop/start cycles, scan during an active connect attempt, and a real controller connect all clean, with a single daemon instance throughout.
