### PR TITLE
fix(deploy): make deploy work from macOS, and actually stop the WAF app

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,23 +23,7 @@ deploy:
     @echo "Remounting filesystems as writable..."
     ssh {{host}} "/usr/sbin/mntroot rw && mount -o remount,rw /mnt/base-us"
     @echo "Copying all files via tar pipe..."
-    (cd {{src_dir}} && tar cf - \
-        --transform='s|^kindle_hid_passthrough/hid-passthrough-dev.upstart|etc/upstart/hid-passthrough.conf|' \
-        --transform='s|^kindle_hid_passthrough/|mnt/us/kindle_hid_passthrough/|' \
-        --transform='s|^assets/99-hid-keyboard.rules|etc/udev/rules.d/99-hid-keyboard.rules|' \
-        --transform='s|^scripts/dev_is_keyboard.sh|mnt/us/kindle_hid_passthrough/scripts/dev_is_keyboard.sh|' \
-        --transform='s|^illusion/BTManager/|mnt/us/kindle_hid_passthrough/illusion/BTManager/|' \
-        --transform='s|^illusion/BTManager.sh|mnt/us/kindle_hid_passthrough/illusion/BTManager.sh|' \
-        kindle_hid_passthrough/*.py \
-        kindle_hid_passthrough/config.ini \
-        kindle_hid_passthrough/BUILD_SHA \
-        kindle_hid_passthrough/hid-passthrough-dev.upstart \
-        kindle_hid_passthrough/modules/*.ko \
-        assets/99-hid-keyboard.rules \
-        scripts/dev_is_keyboard.sh \
-        illusion/BTManager/* \
-        illusion/BTManager.sh \
-    ) | ssh {{host}} "tar xf - -C /"
+    @just host={{host}} push-files
     -ssh {{host}} "udevadm control --reload-rules" 2>/dev/null || true
     @echo "Clearing Python bytecode cache..."
     ssh {{host}} "rm -rf {{remote_dir}}/__pycache__"
@@ -52,6 +36,44 @@ deploy:
     @just host={{host}} server
     ssh {{host}} 'lipc-set-prop com.lab126.appmgrd start app://com.lzampier.btmanager'
     @echo "Deployment complete!"
+
+# Ship the tree with one tar per destination.
+#
+# The old form rewrote paths with GNU tar's --transform. macOS ships bsdtar, which
+# rejects the option and writes nothing, so the remote tar failed on the empty
+# stream and just stopped at that line: loud, but it made deploy unusable on macOS.
+#
+# Files are named individually rather than by directory so that no archive carries
+# a directory member. A member for etc/ or mnt/ would, on extraction as root, reset
+# the mode and ownership of the device's real /etc and /mnt to the build host's.
+#
+# Runs under pipefail. A local tar error (an unmatched glob, an unreadable file)
+# still yields a valid archive that the remote tar extracts happily and exits 0 on,
+# so without pipefail a partial deploy would report success.
+[private]
+push-files:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Every -C target must exist: unlike "-C /", tar will not create a parent that
+    # is not itself a member of the archive.
+    ssh {{host}} "mkdir -p {{remote_dir}}/scripts {{remote_dir}}/modules \
+        {{remote_dir}}/illusion/BTManager /etc/upstart /etc/udev/rules.d"
+    (cd {{src_dir}}/kindle_hid_passthrough && tar cf - *.py config.ini BUILD_SHA modules/*.ko) \
+        | ssh {{host}} "tar xf - -C {{remote_dir}}"
+    (cd {{src_dir}}/scripts && tar cf - dev_is_keyboard.sh) \
+        | ssh {{host}} "tar xf - -C {{remote_dir}}/scripts"
+    (cd {{src_dir}}/illusion && tar cf - BTManager.sh BTManager/*) \
+        | ssh {{host}} "tar xf - -C {{remote_dir}}/illusion"
+    (cd {{src_dir}}/assets && tar cf - 99-hid-keyboard.rules) \
+        | ssh {{host}} "tar xf - -C /etc/udev/rules.d"
+    # The upstart conf is the one file renamed in transit. Stage it under its
+    # destination name so the archive holds that single member and no directory.
+    stage=$(mktemp -d)
+    trap 'rm -r "$stage"' EXIT
+    name=$(basename '{{upstart_conf}}')
+    cp {{src_dir}}/kindle_hid_passthrough/hid-passthrough-dev.upstart "$stage/$name"
+    (cd "$stage" && tar cf - "$name") \
+        | ssh {{host}} "tar xf - -C $(dirname '{{upstart_conf}}')"
 
 # Register BTManager WAF app in appreg.db and install scriptlet (idempotent)
 register-waf:
@@ -70,16 +92,20 @@ register-waf:
 
 # Kill daemon and close WAF app
 kill:
+    # The patterns are bracket-escaped so they do not match this ssh command's own
+    # shell, whose cmdline contains them verbatim. Unescaped, the first pkill
+    # SIGKILLs that shell and every later command in the list silently never runs.
     -ssh {{host}} 'lipc-set-prop com.lab126.appmgrd start app://com.lab126.booklet.home 2>/dev/null; \
         /sbin/initctl stop hid-passthrough 2>/dev/null; \
-        pkill -9 -f "main.py --daemon" 2>/dev/null; \
-        pkill -9 -f daemon.py 2>/dev/null; \
+        pkill -9 -f "main[.]py --daemon" 2>/dev/null; \
+        pkill -9 -f "daemon[.]py" 2>/dev/null; \
+        pkill -f "mesquite -l com[.]lzampier[.]btmanager" 2>/dev/null; \
         true'
     @echo "All processes stopped."
 
 # Start daemon + API server
 server:
-    -ssh {{host}} "pkill -9 -f 'main.py --daemon'" 2>/dev/null || true
+    -ssh {{host}} "pkill -9 -f 'main[.]py --daemon'" 2>/dev/null || true
     ssh {{host}} "sleep 2 && /mnt/us/python3.10-kindle/python3-wrapper.sh /mnt/us/kindle_hid_passthrough/main.py --daemon > /dev/null 2>&1 &"
     @echo "Daemon + API starting (takes ~8s on Kindle)."
 
@@ -165,10 +191,9 @@ run:
 deploy-koreader:
     @echo "Deploying KOReader plugin..."
     ssh {{host}} "rm -rf /mnt/us/koreader/plugins/hidpassthrough.koplugin"
-    (cd {{src_dir}} && tar cf - \
-        --transform='s|^koreader-plugin/hidpassthrough.koplugin/|mnt/us/koreader/plugins/hidpassthrough.koplugin/|' \
-        koreader-plugin/hidpassthrough.koplugin/ \
-    ) | ssh {{host}} "tar xf - -C /"
+    ssh {{host}} "mkdir -p /mnt/us/koreader/plugins"
+    (cd {{src_dir}}/koreader-plugin && tar cf - hidpassthrough.koplugin) \
+        | ssh {{host}} "tar xf - -C /mnt/us/koreader/plugins"
     @echo "KOReader plugin deployed!"
 
 # Remove autostart (removes upstart config)


### PR DESCRIPTION
Three faults in the deploy path, found while deploying from a Mac. Independent of the #101 work.

**1. `deploy` cannot run from macOS at all.** The copy step rewrites paths with GNU tar's `--transform`. macOS ships bsdtar, which rejects the option and writes nothing, so the remote tar fails on the empty stream and `just` stops there. It fails loudly, but the recipe is simply unusable from a Mac.

Replaced with one tar per destination, extracted with `-C`. Files are named individually rather than by directory, deliberately: an archive built from a staged tree also carries members for `etc/` and `mnt/` themselves, and extracting those as root would reset the mode and ownership of the device's real `/etc` and `/mnt` to whatever the build host had. Because `-C` replaces `-C /`, tar can no longer create a target's parent as a side effect, so the remote `mkdir -p` now covers every `-C` target.

Verified that all 40 files land at exactly the paths the `--transform` version produced, and that no archive on the deploy path contains a directory member.

**2. A partial deploy could report success.** A local tar error — an unmatched glob, an unreadable file — still produces a valid archive that busybox tar extracts and exits 0 on, and `just`'s default linewise `sh -cu` has no pipefail. The copy step now lives in a private recipe with `set -euo pipefail`.

**3. `kill` never stopped the WAF app, so deploy wedged it.** It switches the foreground away from BTManager but leaves its `mesquite` process running. `deploy` then deletes `/var/local/mesquite/com.lzampier.btmanager` from under the live app and starts it again, which wedges the UI in a way that presents as the whole device being frozen. Two deploys in quick succession is enough.

Adding a `pkill` for it is not sufficient on its own, which is the part I'd most like you to sanity-check. All the pkills run inside one ssh command whose own shell has the patterns in its cmdline, so `pkill -9 -f "main.py --daemon"` SIGKILLs that shell and every later command in the list silently never runs. Reproduced on busybox 1.31.1 and 1.38.0: wrapper exits 137, the later pkills are unreachable. The patterns are now bracket-escaped so they cannot match the wrapper. That also revives `pkill -9 -f daemon.py`, which has been dead for the same reason.

`deploy-koreader` had the same `--transform` problem, plus a subtler one: tar matches a member name without its trailing slash, so that rule's own trailing `/` could never match the directory member, and `-C /` created a stray `/koreader-plugin/hidpassthrough.koplugin` on the root filesystem.

**Deliberately not included:** `deploy` remounts root read-write and never restores it, unlike `remove-autostart` and `install-udev`. Doing that safely means waiting for the daemon to be up first, since `server` backgrounds it and it opens `/var/log/hid_passthrough.log` on start — so it wants its own change. Happy to send that separately if you'd like it.

Tested from macOS against a PW5. I have not tested from a Linux host, though I did confirm the new archives produce identical member sets under GNU tar.
