### PR TITLE
fix(uhid): self-heal uhid.ko on reconnect + surface HID-not-ready state

### DIFF
--- a/illusion/BTManager/index.html
+++ b/illusion/BTManager/index.html
@@ -29,6 +29,9 @@
         <div id="connectedSection" style="display:none;">
             <div class="section-label">Connected</div>
             <div id="connectedList" class="device-list"></div>
+            <div id="hidWarning" class="hid-warning" style="display:none;">
+                No input device. Page turns won't work. Try restarting the daemon.
+            </div>
         </div>
 
         <!-- Paired devices section -->
@@ -84,6 +87,9 @@
             </div>
             <div id="detailHid" style="display:none;">
                 <div class="section-label">HID</div>
+                <div id="detailHidWarning" class="hid-warning" style="display:none;">
+                    No input device created. Page turns won't work.
+                </div>
                 <div class="detail-row">
                     <span class="detail-label">UHID Device</span>
                     <span id="detailUhid" class="detail-value"></span>

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -180,6 +180,9 @@ var BTManager = (function() {
 
             renderDeviceLists(data.devices, data.connected_device || null);
 
+            getEl("hidWarning").style.display =
+                (data.connected_device && data.hid_ready === false) ? "block" : "none";
+
             if (data.version) {
                 getEl("footerVersion").innerHTML = "v" + escapeHtml(data.version);
             }
@@ -265,12 +268,19 @@ var BTManager = (function() {
 
         // HID info
         var hidSection = getEl("detailHid");
+        var hidWarn = getEl("detailHidWarning");
         hidSection.style.display = "none";
+        hidWarn.style.display = "none";
 
         if (isConnected && lastStatus) {
             var uhid = lastStatus.uhid_name;
             var inputs = lastStatus.input_paths;
-            if (uhid || inputs) {
+            if (lastStatus.hid_ready === false) {
+                hidWarn.style.display = "block";
+                getEl("detailUhid").innerHTML = "--";
+                getEl("detailInputPaths").innerHTML = "--";
+                hidSection.style.display = "block";
+            } else if (uhid || inputs) {
                 getEl("detailUhid").innerHTML = escapeHtml(uhid || "--");
                 getEl("detailInputPaths").innerHTML = inputs && inputs.length ? escapeHtml(inputs.join(", ")) : "--";
                 hidSection.style.display = "block";

--- a/illusion/BTManager/style.css
+++ b/illusion/BTManager/style.css
@@ -421,6 +421,17 @@ html {
     border-top-style: dashed;
 }
 
+.hid-warning {
+    margin: 8px 0 4px;
+    padding: 12px 16px;
+    border: 3px dashed #000;
+    background: #fff;
+    color: #000;
+    font-size: 30px;
+    font-weight: bold;
+    text-align: center;
+}
+
 /* ---- Confirm dialog overlay ---- */
 
 .overlay {
@@ -628,6 +639,7 @@ html {
     .footer { font-size: 15px; padding: 7px 12px 5px 12px; }
     .device-empty { font-size: 20px; }
     .message-bar { font-size: 20px; padding: 9px 12px; }
+    .hid-warning { font-size: 18px; padding: 8px 10px; }
     .dialog { padding: 18px; }
     .dialog p { font-size: 22px; }
     .dialog .dialog-addr, .pair-dialog .pair-addr { font-size: 20px; }

--- a/kindle_hid_passthrough/bt_setup.py
+++ b/kindle_hid_passthrough/bt_setup.py
@@ -79,7 +79,7 @@ def _log_missing_kmod(codename, expected=None):
     log.error("  ^ open an issue with these lines so we can compile the module")
 
 
-def _ensure_uhid():
+def ensure_uhid():
     """Load bundled uhid.ko on Kindles whose stock kernel lacks CONFIG_UHID."""
     if os.path.exists('/dev/uhid'):
         return True
@@ -105,6 +105,6 @@ def _ensure_uhid():
 
 def prepare_bt():
     """Load uhid if needed, then prepare the chip. True if BT is ready."""
-    _ensure_uhid()
+    ensure_uhid()
     log.info("Preparing Bluetooth hardware...")
     return chip().prepare()

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -64,6 +64,7 @@ class DaemonController:
             status["connected_device"] = conn.get("address")
             status["connected_protocol"] = conn.get("protocol")
             status["connected_name"] = conn.get("name")
+            status["hid_ready"] = conn.get("hid_ready", False)
             if conn.get("uhid_name"):
                 status["uhid_name"] = conn["uhid_name"]
             if conn.get("input_paths"):

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -9,6 +9,7 @@ from bumble.core import InvalidStateError
 from bumble.hci import HCI_LE_SET_PRIVACY_MODE_COMMAND, HCI_LE_Set_Privacy_Mode_Command, HCI_Write_Class_Of_Device_Command, HCI_Write_Local_Name_Command
 
 from ble import BLEMixin
+from bt_setup import ensure_uhid
 from classic import ClassicMixin
 from config import Protocol, config, get_version, normalize_addr
 from device_cache import DeviceCache
@@ -86,6 +87,7 @@ class HIDHost(ClassicMixin, BLEMixin):
             "address": normalize_addr(self.current_device_address) if self.current_device_address else None,
             "protocol": self.connected_protocol.value if self.connected_protocol else None,
             "name": self.device_name,
+            "hid_ready": self.uhid_device is not None,
         }
         if self.uhid_device:
             state["uhid_name"] = self.uhid_device.name
@@ -358,6 +360,10 @@ class HIDHost(ClassicMixin, BLEMixin):
         """Create UHID virtual device."""
         if not self.report_map:
             log.warning("No report descriptor for UHID")
+            return
+
+        if not ensure_uhid():
+            log.error("uhid unavailable; connected device will have no input path")
             return
 
         try:

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -30,6 +30,7 @@ state = {
     "connected_device": None,
     "connected_protocol": None,
     "connected_name": None,
+    "hid_ready": True,
     "version": "3.0.0",
     "scan_results": [
         {"address": "AA:BB:CC:DD:EE:01", "name": "BT Keyboard", "protocol": "classic", "rssi": -45},
@@ -66,6 +67,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                 resp["connected_device"] = state["connected_device"]
                 resp["connected_protocol"] = state["connected_protocol"]
                 resp["connected_name"] = state["connected_name"]
+                resp["hid_ready"] = state["hid_ready"]
             self._json(resp)
 
         elif self.path == "/scan":


### PR DESCRIPTION
Follow-up to the testing feedback on #33 from @rubyxs (PW4/rex, Oasis3/zelda). Addresses the top reported failure: **a device connects over Bluetooth but no input node is created, so page turns silently stop working while `/status` still reports it as connected.**

## Changes

### 1. Self-heal the uhid.ko load on reconnect
`ensure_uhid()` (renamed from `_ensure_uhid`) previously ran only once, at daemon startup, and its result was discarded. If the bundled `uhid.ko` failed to load at boot (lost across a reboot, or a racy boot-time `insmod`), `/dev/uhid` stayed missing and every reconnect kept building nothing.

`_create_uhid_device()` now calls `ensure_uhid()` before creating the device. It short-circuits when `/dev/uhid` already exists (free on the happy path) and retries the `insmod` otherwise, so a reconnect recovers on its own instead of leaving a wedged connection.

### 2. Make "connected but HID wedged" a distinct, visible state
- `connection_state` / API `/status` now include `hid_ready` (`self.uhid_device is not None`).
- BTManager WAF app shows a warning under the **Connected** list and in the **device detail** overlay when connected but `hid_ready` is false.
- Mock API server returns `hid_ready` so the UI path is testable locally.

## Not included
- Report 2 (API alive but daemon `_op_lock` wedged / `/start` no-op) and Report 3 (Oasis3 scan failures / BT stack reset at startup) need device logs to fix responsibly; better tracked as their own issues.

## Verify on device
`just deploy`, reboot, then hit `/status`: expect `hid_ready: true` on a good boot. On a boot that previously lost the module, watch `just logs` for `loading uhid-...ko` on reconnect and confirm page turns recover. Force the bad state (rename/remove the bundled `.ko`) to see the WAF warning render.

Diff: 7 files, +40/-3.