### PR TITLE
fix(name): filter device names by code point, not just byte validity

### DIFF
--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import subprocess
+import unicodedata
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
@@ -48,21 +49,35 @@ __all__ = ['config', 'Config', 'Protocol', 'normalize_addr', 'clean_device_name'
            '__version__', 'get_version']
 
 
+_UNPRINTABLE_CATEGORIES = {'Cc', 'Cf', 'Co', 'Cs', 'Cn', 'Zl', 'Zp'}
+
+
 def normalize_addr(address: str) -> str:
     """Normalize Bluetooth address - strip /P suffix, uppercase."""
     return address.split('/')[0].upper()
 
 
 def clean_device_name(name) -> str:
-    """Decode a device name, dropping NUL padding and invalid bytes.
+    """Decode a device name, dropping padding and unprintable characters.
 
-    Fixed-length name buffers are usually NUL-padded C strings, and some
-    devices pad with junk that isn't valid UTF-8. Truncate at the first NUL
-    and drop remaining invalid bytes instead of rendering U+FFFD.
+    Fixed-length name buffers are usually NUL-padded C strings, but some
+    devices pad with junk bytes. Dropping only *invalid* UTF-8 is not enough:
+    padding that happens to be valid UTF-8 decodes to control, unassigned or
+    private-use code points that still render as boxes or U+FFFD downstream.
+    So truncate at the first NUL, ignore undecodable bytes, then filter by
+    code point category. Accepts str too, since names arriving from bumble,
+    the HTTP API or devices.conf are already decoded.
     """
-    if isinstance(name, bytes):
-        name = name.split(b'\x00')[0].decode('utf-8', errors='ignore')
-    return str(name).strip()
+    if name is None:
+        return ''
+    if isinstance(name, (bytes, bytearray)):
+        name = bytes(name).split(b'\x00')[0].decode('utf-8', errors='ignore')
+    cleaned = ''.join(
+        ch for ch in str(name)
+        if ch == ' ' or (ch != '\ufffd'
+                         and unicodedata.category(ch) not in _UNPRINTABLE_CATEGORIES)
+    )
+    return cleaned.strip()
 
 
 class Protocol(Enum):
@@ -306,6 +321,7 @@ class Config:
         """
         logger = logging.getLogger(__name__)
         conf_file = self.devices_config_file
+        name = clean_device_name(name) if name else None
 
         dir_path = os.path.dirname(conf_file)
         if dir_path:
@@ -358,7 +374,7 @@ class Config:
                     parts = line.split(None, 2)  # Split into max 3 parts
                     address = parts[0] if parts[0] == '*' else normalize_addr(parts[0])
                     protocol = self._parse_protocol(parts[1]) if len(parts) > 1 else self.protocol
-                    name = parts[2] if len(parts) > 2 else None
+                    name = (clean_device_name(parts[2]) or None) if len(parts) > 2 else None
                     devices.append((address, protocol, name))
 
         return devices

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -11,7 +11,7 @@ from bumble.hci import HCI_LE_SET_PRIVACY_MODE_COMMAND, HCI_LE_Set_Privacy_Mode_
 from ble import BLEMixin
 from bt_setup import ensure_uhid
 from classic import ClassicMixin
-from config import Protocol, config, get_version, normalize_addr
+from config import Protocol, clean_device_name, config, get_version, normalize_addr
 from device_cache import DeviceCache
 from logging_utils import log
 from pairing import create_keystore, create_pairing_config
@@ -351,7 +351,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         cache = self.device_cache.load(address)
         if cache and 'report_map' in cache:
             self.report_map = bytes.fromhex(cache['report_map'])
-            self.device_name = cache.get('device_name')
+            self.device_name = clean_device_name(cache.get('device_name') or '') or None
             log.success(f"Loaded cached descriptor ({len(self.report_map)} bytes)")
             return True
         return False

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -175,8 +175,7 @@ class Scanner:
                 except UnicodeDecodeError as e:
                     log.debug(f"Using Unknown name for malformed BLE advertisement from {addr_str}: {e}")
                     name = 'Unknown'
-                if isinstance(name, bytes):
-                    name = clean_device_name(name) or 'Unknown'
+                name = clean_device_name(name) or 'Unknown'
 
             device = DiscoveredDevice(
                 address=addr_str,
@@ -233,6 +232,10 @@ class Scanner:
                         name_data = eir_data.get(0x09) or eir_data.get(0x08)
                         if name_data:
                             name = clean_device_name(name_data) or 'Unknown'
+                            raw = (name_data if isinstance(name_data, bytes)
+                                   else str(name_data).encode('utf-8', errors='replace'))
+                            if name != raw.decode('utf-8', errors='ignore').strip():
+                                log.info(f"  Cleaned EIR name for {addr_str}: {raw.hex()}")
                     except Exception:
                         pass
 


### PR DESCRIPTION
Refs #85, follow-up to #116 after danergo's test on that PR still showed the garbled name.

#116 routed all four decode paths through `clean_device_name()`, but that function only dropped bytes that were *invalid* UTF-8. Digging into the log from the retest, the junk on the 8BitDo Zero 2 must be valid UTF-8: bumble decodes local names with a strict `ad_data.decode("utf-8")`, so if the padding were undecodable the scanner's `except` would have caught it and shown `Unknown` instead. It decoded fine and landed on control / unassigned / private-use code points, which `errors='ignore'` doesn't touch and which still render as boxes or U+FFFD everywhere downstream.

Two more holes came out of that:

- `clean_device_name()` was a no-op on `str` input (it only sanitized the `bytes` branch), so anything already decoded upstream passed straight through.
- The name that actually lands in devices.conf is the one from the HTTP `/pair` request, which `controller._do_pair()` hands to `config.add_device()` verbatim. It never went near `clean_device_name()`, which is why the tester still saw junk in `config: Added:` and then in the UHID device name (`host._create_uhid_device()` prefers the devices.conf name over the SDP one).

So this changes the filter to be by `unicodedata` category (drop `Cc`/`Cf`/`Co`/`Cs`/`Cn`/`Zl`/`Zp` and U+FFFD, keep spaces) and applies it to `str` as well as `bytes`. Then it makes both ends of devices.conf choke points: `add_device()` cleans on write, `get_all_devices()` cleans on read. Cached device names get cleaned on load too.

The read-side cleaning means names already stored garbled come out clean on the next start — no `just clear-cache` or unpair/repair needed this time.

Also added a debug log of the raw EIR name bytes in the Classic scan path, so if some device still comes through wrong we can see the actual bytes instead of guessing from mangled log text.

Checked locally against NUL padding, invalid-byte padding, valid-UTF-8-but-unprintable padding (the case this fixes), pre-mangled strings, a name with a newline that would corrupt the devices.conf line format, non-ASCII names that must survive ("Clavier Français", katakana), and all-junk input coming back empty so the fallback kicks in. Also ran the devices.conf round trip: a dirty entry written by an older build reads back clean.