### PR TITLE
fix(just): show pairing keys with the bundled interpreter, not python3

### DIFF
--- a/justfile
+++ b/justfile
@@ -126,7 +126,9 @@ edit-devices:
 
 # Show pairing keys
 keys:
-    @ssh {{host}} "cat {{remote_dir}}/cache/pairing_keys.json 2>/dev/null | python3 -m json.tool || echo 'No pairing keys'"
+    @ssh {{host}} "[ -f {{remote_dir}}/cache/pairing_keys.json ] \
+        && {{python}} -m json.tool {{remote_dir}}/cache/pairing_keys.json \
+        || echo 'No pairing keys'"
 
 # Print a read-only diagnostics dump for bug reports
 diagnostics:


### PR DESCRIPTION
Small one, found while working on the phone-as-keyboard branches in #101.

`just keys` pipes the keystore through `python3 -m json.tool`, but the Kindle has no `python3` on PATH — `command -v python3` finds nothing on a PW5. So the pipe always fails and the `||` branch reports **"No pairing keys"**, which is also what it prints for a genuinely empty keystore. The recipe gives a confidently wrong answer rather than an error, which is why it took a while to notice.

Switched to `{{python}}`, matching what `diagnostics`, `pair-classic`, `pair-ble` and `run` already use. Passing the file as an argument instead of piping also means a missing file is caught by the `[ -f ]` test rather than surfacing as a JSON parse error.

One honesty note on testing: I verified the fix against a real keystore with an equivalent invocation and it prints the parsed JSON where the old form printed "No pairing keys". I could **not** verify it with `{{python}}` resolving exactly as shipped, because my device has `python3.11-kindle` and that variable points at `python3.10-kindle`. That mismatch is a separate question from this fix and I've left it alone here.
