### PR TITLE
fix(bt): correctness fixes from implementation review (protocol mode, discovery, routing, unplug, radio lock)

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -388,12 +388,12 @@ class BLEMixin:
                     pass
 
         if report_type == HID_REPORT_TYPE_INPUT:
-            self.hid_reports[report_id] = char
+            self.hid_reports.append((report_id, char))
             log.info(f"[BLE] Found input report {report_id}")
 
     async def _subscribe_to_ble_reports(self):
         """Subscribe to BLE HID input report notifications."""
-        for report_id, char in self.hid_reports.items():
+        for report_id, char in self.hid_reports:
             try:
                 def make_callback(rid):
                     return lambda value: self._on_ble_hid_report(value, rid)

--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -404,7 +404,7 @@ class BLEMixin:
                 log.warning(f"[BLE] Failed to subscribe to report {report_id}: {e}")
 
     async def _ble_activate_hid_service(self):
-        """Write Exit Suspend to HID Control Point and read Protocol Mode."""
+        """Write Exit Suspend to HID Control Point and force Report Protocol Mode."""
         if not self.peer:
             log.warning("[BLE] No peer for HID activation")
             return
@@ -434,8 +434,11 @@ class BLEMixin:
                     value = await self.peer.read_value(char)
                     mode = "Report" if bytes(value) == b'\x01' else "Boot"
                     log.info(f"[BLE] Protocol Mode: {mode}")
+                    if bytes(value) != b'\x01':
+                        await self.peer.write_value(char, bytes([0x01]), with_response=False)
+                        log.info("[BLE] Forced Report Protocol Mode")
                 except Exception as e:
-                    log.warning(f"[BLE] Failed to read Protocol Mode: {e}")
+                    log.warning(f"[BLE] Protocol Mode read/write failed: {e}")
 
         if not found_cp:
             log.info(f"[BLE] No HID Control Point characteristic (found {len(hid_service.characteristics)} chars)")

--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -135,6 +135,7 @@ class BLEMixin:
                 future.exception()
         pending.add_done_callback(consume_exception)
 
+        await self._radio_lock.acquire()
         self.device.on(Device.EVENT_CONNECTION, on_connection)
         self.device.on(Device.EVENT_CONNECTION_FAILURE, on_failure)
 
@@ -174,6 +175,7 @@ class BLEMixin:
             self.device.le_connecting = False
             self.device.remove_listener(Device.EVENT_CONNECTION, on_connection)
             self.device.remove_listener(Device.EVENT_CONNECTION_FAILURE, on_failure)
+            self._radio_lock.release()
 
     async def _ble_scan_for_rotated(self, known: set, window: float):
         """Scan for bonded devices advertising, including from a rotated
@@ -187,6 +189,7 @@ class BLEMixin:
             if match:
                 rotated.set_result((advertisement.address,) + match)
 
+        await self._radio_lock.acquire()
         self.device.on('advertisement', on_advertisement)
         scanning = False
         try:
@@ -212,6 +215,7 @@ class BLEMixin:
                     await self.device.stop_scanning(legacy=True)
                 except Exception:
                     pass
+            self._radio_lock.release()
 
     def _match_rotated_ble_device(self, advertisement, known: set):
         """Match an advertisement by known address, IRK resolution, or
@@ -271,12 +275,13 @@ class BLEMixin:
             self.device.on('advertisement', on_advertisement)
 
             try:
-                await self.device.start_scanning()
-                for _ in range(20):
-                    if found_device or self._connection_future.done():
-                        break
-                    await asyncio.sleep(0.5)
-                await self.device.stop_scanning()
+                async with self._radio_lock:
+                    await self.device.start_scanning()
+                    for _ in range(20):
+                        if found_device or self._connection_future.done():
+                            break
+                        await asyncio.sleep(0.5)
+                    await self.device.stop_scanning()
             except Exception as e:
                 log.warning(f"[BLE] Scan error: {e}")
             finally:
@@ -290,11 +295,12 @@ class BLEMixin:
                 for attempt in range(1, max_attempts + 1):
                     try:
                         log.info(f"[BLE] Connecting to {found_device.address} (Attempt {attempt}/{max_attempts})...")
-                        self.connection = await self.device.connect(
-                            found_device.address,
-                            own_address_type=OwnAddressType.PUBLIC,
-                            timeout=config.connect_timeout,
-                        )
+                        async with self._radio_lock:
+                            self.connection = await self.device.connect(
+                                found_device.address,
+                                own_address_type=OwnAddressType.PUBLIC,
+                                timeout=config.connect_timeout,
+                            )
 
                         if self._connection_future.done():
                             await self.connection.disconnect()

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -327,4 +327,5 @@ class ClassicMixin:
     def _on_virtual_cable_unplug(self):
         """Handle virtual cable unplug."""
         log.warning("[Classic] Virtual cable unplugged")
+        self._virtual_cable_unplug_address = self.current_device_address
         self._disconnection_event.set()

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -9,7 +9,7 @@ from bumble.hci import (
     Address,
     HCI_Write_Scan_Enable_Command,
 )
-from bumble.hid import HID_CONTROL_PSM, HID_INTERRUPT_PSM
+from bumble.hid import HID_CONTROL_PSM, HID_INTERRUPT_PSM, Message
 from bumble.hid import Host as BumbleHIDHost
 from bumble.sdp import Client as SDPClient
 
@@ -162,6 +162,8 @@ class ClassicMixin:
                     )
                 return
 
+            self._classic_set_report_protocol()
+
             if not self._connection_future.done():
                 self._connection_future.set_result(connection)
 
@@ -256,6 +258,16 @@ class ClassicMixin:
 
             if not self._connection_future.done():
                 await asyncio.sleep(self.ACTIVE_RETRY_INTERVAL)
+
+    def _classic_set_report_protocol(self):
+        """Send HIDP SET_PROTOCOL(Report) on the control channel."""
+        if not self.hid_host or not self.hid_host.l2cap_ctrl_channel:
+            return
+        try:
+            self.hid_host.set_protocol(Message.ProtocolMode.REPORT_PROTOCOL)
+            log.info("[Classic] Sent SET_PROTOCOL (Report)")
+        except Exception as e:
+            log.warning(f"[Classic] SET_PROTOCOL failed: {e}")
 
     def _finalize_classic_hid(self):
         """Apply fallback descriptor if needed and create UHID."""

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -216,6 +216,7 @@ class ClassicMixin:
                 log.info(f"[Classic] Attempt {attempt}: {self._format_device(addr)}")
 
                 target = Address(addr, Address.PUBLIC_DEVICE_ADDRESS)
+                await self._radio_lock.acquire()
                 connect_task = asyncio.create_task(
                     self.device.connect(target, transport=BT_BR_EDR_TRANSPORT)
                 )
@@ -255,6 +256,7 @@ class ClassicMixin:
                         await connect_task
                     except (asyncio.CancelledError, Exception):
                         pass
+                    self._radio_lock.release()
 
             if not self._connection_future.done():
                 await asyncio.sleep(self.ACTIVE_RETRY_INTERVAL)

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -182,13 +182,20 @@ class HIDDaemon:
                 # here avoids a race where both paths run host.cleanup() in
                 # parallel and deadlock on transport/connection teardown.
                 auth_fail_addr = None
+                vc_unplug_addr = None
                 if self.host and not self._suspended:
                     auth_fail_addr = self.host.get_auth_failure_address()
+                    vc_unplug_addr = self.host.get_virtual_cable_unplug_address()
                     try:
                         await self.host.cleanup()
                     except Exception:
                         pass
                     self.host = None
+
+                if vc_unplug_addr:
+                    logger.info(f"Virtual cable unplugged by {vc_unplug_addr}, removing device")
+                    config.remove_device(vc_unplug_addr)
+                    skip_delay = True
 
                 if auth_fail_addr:
                     logger.info(f"Auth failure for {auth_fail_addr}, clearing stale key")

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -80,6 +80,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         self._connection_future = None
         self._last_report = None
         self._auth_failure_address = None
+        self._virtual_cable_unplug_address = None
 
     @property
     def connection_state(self) -> dict:
@@ -706,4 +707,10 @@ class HIDHost(ClassicMixin, BLEMixin):
         """Get address that had auth failure, if any."""
         addr = self._auth_failure_address
         self._auth_failure_address = None
+        return addr
+
+    def get_virtual_cable_unplug_address(self) -> str:
+        """Get address that sent a virtual cable unplug, if any."""
+        addr = self._virtual_cable_unplug_address
+        self._virtual_cable_unplug_address = None
         return addr

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -194,14 +194,20 @@ class HIDHost(ClassicMixin, BLEMixin):
             except Exception as e:
                 log.warning(f"Failed to load keystore: {e}")
 
-    def _format_device(self, addr: str) -> str:
-        """Format device address with name if available."""
+    def _configured_name(self, addr: str) -> Optional[str]:
+        """Return the configured devices.conf name for addr, if any."""
+        if not addr:
+            return None
         norm = normalize_addr(addr)
         for dev in self.classic_devices + self.ble_devices:
-            if dev.address == norm:
-                if dev.name:
-                    return f"{dev.name} ({addr})"
-        return addr
+            if dev.address == norm and dev.name:
+                return dev.name
+        return None
+
+    def _format_device(self, addr: str) -> str:
+        """Format device address with name if available."""
+        name = self._configured_name(addr)
+        return f"{name} ({addr})" if name else addr
 
     async def run(self):
         """Main run loop - handle both protocols concurrently."""
@@ -613,7 +619,7 @@ class HIDHost(ClassicMixin, BLEMixin):
             return
 
         try:
-            name = self.device_name or "HID Device"
+            name = self.device_name or self._configured_name(self.current_device_address) or "HID Device"
             descriptor = strip_digitizer_collections(self.report_map)
             self.uhid_device = UHIDDevice(
                 name=name,

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -81,6 +81,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         self._last_report = None
         self._auth_failure_address = None
         self._virtual_cable_unplug_address = None
+        self._radio_lock = None
 
     @property
     def connection_state(self) -> dict:
@@ -206,6 +207,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         """Main run loop - handle both protocols concurrently."""
         self._disconnection_event = asyncio.Event()
         self._connection_future = asyncio.get_event_loop().create_future()
+        self._radio_lock = asyncio.Lock()
 
         self._parse_devices()
         await self.start()

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -64,7 +64,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         self.current_device_address = None
         self.device_name = None
         self.report_map: Optional[bytes] = None
-        self.hid_reports = {}
+        self.hid_reports = []
 
         self.classic_devices: List[DeviceConfig] = []
         self.ble_devices: List[DeviceConfig] = []

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -543,6 +543,7 @@ class HIDHost(ClassicMixin, BLEMixin):
             log.error("[Classic] Failed to connect HID interrupt channel")
             return
 
+        self._classic_set_report_protocol()
         self._finalize_classic_hid()
 
     async def _continue_ble_after_pairing(self):

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -155,6 +155,11 @@ class Scanner:
                             is_hid = True
                             break
 
+                if not is_hid:
+                    appearance = advertisement.data.get(AdvertisingData.APPEARANCE)
+                    if appearance is not None and (int(appearance) >> 6) == 0x0F:
+                        is_hid = True
+
             if not is_hid:
                 return
             seen_addresses.add(addr_str)

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -140,7 +140,6 @@ class Scanner:
             addr_str = str(advertisement.address)
             if addr_str in seen_addresses:
                 return
-            seen_addresses.add(addr_str)
 
             # Check for HID service in advertising data
             is_hid = False
@@ -156,24 +155,27 @@ class Scanner:
                             is_hid = True
                             break
 
-            if is_hid:
-                name = 'Unknown'
-                if hasattr(advertisement, 'data') and advertisement.data:
-                    name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
-                           advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME) or 'Unknown'
-                    if isinstance(name, bytes):
-                        name = name.decode('utf-8', errors='replace')
+            if not is_hid:
+                return
+            seen_addresses.add(addr_str)
 
-                device = DiscoveredDevice(
-                    address=addr_str,
-                    name=name,
-                    protocol=Protocol.BLE,
-                    rssi=advertisement.rssi or -100
-                )
-                devices_found.append(device)
-                log.info(f"  Found: {device}")
-                if self.on_device_found:
-                    self.on_device_found(device)
+            name = 'Unknown'
+            if hasattr(advertisement, 'data') and advertisement.data:
+                name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
+                       advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME) or 'Unknown'
+                if isinstance(name, bytes):
+                    name = name.decode('utf-8', errors='replace')
+
+            device = DiscoveredDevice(
+                address=addr_str,
+                name=name,
+                protocol=Protocol.BLE,
+                rssi=advertisement.rssi or -100
+            )
+            devices_found.append(device)
+            log.info(f"  Found: {device}")
+            if self.on_device_found:
+                self.on_device_found(device)
 
         self.device.on('advertisement', on_advertisement)
         try:


### PR DESCRIPTION
Batch of medium-severity correctness fixes from a review of the userspace BT HID
implementation. Each is its own commit so they can be bisected/reverted independently.

## Fixes

- **D2 — Report Protocol Mode** (`1a8f0b5`): both transports assumed the peer was
  already in Report Protocol. A boot-capable device that comes up in Boot Protocol
  streams boot-format reports that don't match the descriptor handed to UHID. BLE now
  writes `0x01` to the Protocol Mode characteristic when the device reports Boot;
  Classic sends HIDP `SET_PROTOCOL(Report)` once the control channel is up.
- **B7 — scanner dedup** (`835e133`): an address was marked "seen" on its first
  advertisement, locking the HID decision to a possibly-incomplete report. Now only
  recorded as seen once classified as HID, so HID data in a later report isn't missed.
- **B6 — Appearance discovery** (`5be005b`): BLE discovery only matched the 0x1812 HID
  UUID. Many HOGP devices expose HID only via GATT and signal type via GAP Appearance;
  now also treats Appearance category 0x0F (HID) as a candidate.
- **B4 — BLE report routing** (`ebc3b30`): `hid_reports` was a dict keyed by report_id,
  so two input reports that both resolved to id 0 overwrote each other and only the last
  was subscribed. Stored as a list of `(report_id, char)` so every input report is kept.
- **D3 — Virtual Cable Unplug** (`22c84cf`): unplug only set the disconnection event,
  leaving the link key in the keystore so the daemon kept auto-reconnecting to a device
  the user had unpaired. Now treated as terminal: the device (and its key) is removed,
  matching how BlueZ drops a HID device on unplug.
- **B2 — radio serialization** (`c8aa12c`): the BLE and Classic handlers are separate
  tasks on one MT8112, which can't scan while initiating. Added a shared radio lock held
  across each BLE initiate/scan window and Classic page. No-op for single-protocol
  configs (lock is uncontended).

## Testing

Verified on a Kindle Basic 5 (MT8112) with an Xbox Wireless Controller (Classic):
- `Sent SET_PROTOCOL (Report)` fires on connect (D2).
- Controller still reaches "Receiving HID reports" with the radio lock in place (B2);
  no lock/HCI errors at runtime.

## Deliberately not included

- **B5** (SDP-fail fallback descriptor): the gamepad + Report ID 1 fallback is what the
  Xbox controller actually uses when its SDP query fails, so the review's "make it
  unnumbered / remove it" suggestion would break the reference device. Left as-is.
- **B3** (Classic single-flight + `Create_Connection_Cancel` on abandon): pending,
  separate change — it touches the active-connect path and wants live reconnect testing.
- D5 (host→device Output/LED path) and B9 (key storage on FAT) are parked per discussion.
