### PR TITLE
fix(name): clean device names on every decode path, not just SDP

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -24,7 +24,7 @@ from bumble.hci import (
     OwnAddressType,
 )
 
-from config import Protocol, config, normalize_addr
+from config import Protocol, config, normalize_addr, clean_device_name
 from logging_utils import log
 
 HID_REPORT_TYPE_INPUT = 1
@@ -243,7 +243,7 @@ class BLEMixin:
             log.debug(f"[BLE] Ignoring malformed advertisement from {addr_norm}: {e}")
             return None
         if isinstance(name, bytes):
-            name = name.decode('utf-8', errors='replace')
+            name = clean_device_name(name)
         if name:
             dev = next((d for d in self.ble_devices if d.name == name), None)
             if dev:
@@ -374,7 +374,7 @@ class BLEMixin:
                     for char in service.characteristics:
                         if char.uuid == GATT_DEVICE_NAME_CHARACTERISTIC:
                             value = await self.peer.read_value(char)
-                            self.device_name = bytes(value).decode('utf-8', errors='replace')
+                            self.device_name = clean_device_name(bytes(value))
                             log.info(f"[BLE] Device name: {self.device_name}")
                             return
         except Exception as e:

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -13,7 +13,7 @@ from bumble.hid import HID_CONTROL_PSM, HID_INTERRUPT_PSM, Message
 from bumble.hid import Host as BumbleHIDHost
 from bumble.sdp import Client as SDPClient
 
-from config import Protocol, config, normalize_addr
+from config import Protocol, config, normalize_addr, clean_device_name
 from logging_utils import log
 
 FALLBACK_HID_DESCRIPTOR = bytes([
@@ -441,11 +441,7 @@ class ClassicMixin:
                             self._parse_hid_descriptor_list(attr.value)
                         elif hasattr(attr, 'id') and attr.id == 0x0100:
                             try:
-                                name = attr.value.value
-                                if isinstance(name, bytes):
-                                    name = name.split(b'\x00')[0].decode(
-                                        'utf-8', errors='ignore')
-                                name = str(name).strip()
+                                name = clean_device_name(attr.value.value)
                                 if name:
                                     self.device_name = name
                             except Exception:

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -44,12 +44,25 @@ def get_version() -> str:
         return f"{__version__}-{sha}"
     return __version__
 
-__all__ = ['config', 'Config', 'Protocol', 'normalize_addr', '__version__', 'get_version']
+__all__ = ['config', 'Config', 'Protocol', 'normalize_addr', 'clean_device_name',
+           '__version__', 'get_version']
 
 
 def normalize_addr(address: str) -> str:
     """Normalize Bluetooth address - strip /P suffix, uppercase."""
     return address.split('/')[0].upper()
+
+
+def clean_device_name(name) -> str:
+    """Decode a device name, dropping NUL padding and invalid bytes.
+
+    Fixed-length name buffers are usually NUL-padded C strings, and some
+    devices pad with junk that isn't valid UTF-8. Truncate at the first NUL
+    and drop remaining invalid bytes instead of rendering U+FFFD.
+    """
+    if isinstance(name, bytes):
+        name = name.split(b'\x00')[0].decode('utf-8', errors='ignore')
+    return str(name).strip()
 
 
 class Protocol(Enum):

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -9,7 +9,7 @@ from bumble.core import AdvertisingData, DeviceClass
 from bumble.gatt import GATT_HUMAN_INTERFACE_DEVICE_SERVICE
 from bumble.hci import Address
 
-from config import Protocol, config
+from config import Protocol, config, clean_device_name
 from logging_utils import log
 from transport import create_bumble_device
 
@@ -176,7 +176,7 @@ class Scanner:
                     log.debug(f"Using Unknown name for malformed BLE advertisement from {addr_str}: {e}")
                     name = 'Unknown'
                 if isinstance(name, bytes):
-                    name = name.decode('utf-8', errors='replace')
+                    name = clean_device_name(name) or 'Unknown'
 
             device = DiscoveredDevice(
                 address=addr_str,
@@ -232,10 +232,7 @@ class Scanner:
                     try:
                         name_data = eir_data.get(0x09) or eir_data.get(0x08)
                         if name_data:
-                            if isinstance(name_data, bytes):
-                                name = name_data.decode('utf-8', errors='replace')
-                            else:
-                                name = str(name_data)
+                            name = clean_device_name(name_data) or 'Unknown'
                     except Exception:
                         pass
 


### PR DESCRIPTION
Refs #85. Follow-up to #104 based on the tester feedback there (the garbled name showing up in devices.conf and connection details).

#104 fixed the SDP service-name decode, but that turned out to be decoding a value nobody actually saves. The name that lands in devices.conf comes from the scan result (the scanner hands the decoded name straight to the pair request), and both the scanner and the BLE paths were still decoding with `errors='replace'`, so the 8BitDo's junk bytes came through as U+FFFD and got written to disk. The connection-details name is the UHID device name, which gets baked in at connect time from that same garbled value, so editing devices.conf by hand afterwards doesn't fix it.

So this pulls the decode into one place, `clean_device_name()` in config.py (truncate at the first NUL, then `errors='ignore'`), and routes all four reads through it:
- SDP service name (was #104's inline fix)
- Classic EIR name in the scanner
- BLE advertisement name in the scanner
- BLE GATT device-name characteristic

That way no path can render replacement chars again, and there's a single spot to fix if another one shows up.

One heads up for testing: the code stops *new* garbage at the source, but a name that's already in the device_cache or on an already-connected UHID device will hang around until a reconnect. So after grabbing this, `just clear-cache` (or unpair/repair) and reconnect to see a clean name in connection details.

Tested `clean_device_name` against the reported name with trailing junk, NUL padding, a non-ASCII name ("Clavier Français"), and an all-junk buffer (comes back empty so the fallback name kicks in).