### PR TITLE
fix(gatt): work around nuitka miscompiling async genexpr in bumble (#109)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -12,6 +12,7 @@ FROM arm32v7/python:3.11-slim-bookworm
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    patch \
     patchelf \
     ccache \
     libffi-dev \
@@ -28,6 +29,13 @@ RUN pip install --no-cache-dir \
     ordered-set \
     bumble==0.0.226 \
     aiofiles>=23.0.0
+
+# Patch bumble before Nuitka compiles it: Nuitka miscompiles the async
+# generator expression in gatt_server.on_att_find_by_type_value_request,
+# crashing the GATT server on inbound Find By Type Value requests (issue #109).
+COPY patches/ /build/patches/
+RUN BUMBLE_DIR="$(python3 -c 'import bumble, os; print(os.path.dirname(bumble.__file__))')" && \
+    patch -p1 -d "$BUMBLE_DIR" < /build/patches/bumble-gatt-server-async-genexpr.patch
 
 # Enable ccache and Nuitka's own caching
 ENV CCACHE_DIR=/ccache

--- a/patches/bumble-gatt-server-async-genexpr.patch
+++ b/patches/bumble-gatt-server-async-genexpr.patch
@@ -1,0 +1,41 @@
+Rewrite on_att_find_by_type_value_request's async generator expression as a
+plain for-loop. Nuitka miscompiles `async for ... in (genexpr with await)`,
+leaking the yielded Attribute into the asyncio Task and crashing the GATT
+server request handler with "RuntimeError: Task got bad yield: Attribute(...)"
+whenever a peer sends an ATT Find By Type Value Request during discovery.
+
+The stock CPython interpreter handles the original code correctly; only the
+Nuitka-compiled release build is affected. See issue #109. Filed upstream at
+Nuitka as an async-generator-expression codegen bug.
+
+Applies against bumble==0.0.226.
+--- a/gatt_server.py
++++ b/gatt_server.py
+@@ -716,15 +716,18 @@
+         pdu_space_available = bearer.att_mtu - 2
+         attributes = []
+         response: att.ATT_PDU
+-        async for attribute in (
+-            attribute
+-            for attribute in self.attributes
+-            if attribute.handle >= request.starting_handle
+-            and attribute.handle <= request.ending_handle
+-            and attribute.type == request.attribute_type
+-            and (await attribute.read_value(bearer)) == request.attribute_value
+-            and pdu_space_available >= 4
+-        ):
++        for attribute in self.attributes:
++            if not (
++                attribute.handle >= request.starting_handle
++                and attribute.handle <= request.ending_handle
++                and attribute.type == request.attribute_type
++            ):
++                continue
++            if (await attribute.read_value(bearer)) != request.attribute_value:
++                continue
++            if pdu_space_available < 4:
++                break
++
+             # TODO: check permissions
+
+             # Add the attribute to the list


### PR DESCRIPTION
## What

Fixes #109 — the `RuntimeError: Task got bad yield: Attribute(...)` traceback in the BTManager Debug window.

## Root cause

Nuitka miscompiles the async generator expression in bumble's `gatt_server.on_att_find_by_type_value_request`. The yielded `Attribute` leaks into the asyncio Task instead of being consumed by `__anext__`, so the handler crashes whenever a peer sends an ATT Find By Type Value Request during GATT discovery.

Verified it's Nuitka-specific, not the Kindle Python:
- Stock CPython 3.10/3.11/3.14 run the construct fine.
- The **real bumble handler on the real device** `python3.10-kindle` returns a normal response — no crash.
- Nuitka-compiling the **real handler** reproduces the exact error: `Task got bad yield: Attribute(handle=0x0001, type=UUID-16:2800 (Primary Service), ..., value=0018)`.

Only the Nuitka-compiled release is affected, which is why the reporter saw it on every release build while the keyboard kept working (HID input flows over a different path; the crash is caught by bumble's `run_in_task` wrapper).

Latest Nuitka (4.1.3) still has the bug, and there's an open upstream Nuitka issue with the same symptom — so we carry a workaround.

## Fix

Rewrite the handler to a plain `for` loop (await in the body, no async-gen), applied to the pip-installed bumble **before** Nuitka compiles it. Verified: the patched handler compiled with Nuitka returns a normal `ATT_Find_By_Type_Value_Response` and matches the original semantics (match / tiny-MTU / no-match / handle-range).

The interpreted SSH dev-deploy is unaffected and unchanged.

## Testing

Building here so it runs on the same CI/ARM builder as production. Final on-device check: flash the release, connect a keyboard, open BTManager → Debug, hit a key → no traceback.