### PR TITLE
fix(koplugin): suppress FBInk input-scan recap spam

### DIFF
--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -203,6 +203,14 @@ do
     end
 end
 
+-- NO_RECAP silences fbink_input_check's per-device log line. Absent on older
+-- koreader-base builds, so resolve defensively.
+local INPUT_SCAN_FLAGS = 0
+do
+    local ok, flag = pcall(function() return C.NO_RECAP end)
+    if ok and flag then INPUT_SCAN_FLAGS = flag end
+end
+
 -- Stub functions used to flip Device.has* properties on/off.
 local function yes() return true end
 local function no()  return false end
@@ -268,7 +276,8 @@ end
 function HIDPassthrough:_checkKeyboard(path)
     if not FBInkInput then return nil end
     local ok, result = pcall(function()
-        local dev = FBInkInput.fbink_input_check(path, C.INPUT_KEYBOARD, 0, 0)
+        local dev = FBInkInput.fbink_input_check(path, C.INPUT_KEYBOARD, 0,
+            INPUT_SCAN_FLAGS)
         if dev == nil then return nil end
         local r
         if dev.matched then


### PR DESCRIPTION
## Problem

When the HID daemon is running, `HIDPassthrough:_reconcileKeyboards()` polls every `WATCHER_INTERVAL` (3s) and calls `_checkKeyboard()` for every `/dev/input/event*`. Each `fbink_input_check(...)` was passed `0` as the `settings` arg, so FBInk logs a per-device capabilities recap at `ELOG` level (ungated by verbosity):

```c
if (!(settings & NO_RECAP)) {
    ELOG("%s: `%s`%s", dev->path, dev->name, recap);
}
```

The result is the full input-device enumeration block re-logged every 3s, burying the actual HID log lines.

## Fix

Resolve FBInk's `NO_RECAP` flag once (defensively — it's absent on older koreader-base builds, in which case we fall back to `0` / prior behavior) and pass it as the scan `settings` argument to `fbink_input_check`. The plugin already logs its own `attached keyboard` / `detached keyboard` lines, so the FBInk recap was redundant noise.

## Test — Kindle Basic 4 (`KindleBasic4`), KOReader `v2026.03`

- **Before:** watcher logged a recap block per device every 3s, forever (thousands of lines accumulated across sessions).
- **After:** watcher ran ~50s (many 3s passes checking event0/event1/event3) and logged **0** recap lines. The only recap lines in the session are two one-time `event0–event3` scans from KOReader core's own input init at startup — unrelated to the polling loop.

`C.NO_RECAP` resolved fine on this build, so the fallback path wasn't exercised on-device but is there for older cores.

Closes #74