### PR TITLE
fix(btmanager): refresh device page on connect/disconnect

### DIFF
--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -30,6 +30,7 @@ var BTManager = (function() {
 
     // Currently viewed device in detail overlay
     var detailDevice = null;
+    var detailRenderKey = "";
 
     // ---- XHR Helper ----
 
@@ -188,6 +189,8 @@ var BTManager = (function() {
             }
 
             lastStatus = data;
+
+            renderDeviceDetail();
         });
     }
 
@@ -239,7 +242,7 @@ var BTManager = (function() {
             var proto = escapeHtml(dev.protocol || "");
             var name = escapeHtml(dev.name || "") || addr;
 
-            html += '<div class="device-row" data-addr="' + addr + '" data-proto="' + proto + '" data-name="' + escapeHtml(dev.name || "") + '" data-connected="' + (isConnected ? '1' : '0') + '">';
+            html += '<div class="device-row" data-addr="' + addr + '" data-proto="' + proto + '" data-name="' + escapeHtml(dev.name || "") + '">';
             html += '<span class="device-row-chevron">&#x276F;</span>';
             html += '<div class="device-row-name' + (isConnected ? '' : ' idle') + '">' + name + '</div>';
             html += '<div class="device-row-sub">' + proto.toUpperCase() + '</div>';
@@ -250,49 +253,65 @@ var BTManager = (function() {
 
     // ---- Device Detail Overlay ----
 
-    function showDeviceDetail(addr, proto, name, isConnected) {
-        detailDevice = { addr: addr, proto: proto, name: name, connected: isConnected };
+    function showDeviceDetail(addr, proto, name) {
+        detailDevice = { addr: addr, proto: proto, name: name, connected: false };
+        detailRenderKey = "";
         window.scrollTo(0, 0);
+        renderDeviceDetail();
+        getEl("deviceOverlay").className = "device-overlay visible";
+    }
 
-        getEl("detailName").innerHTML = escapeHtml(name) || escapeHtml(addr);
+    function isDetailConnected() {
+        if (!detailDevice || !detailDevice.addr) return false;
+        if (!lastStatus || !lastStatus.connected_device) return false;
+        return lastStatus.connected_device.toUpperCase() === detailDevice.addr.toUpperCase();
+    }
+
+    function renderDeviceDetail() {
+        if (!detailDevice) return;
+
+        var isConnected = isDetailConnected();
+        detailDevice.connected = isConnected;
+
+        var uhid = isConnected && lastStatus ? (lastStatus.uhid_name || "") : "";
+        var inputs = isConnected && lastStatus && lastStatus.input_paths
+            ? lastStatus.input_paths.join(", ") : "";
+        var hidReady = isConnected && lastStatus ? lastStatus.hid_ready : null;
+
+        var key = [isConnected ? "1" : "0", String(hidReady), uhid, inputs,
+                   detailDevice.name, detailDevice.proto].join("|");
+        if (key === detailRenderKey) return;
+        detailRenderKey = key;
+
+        getEl("detailName").innerHTML = escapeHtml(detailDevice.name) || escapeHtml(detailDevice.addr);
         getEl("detailStatus").innerHTML = isConnected ? "&#x25CF; Connected" : "&#x25CB; Not Connected";
-        getEl("detailProtocol").innerHTML = escapeHtml(proto).toUpperCase();
-        getEl("detailAddress").innerHTML = escapeHtml(addr);
+        getEl("detailProtocol").innerHTML = escapeHtml(detailDevice.proto).toUpperCase();
+        getEl("detailAddress").innerHTML = escapeHtml(detailDevice.addr);
+        getEl("btnDetailAction").innerHTML = isConnected ? "Disconnect" : "Connect";
 
-        var actionBtn = getEl("btnDetailAction");
-        if (isConnected) {
-            actionBtn.innerHTML = "Disconnect";
-        } else {
-            actionBtn.innerHTML = "Connect";
-        }
-
-        // HID info
         var hidSection = getEl("detailHid");
         var hidWarn = getEl("detailHidWarning");
         hidSection.style.display = "none";
         hidWarn.style.display = "none";
 
-        if (isConnected && lastStatus) {
-            var uhid = lastStatus.uhid_name;
-            var inputs = lastStatus.input_paths;
-            if (lastStatus.hid_ready === false) {
+        if (isConnected) {
+            if (hidReady === false) {
                 hidWarn.style.display = "block";
                 getEl("detailUhid").innerHTML = "--";
                 getEl("detailInputPaths").innerHTML = "--";
                 hidSection.style.display = "block";
             } else if (uhid || inputs) {
-                getEl("detailUhid").innerHTML = escapeHtml(uhid || "--");
-                getEl("detailInputPaths").innerHTML = inputs && inputs.length ? escapeHtml(inputs.join(", ")) : "--";
+                getEl("detailUhid").innerHTML = escapeHtml(uhid) || "--";
+                getEl("detailInputPaths").innerHTML = escapeHtml(inputs) || "--";
                 hidSection.style.display = "block";
             }
         }
-
-        getEl("deviceOverlay").className = "device-overlay visible";
     }
 
     function hideDeviceDetail() {
         getEl("deviceOverlay").className = "device-overlay";
         detailDevice = null;
+        detailRenderKey = "";
     }
 
     function detailAction() {
@@ -712,8 +731,7 @@ var BTManager = (function() {
                     addr = row.getAttribute("data-addr");
                     proto = row.getAttribute("data-proto");
                     name = row.getAttribute("data-name");
-                    var isConn = row.getAttribute("data-connected") === "1";
-                    showDeviceDetail(addr, proto, name, isConn);
+                    showDeviceDetail(addr, proto, name);
                     return;
                 }
                 row = row.parentNode;

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import subprocess
-import unicodedata
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
@@ -49,9 +48,6 @@ __all__ = ['config', 'Config', 'Protocol', 'normalize_addr', 'clean_device_name'
            '__version__', 'get_version']
 
 
-_UNPRINTABLE_CATEGORIES = {'Cc', 'Cf', 'Co', 'Cs', 'Cn', 'Zl', 'Zp'}
-
-
 def normalize_addr(address: str) -> str:
     """Normalize Bluetooth address - strip /P suffix, uppercase."""
     return address.split('/')[0].upper()
@@ -74,8 +70,7 @@ def clean_device_name(name) -> str:
         name = bytes(name).split(b'\x00')[0].decode('utf-8', errors='ignore')
     cleaned = ''.join(
         ch for ch in str(name)
-        if ch == ' ' or (ch != '\ufffd'
-                         and unicodedata.category(ch) not in _UNPRINTABLE_CATEGORIES)
+        if ch == ' ' or (ch != '\ufffd' and ch.isprintable())
     )
     return cleaned.strip()
 


### PR DESCRIPTION
The device page painted once when you tapped a row and then never again. The 3s `/status` poll was only re-rendering the device lists, so a controller powering on and connecting while the page was open never reached it, and it sat on "Not Connected" until you closed and reopened it, which is exactly what #129 describes.

Connected state now comes from `lastStatus.connected_device` and the page repaints on every poll. The repaint is keyed on the fields the page actually shows so an unrelated status change does not flash e-ink for nothing. The HID rows follow along too, so the uhid name and input paths show up as soon as the device is ready.

Second commit is unrelated and can be split out if you would rather, but without it nothing runs. PR #123 imported `unicodedata` at module scope and the cross-compiled python3.10 on the Kindle does not ship that module, so `config.py` raised ModuleNotFoundError and the daemon would not start. Only the hard-float `unicodedata.so` exists in `cross-compile/output-hf` and it fails to load on the soft-float build with `internal error`. `str.isprintable()` is in the interpreter core and tests the same categories, differing on 16 code points out of 1114112 (the non-ASCII Zs spaces, dropped rather than kept).

Tested on device, connect and disconnect both track live now. Also checked against `tests/mock_api_server.py` with a jsdom harness driving the connect out of band to mimic a controller powering on, which reproduces the stale page on main and passes here.

Fixes #129