### PR TITLE
simplified installation

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -68,34 +68,69 @@ jobs:
       - name: Extract binaries
         run: |
           CONTAINER_ID=$(docker create kindle-hid-passthrough-builder)
-          mkdir -p output/dist
+          mkdir -p output/kindle_hid_passthrough/dist
 
-          # Extract C wrapper and syscall shim
-          docker cp "$CONTAINER_ID:/build/kindle-hid-passthrough" ./output/kindle-hid-passthrough
-          docker cp "$CONTAINER_ID:/build/libsyscall_wrapper.so" ./output/libsyscall_wrapper.so
+          # Extract C wrapper and syscall shim into kindle_hid_passthrough/
+          docker cp "$CONTAINER_ID:/build/kindle-hid-passthrough" ./output/kindle_hid_passthrough/kindle-hid-passthrough
+          docker cp "$CONTAINER_ID:/build/libsyscall_wrapper.so" ./output/kindle_hid_passthrough/libsyscall_wrapper.so
 
           # Extract entire Nuitka standalone dist directory (includes ld-linux + all .so deps)
-          docker cp "$CONTAINER_ID:/build/nuitka-out/main.dist/." ./output/dist/
+          docker cp "$CONTAINER_ID:/build/nuitka-out/main.dist/." ./output/kindle_hid_passthrough/dist/
 
           docker rm "$CONTAINER_ID"
-          chmod +x output/kindle-hid-passthrough output/dist/main.bin output/dist/ld-linux-armhf.so.3
+          chmod +x output/kindle_hid_passthrough/kindle-hid-passthrough \
+                   output/kindle_hid_passthrough/dist/main.bin \
+                   output/kindle_hid_passthrough/dist/ld-linux-armhf.so.3
 
       - name: Add scripts and assets
         run: |
-          cp -r scripts/ output/
-          cp -r assets/ output/
-          cp -r illusion/ output/
-          cp -r koreader-plugin/ output/
-          cp kindle_hid_passthrough/config.ini output/
+          mkdir -p output/documents
+          mkdir -p output/koreader/plugins/hidpassthrough.koplugin
+          mkdir -p output/extensions/hid-passthrough
+          mkdir -p output/kindle_hid_passthrough/assets
+          mkdir -p output/kindle_hid_passthrough/cache
+          mkdir -p output/kindle_hid_passthrough/illusion
+          mkdir -p output/kindle_hid_passthrough/scripts
+
+          # documents/
+          cp illusion/BTManager.sh output/documents/
+
+          # koreader/plugins/
+          cp -r koreader-plugin/hidpassthrough.koplugin/. output/koreader/plugins/hidpassthrough.koplugin/
+
+          # extensions/hid-passthrough/
+          cp assets/config.xml output/extensions/hid-passthrough/
+          cp assets/menu.json output/extensions/hid-passthrough/
+
+          # kindle_hid_passthrough/assets/
+          cp assets/99-hid-keyboard.rules output/kindle_hid_passthrough/assets/
+          cp assets/hid-passthrough.upstart output/kindle_hid_passthrough/assets/
+          cp scripts/dev_is_keyboard.sh output/kindle_hid_passthrough/assets/
+
+          # kindle_hid_passthrough/ root
+          cp kindle_hid_passthrough/config.ini output/kindle_hid_passthrough/
+          cp scripts/install.sh output/kindle_hid_passthrough/
+
+          # kindle_hid_passthrough/illusion/
+          cp -r illusion/BTManager output/kindle_hid_passthrough/illusion/
+
+          # kindle_hid_passthrough/scripts/
+          cp scripts/dev_is_keyboard.sh output/kindle_hid_passthrough/scripts/
+          cp scripts/hid-passthrough-daemon.sh output/kindle_hid_passthrough/scripts/
+          cp scripts/setlayout.sh output/kindle_hid_passthrough/scripts/
 
       - name: Show contents
         run: |
           echo "=== Top level ==="
           ls -lh output/
-          echo "=== dist/ ==="
-          ls -lh output/dist/ | head -30
+          echo "=== kindle_hid_passthrough/ ==="
+          ls -lh output/kindle_hid_passthrough/
+          echo "=== kindle_hid_passthrough/dist/ ==="
+          ls -lh output/kindle_hid_passthrough/dist/ | head -30
           echo "=== File types ==="
-          file output/kindle-hid-passthrough output/dist/main.bin output/dist/ld-linux-armhf.so.3
+          file output/kindle_hid_passthrough/kindle-hid-passthrough \
+               output/kindle_hid_passthrough/dist/main.bin \
+               output/kindle_hid_passthrough/dist/ld-linux-armhf.so.3
 
       - name: Create tarball
         run: |
@@ -107,15 +142,19 @@ jobs:
           echo "Checking tarball contains all files expected by KindleForge install.sh..."
           MISSING=0
           for f in \
-            kindle-hid-passthrough \
-            assets/hid-passthrough.upstart \
-            assets/99-hid-keyboard.rules \
-            scripts/dev_is_keyboard.sh \
-            illusion/BTManager.sh \
-            koreader-plugin/hidpassthrough.koplugin/main.lua \
-            koreader-plugin/hidpassthrough.koplugin/_meta.lua \
-            config.ini \
-            dist/main.bin; do
+            kindle_hid_passthrough/kindle-hid-passthrough \
+            kindle_hid_passthrough/assets/hid-passthrough.upstart \
+            kindle_hid_passthrough/assets/99-hid-keyboard.rules \
+            kindle_hid_passthrough/scripts/dev_is_keyboard.sh \
+            kindle_hid_passthrough/illusion/BTManager/config.xml \
+            kindle_hid_passthrough/install.sh \
+            kindle_hid_passthrough/config.ini \
+            kindle_hid_passthrough/dist/main.bin \
+            documents/BTManager.sh \
+            koreader/plugins/hidpassthrough.koplugin/main.lua \
+            koreader/plugins/hidpassthrough.koplugin/_meta.lua \
+            extensions/hid-passthrough/config.xml \
+            extensions/hid-passthrough/menu.json; do
             if ! tar -tzf kindle-hid-passthrough-armv7.tar.gz "./$f" >/dev/null 2>&1; then
               echo "MISSING: $f"
               MISSING=1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,35 +10,6 @@ in_install_dir()
     [ "$(pwd)" = "$INSTALL_DIR" ]
 }
 
-installMainFiles()
-{
-  echo " -> Installing main program files"
-  mkdir -p "$INSTALL_DIR/dist" "$INSTALL_DIR/illusion/BTManager" "$INSTALL_DIR/cache"
-  if ! in_install_dir; then
-    cp -r dist/* "$INSTALL_DIR/dist/"
-    cp kindle-hid-passthrough "$INSTALL_DIR/"
-    cp libsyscall_wrapper.so "$INSTALL_DIR/"
-    cp config.ini "$INSTALL_DIR/"
-  fi
-  chmod +x "$INSTALL_DIR/kindle-hid-passthrough"
-  echo " -> Ready."
-}
-
-installAll()
-{
-  echo ""
-  echo "=== Full Install ==="
-  installUdevRules
-  installUpstart
-  installMainFiles
-  installWAFApp
-  if [ -d /mnt/us/koreader/plugins/ ]; then
-    installKOReaderPlugin
-  fi
-  echo ""
-  echo "Installation complete. Open 'BT Manager' from the Kindle library."
-}
-
 installUdevRules()
 {
   echo " -> Installing udev rules"
@@ -66,33 +37,6 @@ pairDevice()
 listDevices()
 {
   cat devices.conf
-}
-
-installWAFApp()
-{
-  echo " -> Installing BTManager app"
-  if ! in_install_dir; then
-    mkdir -p "$INSTALL_DIR/illusion/BTManager"
-    cp -r illusion/BTManager/* "$INSTALL_DIR/illusion/BTManager/"
-    cp illusion/BTManager.sh "$INSTALL_DIR/illusion/BTManager.sh"
-    cp illusion/install-waf-app.sh "$INSTALL_DIR/illusion/install-waf-app.sh"
-  fi
-  if [ -f "$INSTALL_DIR/illusion/install-waf-app.sh" ]; then
-    /bin/sh "$INSTALL_DIR/illusion/install-waf-app.sh"
-  else
-    echo "ERROR: $INSTALL_DIR/illusion/install-waf-app.sh not found"
-  fi
-}
-
-installKOReaderPlugin()
-{
-  if [ ! -d /mnt/us/koreader/plugins/ ]; then
-    echo " -> KOReader not found, skipping plugin install"
-    return
-  fi
-  echo " -> Installing KOReader plugin"
-  cp -r koreader-plugin/hidpassthrough.koplugin /mnt/us/koreader/plugins/hidpassthrough.koplugin
-  echo " -> Ready."
 }
 
 uninstallAll()
@@ -153,26 +97,19 @@ EOF
 print_menu()
 {
   printf "\nSelect an option:\n"
-  printf " 1) Install everything (recommended)\n"
-  printf " 2) Pair Bluetooth keyboard\n"
-  printf " 3) List paired devices\n"
-  printf " 4) Install udev rules (keyboard service)\n"
-  printf " 5) Install upstart (auto-start on boot)\n"
-  printf " 6) Install BTManager app\n"
-  printf " 7) Install KOReader plugin\n"
-  printf " 8) Uninstall everything\n"
-  printf " 9) Quit\n"
+  printf " 1) Pair Bluetooth keyboard\n"
+  printf " 2) List paired devices\n"
+  printf " 3) Install udev rules (keyboard service)\n"
+  printf " 4) Install upstart (auto-start on boot)\n"
+  printf " 5) Uninstall everything\n"
+  printf " 6) Quit\n"
 }
 
 # Non-interactive entry point: `sh install.sh <action>` runs one action and exits.
 if [ $# -gt 0 ]; then
   case "$1" in
-    installAll)         installAll; exit 0 ;;
     installUdevRules)   installUdevRules; exit 0 ;;
     installUpstart)     installUpstart; exit 0 ;;
-    installMainFiles)   installMainFiles; exit 0 ;;
-    installWAFApp)      installWAFApp; exit 0 ;;
-    installKOReaderPlugin) installKOReaderPlugin; exit 0 ;;
     uninstallAll)       uninstallAll; exit 0 ;;
     *) echo "Unknown action: $1" >&2; exit 1 ;;
   esac
@@ -180,34 +117,25 @@ fi
 
 while :; do
   print_menu
-  printf "Enter choice [1-9]: "
+  printf "Enter choice [1-6]: "
   read choice
   case "$choice" in
     1)
-      installAll
-      ;;
-    2)
       pairDevice
       ;;
-    3)
+    2)
       listDevices
       ;;
-    4)
+    3)
       installUdevRules
       ;;
-    5)
+    4)
       installUpstart
       ;;
-    6)
-      installWAFApp
-      ;;
-    7)
-      installKOReaderPlugin
-      ;;
-    8)
+    5)
       uninstallAll
       ;;
-    9)
+    6)
       echo "Exiting."
       break
       ;;


### PR DESCRIPTION
**Previous PR resubmitted.** Needed to update my fork and it diverged slightly from this commit so I had to drop my commit and the PR.

So this PR modifies the workflow file to build the release so it can be copied directly to the Kindle. No need to run `install.sh` to copy the files to the correct location. Still need to run it to copy the keyboard rules and the dev-is-keyboard to the correct location on the system partition.

Before applying this PR make sure the *installation script in KindleForge is updated*.