### PR TITLE
Reload BTManager chrome via graceful appmgrd stop so config changes take effect

### DIFF
--- a/illusion/BTManager.sh
+++ b/illusion/BTManager.sh
@@ -51,6 +51,28 @@ EOF
     fi
 }
 
+# ---- Purge stale WAF cache ----
+
+purge_waf_cache() {
+    # mesquite caches the parsed chrome config and rendered assets per-app under
+    # /var/local/mesquite. That cache survives reinstalls and in-place upgrades,
+    # so an old entry keeps the previous chrome (e.g. a hidden status bar) even
+    # after the app files change. The app persists no client state, so purge on
+    # every launch to guarantee config.xml changes take effect.
+    MESQUITE_DIR="/var/local/mesquite"
+    # Ask appmgrd to unload the app so the next launch spawns fresh and re-reads
+    # config.xml. Use the graceful stop, not pkill: killing mesquite out from
+    # under appmgrd makes it report a crash ("Application Error") to the user.
+    lipc-set-prop com.lab126.appmgrd stop "app://$APP_ID" 2>/dev/null
+    sleep 1
+    [ -d "$MESQUITE_DIR" ] || return
+    for d in "$MESQUITE_DIR"/*[Bb][Tt][Mm]anager* "$MESQUITE_DIR/$APP_NAME" "$MESQUITE_DIR/$APP_ID"; do
+        [ -e "$d" ] || continue
+        rm -rf "$d"
+        log_msg "Purged WAF cache: $d"
+    done
+}
+
 # ---- Start helper daemon ----
 
 start_helper() {
@@ -84,6 +106,9 @@ log_msg "BTManager scriptlet starting"
 
 # Install/update WAF files
 install_waf
+
+# Drop stale WAF cache so config.xml chrome changes render
+purge_waf_cache
 
 # Start the HTTP helper
 start_helper

--- a/illusion/install-waf-app.sh
+++ b/illusion/install-waf-app.sh
@@ -46,9 +46,30 @@ echo "2. Setting permissions..."
 chmod +x "$SCRIPTLET"
 echo "   Done"
 
+# ---- Purge stale WAF cache ----
+#
+# mesquite caches the parsed chrome config and rendered assets per-app under
+# /var/local/mesquite. That cache survives an uninstall/reinstall, so an old
+# entry keeps the previous chrome (e.g. a hidden status bar) even after the
+# app files are updated. Purge it on every install so config.xml changes take.
+echo "3. Purging stale WAF cache..."
+MESQUITE_DIR="/var/local/mesquite"
+# Unload any running instance via appmgrd so the next launch re-reads config.xml.
+# Not pkill: killing mesquite makes appmgrd report a crash to the user.
+lipc-set-prop com.lab126.appmgrd stop "app://$APP_ID" 2>/dev/null
+sleep 1
+if [ -d "$MESQUITE_DIR" ]; then
+    for d in "$MESQUITE_DIR"/*[Bb][Tt][Mm]anager* "$MESQUITE_DIR/BT Manager" "$MESQUITE_DIR/$APP_ID"; do
+        [ -e "$d" ] || continue
+        rm -rf "$d"
+        echo "   Removed $d"
+    done
+fi
+echo "   Done"
+
 # ---- Register in appreg.db ----
 
-echo "3. Registering app..."
+echo "4. Registering app..."
 if [ -f "$APPREG_DB" ]; then
     # Rewritten every time, an existing registration can still be pointing at a
     # stale command or app path after an update.
@@ -71,14 +92,14 @@ fi
 
 # ---- Install scriptlet ----
 
-echo "4. Installing scriptlet..."
+echo "5. Installing scriptlet..."
 cp "$SCRIPTLET" "$SCRIPTLET_DEST"
 chmod +x "$SCRIPTLET_DEST"
 echo "   Installed to $SCRIPTLET_DEST"
 
 # ---- Start helper ----
 
-echo "5. Starting daemon..."
+echo "6. Starting daemon..."
 # Stop existing instances
 /sbin/stop hid-passthrough 2>/dev/null
 pkill -f "ld-linux-armhf." 2>/dev/null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -316,6 +316,17 @@ EOF
   fi
   rm -f "$SCRIPTLET_DEST"
 
+  echo " -> Purging WAF cache"
+  # Graceful appmgrd unload, not pkill (pkill makes appmgrd report a crash).
+  lipc-set-prop com.lab126.appmgrd stop "app://$APP_ID" 2>/dev/null
+  MESQUITE_DIR="/var/local/mesquite"
+  if [ -d "$MESQUITE_DIR" ]; then
+    for d in "$MESQUITE_DIR"/*[Bb][Tt][Mm]anager* "$MESQUITE_DIR/BT Manager" "$MESQUITE_DIR/$APP_ID"; do
+      [ -e "$d" ] || continue
+      rm -rf "$d"
+    done
+  fi
+
   /usr/sbin/mntroot ro
 
   uninstallButtonMapper


### PR DESCRIPTION
Follow-up to #108. mergen3107 reported that after uninstalling the old build and installing the #108 build, the status bar was still missing — the chrome fix didn't take.

Root cause: the "WAF caching layer" isn't a disk cache, it's the resident mesquite process. BTManager is served straight from disk, but mesquite keeps the app process alive in the background and appmgrd just foregrounds it on relaunch, so it never re-reads `config.xml`. The old process keeps whatever chrome it parsed at startup — in this case the pre-`configureSearchBar=system` hidden status bar — even after the files are updated.

Fix: unload the app via appmgrd (`lipc-set-prop com.lab126.appmgrd stop app://<id>`) on every install path so the next launch spawns fresh and re-reads config:
- `illusion/BTManager.sh` — the scriptlet KindleForge relies on (bundled in the release tarball, runs `install_waf` on launch). This is the one that reaches KindleForge users; it never called `install-waf-app.sh`.
- `illusion/install-waf-app.sh` — manual/dev install.
- `scripts/install.sh` — the interactive installer's uninstall path.

Uses the **graceful appmgrd stop, not `pkill`**: killing mesquite out from under appmgrd makes it report a crash ("Application Error") to the user. The `stop` is the same path the native X close button uses — it fully unloads the process cleanly. The app persists no client state (`saveContext=no`, no `localStorage`), so the reload is safe on every run and also covers in-place upgrades (where the appreg entry stays and `install_waf` would otherwise skip). The per-app mesquite storage-dir purge is kept defensively (mesquite names dirs by app id).

## Testing

Verified on a Basic 5 (FW 5.16.2.1.1) with a controlled repro:

| step | state | result |
|------|-------|--------|
| old build | `config=none`, fresh process | heading at top, no native close button / reserved strip |
| new build, no unload | `config=system` on disk, same resident PID | still stale — identical to old build (the bug) |
| scriptlet w/ appmgrd stop | stop unloads → new PID re-reads config | full status bar + native X + reserved strip render, **no crash dialog** |

Confirmed `pkill` triggers the "Application Error" crash dialog whereas `appmgrd stop` unloads cleanly (returns to the previously-resident app with no error).

Refs #107 #108