### PR TITLE
fix(btmanager): close app via appmgrd stop instead of killing mesquite

### DIFF
--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -213,7 +213,8 @@ class RequestHandler(BaseHTTPRequestHandler):
         self._send_json({"ok": True})
         threading.Thread(
             target=lambda: subprocess.run(
-                ["pkill", "-TERM", "-f", "mesquite.*BTManager"],
+                ["lipc-set-prop", "com.lab126.appmgrd", "stop",
+                 "app://com.lzampier.btmanager"],
                 timeout=5,
             ),
             daemon=True,


### PR DESCRIPTION
`/quit-app` killed mesquite with `pkill` to reclaim the ~19-30 MB it leaks on close, but killing it behind appmgrd's back made appmgrd flag an abnormal exit and pop an "Application Error". This switches to `lipc-set-prop com.lab126.appmgrd stop app://com.lzampier.btmanager`, which runs the managed pause/unload/exit so the process is reaped *and* the exit is clean.

Verified on device: `/quit-app` reaps mesquite in <2s with `exitcode=0,abnormal_exit=0`, no popup.