### PR TITLE
Use native chrome so the BTManager status bar renders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ Userspace Bluetooth HID host for Kindle with UHID passthrough.
 
 The Kindle is accessed via SSH using the host alias `kindle`.
 
+## Keep Awake During Development
+
+Stop the Kindle from sleeping/screensaving while developing on it:
+
+```bash
+ssh kindle "lipc-set-prop -i com.lab126.powerd preventScreenSaver 1"   # keep awake
+ssh kindle "lipc-set-prop -i com.lab126.powerd preventScreenSaver 0"   # restore
+```
+
+Verify with `ssh kindle "lipc-get-prop com.lab126.powerd status"` (look for `prevent_screen_saver:1`).
+
 ## Deployment
 
 Use `just` commands for all deployment and management:

--- a/illusion/BTManager/config.xml
+++ b/illusion/BTManager/config.xml
@@ -3,14 +3,14 @@
         xmlns="http://www.w3.org/ns/widgets"
         xmlns:kindle="http://kindle.amazon.com/ns/widget-extensions">
 
-    <name xml:lang="en">HID Passthrough</name>
+    <name xml:lang="en">BT Manager</name>
     <author>Lucas Zampieri</author>
     <description xml:lang="en">Bluetooth HID Passthrough</description>
 
     <content src="index.html" />
 
     <kindle:chrome>
-        <kindle:asset key="configureSearchBar" value="none" />
+        <kindle:asset key="configureSearchBar" value="system" />
     </kindle:chrome>
 
     <kindle:gestures>

--- a/illusion/BTManager/index.html
+++ b/illusion/BTManager/index.html
@@ -8,11 +8,6 @@
 </head>
 <body>
 
-    <div class="header">
-        <h1>BT Manager</h1>
-        <button id="btnBack" class="btn-close">&times;</button>
-    </div>
-
     <div id="messageBar" class="message-bar"></div>
 
     <!-- Bluetooth toggle row -->

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -653,18 +653,6 @@ var BTManager = (function() {
         confirmAddr = null;
     }
 
-    // ---- Quit ----
-
-    function quit() {
-        pressBtn("btnBack");
-        if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.startApplication) {
-            kindle.appmgr.startApplication("com.lab126.booklet.home");
-        } else if (typeof kindle !== "undefined" && kindle.appmgr && kindle.appmgr.back) {
-            kindle.appmgr.back();
-        }
-        request("/quit-app", function() {});
-    }
-
     // ---- Event Binding ----
 
     function bindBtn(id, fn) {
@@ -673,7 +661,6 @@ var BTManager = (function() {
     }
 
     function bindEvents() {
-        bindBtn("btnBack", quit);
         bindBtn("btnToggle", toggleBluetooth);
         bindBtn("btnScan", toggleScan);
         bindBtn("footerDebug", showLogs);

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -11,8 +11,6 @@ Port 8321 on localhost.
 import json
 import os
 import socket
-import subprocess
-import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from urllib.parse import parse_qs, urlparse
@@ -94,8 +92,6 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_disconnect()
             case '/logs':
                 self._handle_logs(param('lines'))
-            case '/quit-app':
-                self._handle_quit_app()
             case _:
                 self._send_json({"ok": False, "error": "Not found"})
 
@@ -211,17 +207,6 @@ class RequestHandler(BaseHTTPRequestHandler):
         controller = self._controller
         controller.request_disconnect()
         self._send_json({"ok": True, "message": "Disconnecting"})
-
-    def _handle_quit_app(self):
-        self._send_json({"ok": True})
-        threading.Thread(
-            target=lambda: subprocess.run(
-                ["lipc-set-prop", "com.lab126.appmgrd", "stop",
-                 "app://com.lzampier.btmanager"],
-                timeout=5,
-            ),
-            daemon=True,
-        ).start()
 
     def _handle_logs(self, lines_str):
         log_file = config.log_file


### PR DESCRIPTION
Fixes the top bar nitpick from #107. Two symptoms, same root cause: while BTManager was open the status bar (clock, wifi, battery) only showed up when one of those values changed, and on exit the home top bar didn't redraw fully, the settings chevron was missing but still tappable.

The WAF had configureSearchBar=none, which lets the app window own the whole screen including the status bar strip. The app's opaque background sat on top of pillow's bar, so nothing showed until pillow repainted a widget on its own and punched through. Same story on exit with the custom quit path.

So I stopped fighting it and switched to configureSearchBar=system, like KindleForge does, and dropped BTManager's own header. Native chrome now owns the status bar, the title and the close button, and the app content starts below the reserved strip instead of covering it. I also ripped out the redraw workaround I'd tried (pillow poke + fbink flush) and the now dead quit endpoint, native close handles teardown and redraws home clean.

Tested on a Basic 4 (FW 5.16.2.1.1): full status bar during the app, single native close, home redraws on exit.

This only covers the second nitpick. The recency one (icons not jumping to recently accessed) is still open.

Refs #107