### PR TITLE
fix(brcm): wake and verify the chip before the first HCI reset (#106)

### DIFF
--- a/kindle_hid_passthrough/bt_brcm.py
+++ b/kindle_hid_passthrough/bt_brcm.py
@@ -18,12 +18,16 @@ from logging_utils import log
 BT_DEV_WAKE_PATH = '/proc/bluetooth/sleep/btwake'
 BT_SLEEP_PROTO_PATH = '/proc/bluetooth/sleep/proto'
 BT_ENABLE_PATH = '/proc/bluetooth/btenable'
+BT_SLEEP_DIR = '/proc/bluetooth/sleep'
 BTENABLE_LIPC = ['lipc-set-prop', 'com.lab126.btfd', 'BTenable', '1:1']
 BSA_WARMUP_TIMEOUT = 12.0   # seconds to wait for bsa_server after BTenable
 BSA_FIRMWARE_SETTLE = 2.0   # let bsa finish the .hcd download before we take over
 BSA_WARMUP_RETRIES = 3      # btd-recovery attempts before giving up on warm-up
 BSA_MIN_AGE = 5.0           # bsa_server younger than this may be mid .hcd download
 POST_WAKE_SETTLE = 0.5      # let the chip settle after wake before first HCI cmd
+HCI_RESET_CMD = bytes([0x01, 0x03, 0x0c, 0x00])  # HCI_Reset command packet
+HCI_RESET_OK = bytes([0x04, 0x0e])               # Command Complete event prefix
+WAKE_VERIFY_ATTEMPTS = 5    # raw HCI Reset tries (re-pulsing wake) before giving up
 
 
 def _pgrep_x(name):
@@ -154,21 +158,107 @@ class BrcmChip(BtChip):
             log.info(f"{device_path} ready (warm handoff complete; wake deferred to open)")
             return True
 
-    def on_transport_open(self):
-        try:
-            with open(BT_DEV_WAKE_PATH, 'w') as f:
-                f.write('0')
-            log.info("BCM chip woken (dev_wake asserted)")
-            time.sleep(0.3)
-        except OSError as e:
-            log.warning(f"Could not assert dev_wake: {e}")
+    def _sleep_state(self):
+        """Snapshot the bluesleep proc files for diagnostics."""
+        parts = []
+        for name in ('btwake', 'proto', 'asleep', 'hostwake'):
+            try:
+                parts.append(f"{name}={open(f'{BT_SLEEP_DIR}/{name}').read().strip()}")
+            except OSError:
+                parts.append(f"{name}=?")
+        return ' '.join(parts)
+
+    def _assert_wake(self):
+        """Disable bluesleep then assert dev_wake (active-low btwake=0)."""
         try:
             with open(BT_SLEEP_PROTO_PATH, 'w') as f:
                 f.write('0')
-            log.info("BCM bluesleep disabled (chip stays awake)")
-            time.sleep(0.2)
         except OSError as e:
             log.warning(f"Could not disable bluesleep: {e}")
+        try:
+            with open(BT_DEV_WAKE_PATH, 'w') as f:
+                f.write('0')
+        except OSError as e:
+            log.warning(f"Could not assert dev_wake: {e}")
+
+    def _wake_pulse(self):
+        """Toggle btwake 1->0 to force a fresh ext_wake edge at the chip."""
+        try:
+            with open(BT_DEV_WAKE_PATH, 'w') as f:
+                f.write('1')
+            time.sleep(0.05)
+            with open(BT_DEV_WAKE_PATH, 'w') as f:
+                f.write('0')
+        except OSError:
+            pass
+
+    def pre_open(self):
+        """Wake the chip and confirm it answers a raw HCI Reset before bumble
+        opens the transport.
+
+        On some BCM Kindles (KOA2/KOA3, zelda) the chip is still asleep when the
+        first HCI command goes out, so bumble's reset times out. Retrying at the
+        bumble layer corrupts its command pipeline, so we do the wake handshake
+        here on our own fd and only hand a proven-awake chip to bumble.
+        """
+        import serial
+        self._assert_wake()
+        time.sleep(POST_WAKE_SETTLE)
+        for attempt in range(1, WAKE_VERIFY_ATTEMPTS + 1):
+            cts = None
+            wrote = False
+            resp = b''
+            try:
+                s = serial.Serial()
+                s.port = self.kindle.device_path
+                s.baudrate = self.kindle.baud_rate or 2000000
+                s.rtscts = (self.kindle.flow_control == 'rtscts')
+                s.timeout = 0
+                s.write_timeout = 1.0
+                s.open()
+            except (OSError, ValueError) as e:
+                log.warning(f"BCM wake probe could not open transport: {e}")
+                return
+            try:
+                time.sleep(0.1)
+                cts = s.cts
+                try:
+                    s.reset_input_buffer()
+                except OSError:
+                    pass
+                try:
+                    s.write(HCI_RESET_CMD)
+                    wrote = True
+                except (OSError, serial.SerialTimeoutException):
+                    wrote = False
+                deadline = time.monotonic() + 0.6
+                while time.monotonic() < deadline:
+                    d = s.read(64)
+                    if d:
+                        resp += d
+                    else:
+                        time.sleep(0.02)
+            finally:
+                try:
+                    s.close()
+                except OSError:
+                    pass
+            if resp.startswith(HCI_RESET_OK):
+                log.info(f"BCM chip awake; answered HCI Reset "
+                         f"(cts={cts}, {self._sleep_state()})")
+                return
+            log.warning(f"BCM wake attempt {attempt}/{WAKE_VERIFY_ATTEMPTS}: "
+                        f"no HCI Reset reply (cts={cts} wrote={wrote} "
+                        f"resp={resp.hex() or 'none'} {self._sleep_state()})")
+            self._wake_pulse()
+            time.sleep(0.2)
+        log.error("BCM chip never answered a raw HCI Reset after wake; "
+                  "transport reset will likely time out")
+
+    def on_transport_open(self):
+        self._assert_wake()
+        log.info(f"BCM chip woken (dev_wake asserted, bluesleep off, "
+                 f"{self._sleep_state()})")
         # Settle after wake before the first HCI command, else HCI Reset times out.
         time.sleep(POST_WAKE_SETTLE)
 

--- a/kindle_hid_passthrough/bt_chip.py
+++ b/kindle_hid_passthrough/bt_chip.py
@@ -45,6 +45,9 @@ class BtChip:
         """Bring the BT device to a state where the transport can open."""
         return True
 
+    def pre_open(self):
+        """Run before the HCI transport opens, to wake/verify the chip."""
+
     def on_transport_open(self):
         """Run right after the transport opens, before the first HCI command."""
 

--- a/kindle_hid_passthrough/transport.py
+++ b/kindle_hid_passthrough/transport.py
@@ -67,6 +67,10 @@ async def create_bumble_device(transport_spec=None, configure=None):
     if not spec:
         raise RuntimeError("No HCI transport available")
 
+    # chip hook: wake/verify the chip before we open and reset it
+    from bt_setup import chip
+    chip().pre_open()
+
     log.info("Opening transport...")
     try:
         transport = await _open_transport_with_recovery(spec)
@@ -75,7 +79,6 @@ async def create_bumble_device(transport_spec=None, configure=None):
         raise
 
     # chip hook: runs after the transport opens, before the first HCI command
-    from bt_setup import chip
     chip().on_transport_open()
 
     try:


### PR DESCRIPTION
## What

Adds a `pre_open()` chip hook that runs **before** the HCI transport opens. For Broadcom (BCM4343) Kindles it asserts wake (bluesleep off, active-low `btwake=0`) and confirms the chip answers a **raw HCI Reset on our own fd**, retrying with a `btwake` pulse between attempts (up to 5). Only a proven-awake chip is handed to bumble. No-op on MediaTek.

## Why

Issue #106: on KOA2/KOA3 (zelda, BCM4343) the chip can still be asleep when bumble sends the first HCI command, so the reset times out and the daemon loops forever re-warming. Two things I found while validating:

- **Retrying at the bumble layer corrupts its command pipeline** (`command result mismatch ... 'int' object has no attribute 'supported_commands'`), so the retry has to happen on a raw fd before bumble touches the port.
- **CTS is the real readiness signal.** The `asleep` proc value reads `1` even when the chip is fully responsive, so it can't gate the reset. The handshake logs `cts=` and the bluesleep proc state on every attempt.

## Status: diagnostics + candidate fix

I validated the mechanism on a **Basic 3 (rex, BCM4343)**, where the current 3.9.1 code already works, so I could confirm no regression but **could not reproduce the zelda-specific failure** (no KOA2/KOA3 hardware here). This PR is therefore both:

1. A **candidate fix** (if zelda just needs a wake pulse / more settle before the first command, the raw retry catches it), and
2. **Instrumentation** so a failing device's log finally shows whether CTS ever asserts and whether the raw reset is answered.

**KOA2/KOA3 owners (@ZongbingHou, @danergo):** please run this branch and paste the new `BCM wake attempt .../... cts=... resp=...` lines from `/var/log/hid_passthrough.log`. That tells us whether this fixes it or whether zelda's wake needs a different path.

## Testing

- Basic 3 (rex, Broadcom): `pre_open` answers the raw reset on the first try (`cts=True`), then bumble reset + power-on succeed. No regression.
- Basic 4 (MediaTek): unaffected (`pre_open` is a no-op), reset + power-on as before.

Closes #106 pending zelda confirmation.