### PR TITLE
fix: ignore malformed BLE advertisements

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -236,8 +236,12 @@ class BLEMixin:
                              f"{self._format_device(resolved_norm)}")
                     return (dev, 'irk')
 
-        name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
-            advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME)
+        try:
+            name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
+                advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME)
+        except UnicodeDecodeError as e:
+            log.debug(f"[BLE] Ignoring malformed advertisement from {addr_norm}: {e}")
+            return None
         if isinstance(name, bytes):
             name = name.decode('utf-8', errors='replace')
         if name:

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -141,9 +141,6 @@ class Scanner:
             if addr_str in seen_addresses:
                 return
 
-            # Check for HID service in advertising data. Some nearby devices
-            # advertise malformed local names, and Bumble may decode them while
-            # iterating the advertising records.
             is_hid = False
             if hasattr(advertisement, 'data') and advertisement.data:
                 try:

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -141,24 +141,30 @@ class Scanner:
             if addr_str in seen_addresses:
                 return
 
-            # Check for HID service in advertising data
+            # Check for HID service in advertising data. Some nearby devices
+            # advertise malformed local names, and Bumble may decode them while
+            # iterating the advertising records.
             is_hid = False
             if hasattr(advertisement, 'data') and advertisement.data:
-                services = advertisement.data.get(
-                    AdvertisingData.COMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
-                ) or advertisement.data.get(
-                    AdvertisingData.INCOMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
-                )
-                if services:
-                    for service_uuid in services:
-                        if service_uuid == GATT_HUMAN_INTERFACE_DEVICE_SERVICE:
-                            is_hid = True
-                            break
+                try:
+                    services = advertisement.data.get(
+                        AdvertisingData.COMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
+                    ) or advertisement.data.get(
+                        AdvertisingData.INCOMPLETE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS
+                    )
+                    if services:
+                        for service_uuid in services:
+                            if service_uuid == GATT_HUMAN_INTERFACE_DEVICE_SERVICE:
+                                is_hid = True
+                                break
 
-                if not is_hid:
-                    appearance = advertisement.data.get(AdvertisingData.APPEARANCE)
-                    if appearance is not None and (int(appearance) >> 6) == 0x0F:
-                        is_hid = True
+                    if not is_hid:
+                        appearance = advertisement.data.get(AdvertisingData.APPEARANCE)
+                        if appearance is not None and (int(appearance) >> 6) == 0x0F:
+                            is_hid = True
+                except UnicodeDecodeError as e:
+                    log.debug(f"Skipping malformed BLE advertisement from {addr_str}: {e}")
+                    return
 
             if not is_hid:
                 return
@@ -166,8 +172,12 @@ class Scanner:
 
             name = 'Unknown'
             if hasattr(advertisement, 'data') and advertisement.data:
-                name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
-                       advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME) or 'Unknown'
+                try:
+                    name = advertisement.data.get(AdvertisingData.COMPLETE_LOCAL_NAME) or \
+                           advertisement.data.get(AdvertisingData.SHORTENED_LOCAL_NAME) or 'Unknown'
+                except UnicodeDecodeError as e:
+                    log.debug(f"Using Unknown name for malformed BLE advertisement from {addr_str}: {e}")
+                    name = 'Unknown'
                 if isinstance(name, bytes):
                     name = name.decode('utf-8', errors='replace')
 


### PR DESCRIPTION
## What

Ignore malformed BLE advertising records instead of letting Bumble's advertising data decoder abort scan or reconnect handling with a `UnicodeDecodeError`.

The fix is intentionally narrow:

- during paired BLE reconnect, skip a malformed advertisement when matching rotated BLE addresses by advertised name
- during BTManager BLE scanning, skip malformed HID-service advertisements or fall back to `Unknown` when only the local name is malformed

## Practical problem

On a Kindle using BTManager for a BLE keyboard, a nearby device can advertise malformed local-name data. When Bumble decodes that advertising record, it may raise `UnicodeDecodeError`. Before this change, that exception could break the BLE scan/reconnect path even though the paired keyboard itself was present and bonded.

In practice this showed up as BTManager failing to find or reconnect a paired Bluetooth keyboard: the UI and daemon were running, the keyboard was nearby, but the reconnect loop could be interrupted by an unrelated malformed BLE advertisement in the environment.

## Validation

Tested on a Kindle PW5 with a paired BLE keyboard.

- built a validation runtime containing this change via GitHub Actions on a fork
- installed the runtime on the Kindle while preserving existing pairing keys and BTManager config
- confirmed the daemon reconnected to the paired keyboard and exposed `/dev/input/event2`
- confirmed recent daemon logs no longer showed the previous `UnicodeDecodeError` from BLE advertisement parsing after the patched daemon started
- confirmed BTManager `/status` reported the keyboard connected with HID descriptor and input path
- ran a sleep/wake validation cycle where the Kindle reached `readyToSuspend`, returned to `active`, and the keyboard remained connected afterward

Local check:

- `python3 -m py_compile kindle_hid_passthrough/*.py`

## Notes

This PR only addresses malformed BLE advertisements interrupting scan/reconnect. It deliberately does not include separate follow-up work for stale controller-side BLE links after suspend or BTManager close behavior.