### PR TITLE
fix: ignore malformed BLE advertisements

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -236,8 +236,12 @@ class BLEMixin:
                              f"{self._format_device(resolved_norm)}")
                     return (dev, 'irk')
 
-        name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
-            advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME)
+        try:
+            name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
+                advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME)
+        except UnicodeDecodeError as e:
+            log.debug(f"[BLE] Ignoring malformed advertisement from {addr_norm}: {e}")
+            return None
         if isinstance(name, bytes):
             name = name.decode('utf-8', errors='replace')
         if name:

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -141,24 +141,30 @@ class Scanner:
             if addr_str in seen_addresses:
                 return
 
-            # Check for HID service in advertising data
+            # Check for HID service in advertising data. Some nearby devices
+            # advertise malformed local names, and Bumble may decode them while
+            # iterating the advertising records.
             is_hid = False
             if hasattr(advertisement, 'data') and advertisement.data:
-                services = advertisement.data.get(
-                    AdvertisingData.COMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
-                ) or advertisement.data.get(
-                    AdvertisingData.INCOMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
-                )
-                if services:
-                    for service_uuid in services:
-                        if service_uuid == GATT_HUMAN_INTERFACE_DEVICE_SERVICE:
-                            is_hid = True
-                            break
+                try:
+                    services = advertisement.data.get(
+                        AdvertisingData.COMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
+                    ) or advertisement.data.get(
+                        AdvertisingData.INCOMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
+                    )
+                    if services:
+                        for service_uuid in services:
+                            if service_uuid == GATT_HUMAN_INTERFACE_DEVICE_SERVICE:
+                                is_hid = True
+                                break
 
-                if not is_hid:
-                    appearance = advertisement.data.get(AdvertisingData.APPEARANCE)
-                    if appearance is not None and (int(appearance) >> 6) == 0x0F:
-                        is_hid = True
+                    if not is_hid:
+                        appearance = advertisement.data.get(AdvertisingData.APPEARANCE)
+                        if appearance is not None and (int(appearance) >> 6) == 0x0F:
+                            is_hid = True
+                except UnicodeDecodeError as e:
+                    log.debug(f"Skipping malformed BLE advertisement from {addr_str}: {e}")
+                    return
 
             if not is_hid:
                 return
@@ -166,8 +172,12 @@ class Scanner:
 
             name = 'Unknown'
             if hasattr(advertisement, 'data') and advertisement.data:
-                name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
-                       advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME) or 'Unknown'
+                try:
+                    name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
+                           advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME) or 'Unknown'
+                except UnicodeDecodeError as e:
+                    log.debug(f"Using Unknown name for malformed BLE advertisement from {addr_str}: {e}")
+                    name = 'Unknown'
                 if isinstance(name, bytes):
                     name = name.decode('utf-8', errors='replace')
 


### PR DESCRIPTION
## Summary
- ignore malformed BLE local-name advertising data during rotated-address matching
- ignore malformed advertising records during BLE HID scanning instead of aborting the scan callback

## Context
On a Kindle PW5 running `3.6.0-5e99c17`, a paired BLE keyboard failed to reconnect after sleep. The daemon reached `[BLE] Waiting for 1 device(s) (accept list)`, then the rotated-address scan repeatedly failed with:

```text
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
  File "/mnt/us/kindle_hid_passthrough/dist/ble.py", line 240, in _match_rotated_ble_device
  File "/mnt/us/kindle_hid_passthrough/dist/bumble/core.py", line 2094, in get
```

This makes reconnect fragile when any nearby BLE advertiser has malformed local-name data. The bad advertisement should be skipped, not allowed to break reconnect or scanning.

## Test
- `python3 -m py_compile kindle_hid_passthrough/ble.py kindle_hid_passthrough/scanner.py`