### PR TITLE
fix(classic): drop invalid bytes from SDP device name instead of replacing

### DIFF
--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -443,8 +443,11 @@ class ClassicMixin:
                             try:
                                 name = attr.value.value
                                 if isinstance(name, bytes):
-                                    name = name.decode('utf-8', errors='replace')
-                                self.device_name = str(name)
+                                    name = name.split(b'\x00')[0].decode(
+                                        'utf-8', errors='ignore')
+                                name = str(name).strip()
+                                if name:
+                                    self.device_name = name
                             except Exception:
                                 pass
 


### PR DESCRIPTION
Refs #85 (fixes the garbled name, the reconnect problem is separate and gets its own PR)

The 8BitDo Zero 2 pads its SDP service name attribute with junk bytes that aren't valid UTF-8. We were decoding with errors='replace', which faithfully turns every junk byte into U+FFFD, so the name showed up as "8BitDo Zero 2 gamepad??????????" in BT Manager, dmesg and the UHID device name.

Fix is two small changes in the decode:
1. truncate at the first NUL, since fixed length name buffers are usually NUL padded C strings
2. decode with errors='ignore' so any remaining invalid bytes get dropped instead of rendered as replacement chars

Valid names in any language pass through untouched, and if the result ends up empty we keep the previous fallback name.

Tested the decode against the reported name with trailing garbage bytes, NUL padding, and a non-ASCII name ("Clavier Français"), all come out clean.