### PR TITLE
fix: close BTManager without killing mesquite

### DIFF
--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -647,12 +647,11 @@ var BTManager = (function() {
 
     function quit() {
         pressBtn("btnBack");
-        if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.startApplication) {
-            kindle.appmgr.startApplication("com.lab126.booklet.home");
-        } else if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.back) {
+        if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.back) {
             kindle.appmgr.back();
+        } else if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.startApplication) {
+            kindle.appmgr.startApplication("com.lab126.booklet.home");
         }
-        request("/quit-app", function() {});
     }
 
     // ---- Event Binding ----

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -11,8 +11,6 @@ Port 8321 on localhost.
 import json
 import os
 import socket
-import subprocess
-import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from urllib.parse import parse_qs, urlparse
@@ -94,8 +92,6 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_disconnect()
             case '/logs':
                 self._handle_logs(param('lines'))
-            case '/quit-app':
-                self._handle_quit_app()
             case _:
                 self._send_json({"ok": False, "error": "Not found"})
 
@@ -209,16 +205,6 @@ class RequestHandler(BaseHTTPRequestHandler):
         controller.request_disconnect()
         self._send_json({"ok": True, "message": "Disconnecting"})
 
-    def _handle_quit_app(self):
-        self._send_json({"ok": True})
-        threading.Thread(
-            target=lambda: subprocess.run(
-                ["pkill", "-TERM", "-f", "mesquite.*BTManager"],
-                timeout=5,
-            ),
-            daemon=True,
-        ).start()
-
     def _handle_logs(self, lines_str):
         log_file = config.log_file
         num_lines = 50
@@ -261,4 +247,3 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._send_json({"ok": True, "lines": short})
         except OSError as e:
             self._send_json({"ok": False, "error": str(e)})
-


### PR DESCRIPTION
## What

Close BTManager through Kindle app manager lifecycle instead of asking the helper API to force-kill the Mesquite WAF process.

The close button now prefers `kindle.appmgr.back()` and keeps `startApplication("com.lab126.booklet.home")` as a fallback. The `/quit-app` request and backend `pkill mesquite.*BTManager` handler are removed.

## Practical problem

The previous `/quit-app` workaround was added to avoid a ~19 MB Mesquite RSS leak after closing BTManager. In practice it also terminated Mesquite from outside appmgrd, which can make Kindle treat BTManager as if it crashed and show an application error after close.

This keeps the memory-cleanup intent while avoiding the crash-looking forced termination path.

## Validation

Tested on a Kindle PW5 with BTManager installed.

- installed a device-only version of this close behavior
- confirmed the installed UI had no `/quit-app` or `pkill` reference
- closed BTManager from the UI and confirmed no BTManager Mesquite process remained afterward, so the RSS cleanup still happened
- confirmed the HID daemon stayed running and the paired keyboard remained connected on `/dev/input/event2`
- checked current Kindle logs after close and found no BTManager `application_state_error`, `abnormal_exit`, or Mesquite close error for the installed variant

Earlier validation of the no-`/quit-app` path also showed appmgrd reclaiming Mesquite normally with `exitcode=0` and `abnormal_exit=0`.

Local check:

- `python3 -m py_compile kindle_hid_passthrough/*.py`

## Notes

This PR changes only BTManager close behavior. It does not change pairing, scanning, reconnect behavior, or daemon lifecycle.