### PR TITLE
fix(bt): clean stock BT handoff on MTK takeover to stop Scribe boot loop (#87)

### DIFF
--- a/assets/hid-passthrough.upstart
+++ b/assets/hid-passthrough.upstart
@@ -11,5 +11,5 @@ env KINDLE_HID_BASE=/mnt/us/kindle_hid_passthrough
 console none
 
 script
-    exec /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon >/dev/null 2>&1
+    exec /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon >>/var/log/hid_passthrough.log 2>&1
 end script

--- a/assets/hid-passthrough.upstart
+++ b/assets/hid-passthrough.upstart
@@ -1,6 +1,6 @@
 # HID Passthrough - Bluetooth HID host with UHID passthrough
 # For use with pre-built binary from releases
-start on started wmt
+start on framework_ready
 stop on stopping filesystems
 
 respawn
@@ -9,6 +9,20 @@ respawn limit 5 60
 env KINDLE_HID_BASE=/mnt/us/kindle_hid_passthrough
 
 console none
+
+pre-start script
+    base=/mnt/us/kindle_hid_passthrough
+    cp /proc/last_kmsg "$base/last_kmsg.txt" 2>/dev/null || true
+    n=$(cat "$base/boot_attempts" 2>/dev/null || echo 0)
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    if [ "$n" -ge 3 ]; then
+        echo "$(date) autostart disabled after $n starts without a stable run" >> "$base/boot.log"
+        stop
+        exit 0
+    fi
+    echo $((n + 1)) > "$base/boot_attempts"
+    echo "$(date) start attempt $((n + 1))" >> "$base/boot.log"
+end script
 
 script
     exec /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon >>/var/log/hid_passthrough.log 2>&1

--- a/kindle_hid_passthrough/bt_mtk.py
+++ b/kindle_hid_passthrough/bt_mtk.py
@@ -4,6 +4,7 @@
 import glob
 import os
 import signal
+import subprocess
 import time
 
 from bt_chip import BtChip, run
@@ -21,6 +22,10 @@ _STOCK_BT_JOBS = ('acsbtfd', 'btmanagerd')
 # Shared Wi-Fi/CONSYS combo processes — killing one can drop Wi-Fi. Never touch.
 _CRITICAL_COMMS = ('wmt_service', 'mtk_wmtd', 'wifid', 'wifim',
                    'stp_main', 'mtk_stp_psm', 'connfem')
+
+# Upstart rests in these; everything else (pre-start, spawned, stopping, ...) is
+# a transition, and evicting a job mid-transition leaves CONSYS half-configured.
+_SETTLED_STATES = ('running', 'waiting')
 
 
 def _find_bt_module(patterns=None):
@@ -110,6 +115,66 @@ def _find_holders(device_path):
     return holders
 
 
+def _job_state(job):
+    """(goal, state) of an upstart job, or (None, None) if it isn't known here."""
+    try:
+        r = subprocess.run(['/sbin/initctl', 'status', job],
+                           capture_output=True, timeout=5)
+    except Exception:
+        return (None, None)
+    if r.returncode != 0:
+        return (None, None)
+    head = r.stdout.decode(errors='replace').split('\n')[0].split(',')[0]
+    fields = head.split()
+    if not fields or '/' not in fields[-1]:
+        return (None, None)
+    goal, _, state = fields[-1].partition('/')
+    return (goal, state)
+
+
+def _wait_for_settle(jobs, timeout, poll=0.5):
+    """Block until every job leaves its transitional state, or timeout expires.
+
+    Starting on a boot event only says the CONSYS chip powered up, not that the
+    stock BT stack finished claiming it. Evicting acsbtfd mid-init flaps the
+    radio Wi-Fi shares, which is what boot-loops a Scribe (#87).
+    """
+    deadline = time.monotonic() + timeout
+    announced = False
+    while True:
+        unsettled = []
+        for job in jobs:
+            goal, state = _job_state(job)
+            if state is not None and state not in _SETTLED_STATES:
+                unsettled.append(f'{job} {goal}/{state}')
+        if not unsettled:
+            if announced:
+                log.info("Stock BT stack settled")
+            return True
+        if time.monotonic() >= deadline:
+            log.warning(f"Stock BT stack still unsettled after {timeout:.0f}s: "
+                        f"{', '.join(unsettled)}")
+            return False
+        if not announced:
+            log.info(f"Waiting for stock BT stack to settle: {', '.join(unsettled)}")
+            announced = True
+        time.sleep(poll)
+
+
+def _wait_for_stopped(job, timeout, poll=0.5):
+    """Block until an upstart job reaches stop/waiting, or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while True:
+        goal, state = _job_state(job)
+        if state is None or (goal, state) == ('stop', 'waiting'):
+            return True
+        if time.monotonic() >= deadline:
+            log.warning(f"'{job}' did not reach stop/waiting in {timeout:.0f}s "
+                        f"(now {goal}/{state})")
+            return False
+        time.sleep(poll)
+
+
 def _graceful_kill(h, settle, device_path):
     """SIGTERM an unknown holder, then SIGKILL only if it clings to the node."""
     for sig in (signal.SIGTERM, signal.SIGKILL):
@@ -124,7 +189,7 @@ def _graceful_kill(h, settle, device_path):
         time.sleep(settle)
 
 
-def _evict_holders(device_path, settle):
+def _evict_holders(device_path, settle, stop_timeout=10.0):
     """Free device_path: stop stock BT via upstart, spare Wi-Fi, SIGTERM the rest."""
     holders = _find_holders(device_path)
     if not holders:
@@ -145,6 +210,8 @@ def _evict_holders(device_path, settle):
         log.info(f"Stopping stock BT service '{job}' via upstart")
         if not run(['/sbin/initctl', 'stop', job]):
             log.warning(f"'initctl stop {job}' failed")
+    for job in stock_jobs:
+        _wait_for_stopped(job, stop_timeout)
     if stock_jobs:
         time.sleep(settle)
 
@@ -192,8 +259,14 @@ class MtkChip(BtChip):
             log.info(f"{device_path} is available")
             return True
 
+        log.info(f"{device_path} is busy, waiting for the stock BT stack to settle...")
+        _wait_for_settle(_STOCK_BT_JOBS, config.bt_stock_settle_timeout)
+        if _is_device_free(device_path):
+            log.info(f"{device_path} is available")
+            return True
+
         log.info(f"{device_path} is busy, identifying and evicting holders...")
-        _evict_holders(device_path, settle)
+        _evict_holders(device_path, settle, config.bt_stop_timeout)
         if _is_device_free(device_path):
             log.info(f"{device_path} is now available")
             return True

--- a/kindle_hid_passthrough/bt_mtk.py
+++ b/kindle_hid_passthrough/bt_mtk.py
@@ -4,7 +4,6 @@
 import glob
 import os
 import signal
-import subprocess
 import time
 
 from bt_chip import BtChip, run
@@ -22,10 +21,6 @@ _STOCK_BT_JOBS = ('acsbtfd', 'btmanagerd')
 # Shared Wi-Fi/CONSYS combo processes — killing one can drop Wi-Fi. Never touch.
 _CRITICAL_COMMS = ('wmt_service', 'mtk_wmtd', 'wifid', 'wifim',
                    'stp_main', 'mtk_stp_psm', 'connfem')
-
-# Upstart rests in these; everything else (pre-start, spawned, stopping, ...) is
-# a transition, and evicting a job mid-transition leaves CONSYS half-configured.
-_SETTLED_STATES = ('running', 'waiting')
 
 
 def _find_bt_module(patterns=None):
@@ -115,66 +110,6 @@ def _find_holders(device_path):
     return holders
 
 
-def _job_state(job):
-    """(goal, state) of an upstart job, or (None, None) if it isn't known here."""
-    try:
-        r = subprocess.run(['/sbin/initctl', 'status', job],
-                           capture_output=True, timeout=5)
-    except Exception:
-        return (None, None)
-    if r.returncode != 0:
-        return (None, None)
-    head = r.stdout.decode(errors='replace').split('\n')[0].split(',')[0]
-    fields = head.split()
-    if not fields or '/' not in fields[-1]:
-        return (None, None)
-    goal, _, state = fields[-1].partition('/')
-    return (goal, state)
-
-
-def _wait_for_settle(jobs, timeout, poll=0.5):
-    """Block until every job leaves its transitional state, or timeout expires.
-
-    Starting on a boot event only says the CONSYS chip powered up, not that the
-    stock BT stack finished claiming it. Evicting acsbtfd mid-init flaps the
-    radio Wi-Fi shares, which is what boot-loops a Scribe (#87).
-    """
-    deadline = time.monotonic() + timeout
-    announced = False
-    while True:
-        unsettled = []
-        for job in jobs:
-            goal, state = _job_state(job)
-            if state is not None and state not in _SETTLED_STATES:
-                unsettled.append(f'{job} {goal}/{state}')
-        if not unsettled:
-            if announced:
-                log.info("Stock BT stack settled")
-            return True
-        if time.monotonic() >= deadline:
-            log.warning(f"Stock BT stack still unsettled after {timeout:.0f}s: "
-                        f"{', '.join(unsettled)}")
-            return False
-        if not announced:
-            log.info(f"Waiting for stock BT stack to settle: {', '.join(unsettled)}")
-            announced = True
-        time.sleep(poll)
-
-
-def _wait_for_stopped(job, timeout, poll=0.5):
-    """Block until an upstart job reaches stop/waiting, or timeout expires."""
-    deadline = time.monotonic() + timeout
-    while True:
-        goal, state = _job_state(job)
-        if state is None or (goal, state) == ('stop', 'waiting'):
-            return True
-        if time.monotonic() >= deadline:
-            log.warning(f"'{job}' did not reach stop/waiting in {timeout:.0f}s "
-                        f"(now {goal}/{state})")
-            return False
-        time.sleep(poll)
-
-
 def _graceful_kill(h, settle, device_path):
     """SIGTERM an unknown holder, then SIGKILL only if it clings to the node."""
     for sig in (signal.SIGTERM, signal.SIGKILL):
@@ -189,7 +124,7 @@ def _graceful_kill(h, settle, device_path):
         time.sleep(settle)
 
 
-def _evict_holders(device_path, settle, stop_timeout=10.0):
+def _evict_holders(device_path, settle):
     """Free device_path: stop stock BT via upstart, spare Wi-Fi, SIGTERM the rest."""
     holders = _find_holders(device_path)
     if not holders:
@@ -210,8 +145,6 @@ def _evict_holders(device_path, settle, stop_timeout=10.0):
         log.info(f"Stopping stock BT service '{job}' via upstart")
         if not run(['/sbin/initctl', 'stop', job]):
             log.warning(f"'initctl stop {job}' failed")
-    for job in stock_jobs:
-        _wait_for_stopped(job, stop_timeout)
     if stock_jobs:
         time.sleep(settle)
 
@@ -259,14 +192,8 @@ class MtkChip(BtChip):
             log.info(f"{device_path} is available")
             return True
 
-        log.info(f"{device_path} is busy, waiting for the stock BT stack to settle...")
-        _wait_for_settle(_STOCK_BT_JOBS, config.bt_stock_settle_timeout)
-        if _is_device_free(device_path):
-            log.info(f"{device_path} is available")
-            return True
-
         log.info(f"{device_path} is busy, identifying and evicting holders...")
-        _evict_holders(device_path, settle, config.bt_stop_timeout)
+        _evict_holders(device_path, settle)
         if _is_device_free(device_path):
             log.info(f"{device_path} is now available")
             return True

--- a/kindle_hid_passthrough/bt_mtk.py
+++ b/kindle_hid_passthrough/bt_mtk.py
@@ -6,7 +6,7 @@ import os
 import signal
 import time
 
-from bt_chip import BtChip, free_device, run
+from bt_chip import BtChip, run
 from config import config
 from logging_utils import log
 
@@ -14,6 +14,13 @@ DEFAULT_MODULE_PATTERNS = [
     'wmt_cdev_bt.ko',   # MediaTek (PW4/5, Kindle 10/11, Scribe)
     'bt_drv.ko',         # Older Freescale/NXP Kindles
 ]
+
+# Stock BT stack: respawn'd upstart jobs, so stop via upstart, never SIGKILL.
+_STOCK_BT_JOBS = ('acsbtfd', 'btmanagerd')
+
+# Shared Wi-Fi/CONSYS combo processes — killing one can drop Wi-Fi. Never touch.
+_CRITICAL_COMMS = ('wmt_service', 'mtk_wmtd', 'wifid', 'wifim',
+                   'stp_main', 'mtk_stp_psm', 'connfem')
 
 
 def _find_bt_module(patterns=None):
@@ -47,14 +54,44 @@ def _is_module_loaded(module_path):
     return False
 
 
-def _kill_holders_via_proc(device_path):
-    """SIGKILL processes holding device_path by scanning /proc (fuser fallback)."""
+def _proc_field(pid, name):
+    """Read /proc/<pid>/<name>, or b'' if unavailable."""
+    try:
+        with open(f'/proc/{pid}/{name}', 'rb') as f:
+            return f.read()
+    except OSError:
+        return b''
+
+
+def _holder_info(pid):
+    """Identity of a process holding a device: comm, cmdline, exe, uid."""
+    comm = _proc_field(pid, 'comm').decode(errors='replace').strip()
+    cmdline = (_proc_field(pid, 'cmdline')
+               .replace(b'\0', b' ').decode(errors='replace').strip())
+    try:
+        exe = os.readlink(f'/proc/{pid}/exe')
+    except OSError:
+        exe = ''
+    try:
+        uid = os.stat(f'/proc/{pid}').st_uid
+    except OSError:
+        uid = None
+    return {'pid': pid, 'comm': comm, 'cmdline': cmdline, 'exe': exe, 'uid': uid}
+
+
+def _describe(h):
+    return (f"pid={h['pid']} comm={h['comm'] or '?'} uid={h['uid']} "
+            f"exe={h['exe'] or '?'} cmd='{h['cmdline']}'")
+
+
+def _find_holders(device_path):
+    """Scan /proc for processes holding device_path (excluding self)."""
     my_pid = os.getpid()
-    killed = 0
+    holders = []
     try:
         pids = [e for e in os.listdir('/proc') if e.isdigit()]
     except OSError:
-        return 0
+        return holders
     for pid in pids:
         if int(pid) == my_pid:
             continue
@@ -65,18 +102,55 @@ def _kill_holders_via_proc(device_path):
             continue
         for fd in fds:
             try:
-                target = os.readlink(f'{fd_dir}/{fd}')
+                if os.readlink(f'{fd_dir}/{fd}') == device_path:
+                    holders.append(_holder_info(pid))
+                    break
             except OSError:
                 continue
-            if target == device_path:
-                try:
-                    os.kill(int(pid), signal.SIGKILL)
-                    killed += 1
-                    log.info(f"Killed PID {pid} holding {device_path}")
-                except OSError as e:
-                    log.warning(f"Could not kill PID {pid}: {e}")
-                break
-    return killed
+    return holders
+
+
+def _graceful_kill(h, settle, device_path):
+    """SIGTERM an unknown holder, then SIGKILL only if it clings to the node."""
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        if _is_device_free(device_path):
+            return
+        try:
+            os.kill(int(h['pid']), sig)
+            log.info(f"Sent {sig.name} to unknown holder {_describe(h)}")
+        except OSError as e:
+            log.warning(f"Could not signal pid={h['pid']}: {e}")
+            return
+        time.sleep(settle)
+
+
+def _evict_holders(device_path, settle):
+    """Free device_path: stop stock BT via upstart, spare Wi-Fi, SIGTERM the rest."""
+    holders = _find_holders(device_path)
+    if not holders:
+        return
+    for h in holders:
+        log.info(f"{device_path} held by {_describe(h)}")
+
+    critical = [h for h in holders if h['comm'] in _CRITICAL_COMMS]
+    if critical:
+        for h in critical:
+            log.error(f"Refusing to evict critical connectivity process {_describe(h)}")
+        return
+
+    stock_jobs = {h['comm'] for h in holders if h['comm'] in _STOCK_BT_JOBS}
+    if 'acsbtfd' in stock_jobs:
+        stock_jobs.add('btmanagerd')
+    for job in stock_jobs:
+        log.info(f"Stopping stock BT service '{job}' via upstart")
+        if not run(['/sbin/initctl', 'stop', job]):
+            log.warning(f"'initctl stop {job}' failed")
+    if stock_jobs:
+        time.sleep(settle)
+
+    for h in holders:
+        if h['comm'] not in _STOCK_BT_JOBS and not _is_device_free(device_path):
+            _graceful_kill(h, settle, device_path)
 
 
 def _is_device_free(device_path):
@@ -118,16 +192,8 @@ class MtkChip(BtChip):
             log.info(f"{device_path} is available")
             return True
 
-        log.info(f"{device_path} is busy, evicting holder...")
-        if free_device(device_path):
-            time.sleep(settle)
-        if _is_device_free(device_path):
-            log.info(f"{device_path} is now available")
-            return True
-
-        log.warning(f"{device_path} still busy, scanning /proc for holders...")
-        if _kill_holders_via_proc(device_path):
-            time.sleep(settle)
+        log.info(f"{device_path} is busy, identifying and evicting holders...")
+        _evict_holders(device_path, settle)
         if _is_device_free(device_path):
             log.info(f"{device_path} is now available")
             return True

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -140,6 +140,9 @@ class Config:
         # Bluetooth hardware setup
         self.bt_module_patterns = self._get_list('bluetooth', 'module_patterns', None)
         self.bt_settle_time = float(self._get('bluetooth', 'settle_time', '0.5'))
+        self.bt_stock_settle_timeout = float(
+            self._get('bluetooth', 'stock_settle_timeout', '45'))
+        self.bt_stop_timeout = float(self._get('bluetooth', 'stop_timeout', '10'))
 
         # Device identity
         self.device_name = self._get('device', 'name', 'Kindle-HID')

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -140,9 +140,6 @@ class Config:
         # Bluetooth hardware setup
         self.bt_module_patterns = self._get_list('bluetooth', 'module_patterns', None)
         self.bt_settle_time = float(self._get('bluetooth', 'settle_time', '0.5'))
-        self.bt_stock_settle_timeout = float(
-            self._get('bluetooth', 'stock_settle_timeout', '45'))
-        self.bt_stop_timeout = float(self._get('bluetooth', 'stop_timeout', '10'))
 
         # Device identity
         self.device_name = self._get('device', 'name', 'Kindle-HID')

--- a/kindle_hid_passthrough/hid-passthrough-dev.upstart
+++ b/kindle_hid_passthrough/hid-passthrough-dev.upstart
@@ -1,6 +1,6 @@
 # HID Passthrough - Bluetooth HID host with UHID passthrough
 # For development with Python environment
-start on started wmt
+start on framework_ready
 stop on stopping filesystems
 
 respawn
@@ -9,6 +9,20 @@ respawn limit 5 60
 env KINDLE_HID_BASE=/mnt/us/kindle_hid_passthrough
 
 console none
+
+pre-start script
+    base=/mnt/us/kindle_hid_passthrough
+    cp /proc/last_kmsg "$base/last_kmsg.txt" 2>/dev/null || true
+    n=$(cat "$base/boot_attempts" 2>/dev/null || echo 0)
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    if [ "$n" -ge 3 ]; then
+        echo "$(date) autostart disabled after $n starts without a stable run" >> "$base/boot.log"
+        stop
+        exit 0
+    fi
+    echo $((n + 1)) > "$base/boot_attempts"
+    echo "$(date) start attempt $((n + 1))" >> "$base/boot.log"
+end script
 
 script
     exec /mnt/us/python3.10-kindle/python3-wrapper.sh /mnt/us/kindle_hid_passthrough/main.py --daemon >>/var/log/hid_passthrough.log 2>&1

--- a/kindle_hid_passthrough/main.py
+++ b/kindle_hid_passthrough/main.py
@@ -17,6 +17,7 @@ import argparse
 import asyncio
 import os
 import sys
+import threading
 
 # Add current directory to path for imports
 sys.path.insert(0, '/mnt/us/kindle_hid_passthrough')
@@ -158,6 +159,13 @@ def _close_inherited_sockets():
             pass
 
 
+def _clear_boot_attempts():
+    try:
+        os.unlink(os.path.join(config.base_path, 'boot_attempts'))
+    except OSError:
+        pass
+
+
 def main():
     _close_inherited_sockets()
 
@@ -178,6 +186,11 @@ def main():
                         help='Print a read-only diagnostics dump for bug reports')
 
     args = parser.parse_args()
+
+    if args.daemon:
+        timer = threading.Timer(120, _clear_boot_attempts)
+        timer.daemon = True
+        timer.start()
 
     if args.diagnostics:
         from diagnostics import run_diagnostics

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -179,6 +179,7 @@ installUdevRules()
 installUpstart()
 {
   echo " -> Installing upstart service"
+  rm -f "$INSTALL_DIR/boot_attempts"
   /usr/sbin/mntroot rw
   cp "$SRC_DIR/assets/hid-passthrough.upstart" /etc/upstart/hid-passthrough.conf
   /usr/sbin/mntroot ro


### PR DESCRIPTION
@cosbot1 reported a boot loop on a Scribe (5.17.3) in #87, enabling hid-passthrough autostart makes the kindle boot loop and lose wifi/ssh, and disabling the upstart job brings it back. @mergen3107 reproduced it on a KS1 and ground through every iteration of this, huge thanks.

The root cause turned out to be the start trigger, not the eviction. `start on started wmt` fires the instant wifi begins bring-up (wmt itself starts on `starting wifim`), so we were loading the BT module and opening /dev/stpbt while the CONSYS combo chip was still initializing. mergen's last_kmsg shows mtk_wmtd still running SoC calibration 30s into boot, which is why his `sleep 30` was the only thing that ever worked and a 10-12s trigger (lab126_gui) still looped.

What's in here:

1. the job now starts on `framework_ready`, the event the framework emits right after tearing down the boot splash. it's the same gate amazon uses for its own deferrable services, so no magic number and no collision window. the keyboard comes up with the home screen.
2. a boot-loop breaker in pre-start. starts are counted in `boot_attempts` on /mnt/us (which survives reboots, unlike /var), after 3 starts without a stable run the job disables itself, and every start snapshots /proc/last_kmsg plus a line in `boot.log`. worst case a bad build loops 3 times, recovers on its own, and leaves a postmortem. the daemon clears the counter after 2 minutes alive, enabling autostart resets it.
3. when /dev/stpbt is actually held, prepare() identifies each holder and stops the stock BT stack through upstart (`initctl stop`) instead of SIGKILL, so it doesn't respawn and fight us. shared wifi/CONSYS processes are never touched, we bail instead of risking wifi. anything else gets SIGTERM first.
4. the release upstart job logs to /var/log/hid_passthrough.log instead of /dev/null.

Tested by @mergen3107 on his KS1: clean boot on the first try, breaker and postmortem files all working. Fixes #87.