### PR TITLE
fix(uhid): fall back to other builds of the same kernel

### DIFF
--- a/kindle_hid_passthrough/bt_setup.py
+++ b/kindle_hid_passthrough/bt_setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Bluetooth hardware setup — select and drive the per-Kindle chip backend."""
 
+import glob
 import os
 import re
 import stat
@@ -26,12 +27,13 @@ def _module_search_dirs():
     return [d for d in dirs if not (d in seen or seen.add(d))]
 
 
-def _find_bundled_ko(name):
+def _find_bundled_kos(pattern, exact_first):
+    """Bundled modules matching a glob, deduped by basename, exact build first."""
+    found = {}
     for d in _module_search_dirs():
-        ko = os.path.join(d, name)
-        if os.path.exists(ko):
-            return ko
-    return None
+        for ko in glob.glob(os.path.join(d, pattern)):
+            found.setdefault(os.path.basename(ko), ko)
+    return sorted(found.values(), key=lambda p: os.path.basename(p) != exact_first)
 
 _chip = None
 
@@ -105,11 +107,11 @@ def _ensure_hid_core(kernel, build, codename):
     """
     if os.path.exists('/sys/bus/hid'):
         return
-    ko = _find_bundled_ko(f"hid-{kernel}-{build}-{codename}.ko")
-    if ko is None:
-        return
-    log.info(f"loading {os.path.basename(ko)} (HID core)")
-    run(['/sbin/insmod', ko])
+    exact = f"hid-{kernel}-{build}-{codename}.ko"
+    for ko in _find_bundled_kos(f"hid-{kernel}-*-{codename}.ko", exact_first=exact):
+        log.info(f"loading {os.path.basename(ko)} (HID core)")
+        if run(['/sbin/insmod', ko]) and os.path.exists('/sys/bus/hid'):
+            return
 
 
 def ensure_uhid():
@@ -125,20 +127,22 @@ def ensure_uhid():
         return False
     kernel = os.uname().release
     expected = f"uhid-{kernel}-{build}-{codename}.ko"
-    ko = _find_bundled_ko(expected)
-    if ko is None:
+    candidates = _find_bundled_kos(f"uhid-{kernel}-*-{codename}.ko", exact_first=expected)
+    if not candidates:
         _log_missing_kmod(codename, expected)
         return False
     _ensure_hid_core(kernel, build, codename)
-    log.info(f"loading {expected}")
-    if not run(['/sbin/insmod', ko]):
-        log.error("insmod failed")
-        return False
-    # devtmpfs kernels create /dev/uhid automatically; older ones (duet)
-    # need the node created by hand from the misc device's sysfs entry.
-    if not os.path.exists('/dev/uhid'):
-        _create_dev_node('/sys/class/misc/uhid/dev', '/dev/uhid')
-    return os.path.exists('/dev/uhid')
+    for ko in candidates:
+        log.info(f"loading {os.path.basename(ko)}")
+        if not run(['/sbin/insmod', ko]):
+            continue
+        # duet lacks devtmpfs, so misc_register doesn't create /dev/uhid
+        if not os.path.exists('/dev/uhid'):
+            _create_dev_node('/sys/class/misc/uhid/dev', '/dev/uhid')
+        if os.path.exists('/dev/uhid'):
+            return True
+    _log_missing_kmod(codename, expected)
+    return False
 
 
 def prepare_bt():

--- a/kindle_hid_passthrough/modules/README.md
+++ b/kindle_hid_passthrough/modules/README.md
@@ -36,3 +36,9 @@ across firmware updates, so a covered model may still hit an unbuilt build. When
 Kindle hits a missing module the daemon logs the exact `uhid-...ko` filename plus
 its model, codename, kernel, and `/etc/version.txt`, which is everything needed to
 build it.
+
+A module's ABI keys on `uname -r`, not the version.txt build in its filename, so
+when the exact build isn't bundled the daemon tries other builds of the same
+kernel and codename and lets `insmod`'s own version check decide. A firmware bump
+that keeps the kernel ABI loads on an existing module; only a real `module_layout`
+change forces a fresh build.


### PR DESCRIPTION
## Problem

Issue #102: PW4 (rex) on firmware build **476968** fails with `/dev/uhid not available` even though we ship a rex module for build **476967** (one digit off).

The daemon looks up the module by exact `uhid-{uname-r}-{build}-{codename}.ko`, where `build` is the trailing number from `/etc/version.txt`. But a module's ABI keys on `uname -r` (`4.1.15-lab126`), **not** the version.txt build number. Confirmed by dumping the shipped modules: `vermagic` is identical across builds; the build number only lives in our own filename. So a firmware bump that keeps the kernel ABI fails to load a module we already have.

## Fix

When the exact-build module isn't bundled, try other bundled builds of the same kernel + codename and let `insmod`'s own version check decide. `insmod` fails cleanly on a real `module_layout` mismatch, so a genuinely incompatible build is no worse than today, just with the exact-module log. Same fallback applied to the `hid.ko` core loader.

## Testing

- Verified the loader logic with a harness: device build 476968 with only 435186 + 476967 shipped loads 476967 and returns `True`; 435186's failed `insmod` is skipped.
- `py_compile` clean.

Needs on-device confirmation on PW4 build 476968 (reporter offered to test). If 476968's kernel ABI genuinely differs from 476967's, `insmod` will reject it and we fall back to compiling the exact module.

Closes #102