### PR TITLE
fix(installer): resolve setlayout.sh by script-dir path

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,9 @@
 
 INSTALL_DIR="/mnt/us/kindle_hid_passthrough"
 
+# Directory holding this script, so sibling scripts resolve regardless of cwd.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # True when the script is running from the install dir itself, so the
 # cp commands below would be a no-op (source == destination).
 in_install_dir()
@@ -72,7 +75,7 @@ setLayout()
 {
   printf "Enter layout code (e.g. fr, de, 'fr(oss)'): "
   read layout
-  /bin/sh setlayout.sh "$layout"
+  /bin/sh "$SCRIPT_DIR/setlayout.sh" "$layout"
 }
 
 installWAFApp()


### PR DESCRIPTION
## Problem

Menu option 7 (set custom keyboard layout) fails with:

```
/bin/sh: can't open 'setlayout.sh': No such file or directory
```

when the installer is launched as `sh scripts/install.sh` (the documented invocation from the tarball root). It only worked when run from inside `scripts/`.

In the release tarball, `install.sh` lives in `scripts/` while `dist/`, `assets/`, `config.ini` etc. sit at the tarball root, so the installer is meant to run as `sh scripts/install.sh` from the root. Every other path is root-relative and resolves fine, but `setlayout.sh` is a sibling of `install.sh` inside `scripts/` and was invoked by a bare relative path, so it only resolved when cwd was `scripts/`.

## Fix

Compute `SCRIPT_DIR` once from `$0` and invoke `"$SCRIPT_DIR/setlayout.sh"`, so it resolves regardless of cwd.

Tested `sh -n` plus resolution from both the tarball root (`sh scripts/install.sh`) and inside `scripts/`.

Fixes #76
Refs #33

Reported by @samarulmeu.