### PR TITLE
fix(waf): sanitize daemon log output before it reaches the debug screen

### DIFF
--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -11,6 +11,7 @@ var BTManager = (function() {
     var HELPER_URL = "http://localhost:8321";
     var POLL_INTERVAL = 3000;
     var MESSAGE_TIMEOUT = 4000;
+    var LOG_VIEW_MAX_CHARS = 6000;
 
     var pollTimer = null;
     var messageTimer = null;
@@ -96,7 +97,7 @@ var BTManager = (function() {
 
     function showMessage(text, isError) {
         var bar = getEl("messageBar");
-        bar.innerHTML = text;
+        setText(bar, text);
         bar.className = "message-bar visible" + (isError ? " error" : "");
         if (messageTimer) clearTimeout(messageTimer);
         messageTimer = setTimeout(function() {
@@ -104,12 +105,46 @@ var BTManager = (function() {
         }, MESSAGE_TIMEOUT);
     }
 
+    // Daemon log lines reach this page verbatim. They carry ANSI colour escapes
+    // and can carry C0/C1 control bytes, neither of which escapeHtml touches and
+    // both of which corrupt the WebKit view this runs in.
+    function sanitizeText(str) {
+        if (str === null || str === undefined) return "";
+        str = String(str);
+        str = str.replace(/\x1b\[[0-?]*[ -\/]*[@-~]/g, "");
+        return str.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, "");
+    }
+
     function escapeHtml(str) {
+        str = sanitizeText(str);
         if (!str) return "";
         return str.replace(/&/g, "&amp;")
                   .replace(/</g, "&lt;")
                   .replace(/>/g, "&gt;")
                   .replace(/"/g, "&quot;");
+    }
+
+    // Assign log text as a text node rather than markup. escapeHtml is enough for
+    // correctness, but a text node cannot be reinterpreted as markup at all, which
+    // is the property worth having for content the page does not author.
+    function setText(el, text) {
+        if (!el) return;
+        text = sanitizeText(text);
+        while (el.firstChild) {
+            el.removeChild(el.firstChild);
+        }
+        el.appendChild(document.createTextNode(text));
+    }
+
+    // Cap what the viewer holds. The log endpoint is polled every few seconds and
+    // the oldest lines are the least interesting, so keep the tail.
+    function renderLogLines(lines) {
+        if (!lines) return "";
+        var text = sanitizeText(lines.join("\n"));
+        if (text.length > LOG_VIEW_MAX_CHARS) {
+            text = text.slice(text.length - LOG_VIEW_MAX_CHARS);
+        }
+        return text;
     }
 
     // ---- Toggle ----
@@ -503,7 +538,7 @@ var BTManager = (function() {
         window.scrollTo(0, 0);
         getEl("pairMessage").innerHTML = "Pairing...";
         getEl("pairAddr").innerHTML = escapeHtml(addr);
-        getEl("pairLogContent").innerHTML = "";
+        setText(getEl("pairLogContent"), "");
         getEl("pairOverlay").className = "pair-overlay visible";
         pollPairLogs();
 
@@ -569,7 +604,7 @@ var BTManager = (function() {
             if (!isPairing) return;
             if (data && data.lines) {
                 var viewer = getEl("pairLogContent");
-                viewer.innerHTML = escapeHtml(data.lines.join("\n"));
+                setText(viewer, renderLogLines(data.lines));
                 var container = viewer.parentNode;
                 container.scrollTop = container.scrollHeight;
             }
@@ -610,11 +645,11 @@ var BTManager = (function() {
     function fetchLogs() {
         request("/logs?lines=100", function(data, err) {
             if (err) {
-                getEl("logContent").innerHTML = "Error loading logs: " + escapeHtml(err);
+                setText(getEl("logContent"), "Error loading logs: " + err);
                 return;
             }
             if (data && data.lines) {
-                getEl("logContent").innerHTML = escapeHtml(data.lines.join("\n"));
+                setText(getEl("logContent"), renderLogLines(data.lines));
                 var viewer = getEl("logViewer");
                 viewer.scrollTop = viewer.scrollHeight;
             }


### PR DESCRIPTION
The log-sanitization fix from #101 — the one of the three you asked for that is still live.

The log and pairing views render daemon log lines straight into the page. `escapeHtml` neutralises `& < > "`, but log text also carries ANSI colour escapes and can carry C0/C1 control bytes, and neither is touched. Those corrupt the WebKit view this runs in.

What this does:

- Strips CSI sequences using the spec's parameter/intermediate/final byte ranges, so colon-separated SGR (`ESC[38:2:R:G:Bm`) and private parameters (`ESC[>0c`) are covered, not just the common `ESC[31m`.
- Strips C0, DEL and the C1 block, **keeping** tab, newline and carriage return so the log stays readable.
- Assigns log text through a text node instead of as markup. Escaping is sufficient for correctness — the text node is belt-and-braces, on the grounds that it cannot be reinterpreted as markup at all, for content the page does not author. The message bar was also taking `innerHTML` from an unescaped argument.
- `escapeHtml` sanitizes first, so the remaining `innerHTML` call sites that go through it benefit without changing.
- Caps the viewer at its last 6000 characters. To be straight about why: each poll replaces the content rather than appending, and `/logs` is already bounded server-side, so this is not fixing unbounded growth. It is a ceiling on how much text the view has to lay out on a slow e-ink device.

Verified against the built file: plain, colon-separated and private-parameter CSI sequences all removed; C0, DEL and the whole C1 block go; tab, newline, CR, `~`, NBSP and accented characters survive; null, undefined and numbers handled; the cap trims to 6000 keeping the tail; a realistic multi-line log sample comes through unchanged apart from its escapes; no log element is assigned `innerHTML` any more.

ES3/DOM-1 only, so it should be fine on WebKit 533 — no `textContent`, no `const`/arrow functions.

Deliberately left out: I also had a change tightening the `/logs` fetch bounds (fewer lines, larger read chunk) for responsiveness. That is a separate concern from sanitizing, so I have not bundled it. Happy to send it if you want it.
