### PR TITLE
fix: strip digitizer collections nested inside combo HID collections

### DIFF
--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -11,17 +11,24 @@ __all__ = ['UHIDDevice', 'UHIDError', 'Bus', 'strip_digitizer_collections']
 logger = logging.getLogger(__name__)
 
 def strip_digitizer_collections(descriptor: bytes) -> bytes:
-    """Strip Digitizer (0x0D) top-level collections from a HID descriptor.
+    """Drop any top-level collection that contains a Digitizer (0x0D) usage.
 
-    The Kindle kernel lacks CONFIG_HID_MULTITOUCH, so hid-core silently
-    drops the entire UHID device when the descriptor contains Digitizer
-    collections. Removing them lets hid-generic claim the rest.
+    Two reasons a Digitizer must never reach the Kindle:
+      * The kernel lacks CONFIG_HID_MULTITOUCH, so hid-core silently drops the
+        whole UHID device when a Digitizer collection is present.
+      * Digitizer Tip Pressure surfaces as EV_ABS:ABS_PRESSURE, which KOReader's
+        Kindle gyro decoders read as a screen-rotation event and use to flip the
+        reader into the opposite landscape (issue #83).
+
+    A Digitizer usage page anywhere inside a top-level collection taints the
+    whole collection, so a digitizer nested in a keyboard/pointer combo is
+    caught too, not only a digitizer declared at the collection's top.
     """
     kept = []
     i = 0
-    usage_page = 0
     seg_start = 0
     depth = 0
+    seg_has_digitizer = False
 
     while i < len(descriptor):
         b = descriptor[i]
@@ -43,21 +50,23 @@ def strip_digitizer_collections(descriptor: bytes) -> bytes:
         else:
             val = 0
 
-        if item_type == 1 and tag == 0 and depth == 0:
-            usage_page = val
+        # Global Usage Page item, at any depth: 0x0D taints the segment.
+        if item_type == 1 and tag == 0 and val == 0x0D:
+            seg_has_digitizer = True
         if item_type == 0 and tag == 10:
             depth += 1
         if item_type == 0 and tag == 12:
             depth -= 1
             if depth == 0:
                 end = i + 1 + size
-                if usage_page != 0x0D:
+                if not seg_has_digitizer:
                     kept.append(descriptor[seg_start:end])
                 seg_start = end
+                seg_has_digitizer = False
 
         i += 1 + size
 
-    if not kept or len(kept) == len(descriptor):
+    if not kept:
         return descriptor
 
     result = b''.join(kept)


### PR DESCRIPTION
Tracked down #83, and it's a fun one. The plugin never touches rotation, the problem is a collision between our HID descriptors and how KOReader decodes the gyro on Kindle.

KOReader runs its gyro translation hook on events from every open input fd, not just the accelerometer node. On the gyro Kindles (Oasis 1/2/3, Scribe 1/2/ColorSoft) that hook converts any `EV_ABS:ABS_PRESSURE` event with value 15..22 into a screen rotation. And the gsensor lock only checks portrait vs landscape, both landscape modes pass it, so even with rotation locked the two landscapes can swap. That matches the report exactly: reader opens in the opposite landscape from the file manager, lock_rotation doesn't help, gyro devices only.

`ABS_PRESSURE` comes from a HID Digitizer collection. We already strip those since #45 (the Kindle kernel drops the whole uhid device otherwise), but the strip only looked at the usage page in effect when a top-level collection opened. A digitizer nested inside a keyboard/pointer combo collection survived the strip, exposed `ABS_PRESSURE` on the uhid input node, and KOReader read stray pressure values as "device rotated to the other landscape".

This makes the strip taint a top-level collection when a digitizer usage page shows up at any depth, and drop the whole collection.

@rubyxs could you grab the build from this PR's CI and give it a go? Fair warning, if your keyboard's descriptor has no digitizer in it this won't be the fix for your unit and we'll keep digging, but the mechanism lines up with everything you described.

Fixes #83
