### PR TITLE
Keep the Kindle awake while a HID device is in use

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from bumble.core import InvalidStateError
 from bumble.hci import HCI_LE_SET_PRIVACY_MODE_COMMAND, HCI_LE_Set_Privacy_Mode_Command, HCI_Write_Class_Of_Device_Command, HCI_Write_Local_Name_Command
 
+import keep_awake
 from ble import BLEMixin
 from bt_setup import ensure_uhid
 from classic import ClassicMixin
@@ -339,6 +340,8 @@ class HIDHost(ClassicMixin, BLEMixin):
         if data != self._last_report:
             log.debug(f"Report: {data.hex()}")
             self._last_report = data
+            # Changed reports only, so a stick parked at rest can't pin the screen on.
+            keep_awake.on_activity()
         if self.uhid_device:
             try:
                 self.uhid_device.send_input(data)

--- a/kindle_hid_passthrough/keep_awake.py
+++ b/kindle_hid_passthrough/keep_awake.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Re-arm powerd's screensaver timer on HID input (issue #136).
+
+powerd only counts native input, so pages turned from a Bluetooth device
+look like an idle Kindle and the screensaver kicks in mid-read. Same poke
+KOReader's AutoSuspend uses, and it leaves the screensaver enabled so the
+power button still works.
+"""
+
+import subprocess
+import threading
+import time
+
+POKE = ['lipc-set-prop', '-i', 'com.lab126.powerd', 'touchScreenSaverTimeout', '1']
+INTERVAL = 240.0  # under powerd's 10 min t1 timeout
+
+_last_poke = None
+_lock = threading.Lock()
+
+
+def on_activity():
+    """Poke powerd, throttled. Safe to call from the report hot path."""
+    global _last_poke
+    now = time.monotonic()
+    with _lock:
+        if _last_poke is not None and now - _last_poke < INTERVAL:
+            return
+        _last_poke = now
+    threading.Thread(target=_poke, name='keep_awake', daemon=True).start()
+
+
+def _poke():
+    try:
+        subprocess.call(POKE, stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        pass


### PR DESCRIPTION
powerd's idle timer only counts native input, so turning pages from a Bluetooth remote leaves the Kindle looking idle and the screensaver kicks in mid-read. kindle-button-mapper has had this covered for a while, we never did.

The daemon now re-arms powerd's timer whenever a report comes in, using the same `lipc-set-prop touchScreenSaverTimeout 1` poke KOReader's AutoSuspend already uses on Kindle. Throttled to once every four minutes, which sits under powerd's 10 minute t1 timeout, and it only counts reports that actually changed so a gamepad parked at rest streaming an identical report can't pin the screen on forever. The poke runs on a throwaway thread so it never blocks the report path.

It re-arms the timer rather than setting `preventScreenSaver 1`, so the screensaver stays enabled and the power button still sleeps the device on demand. KOReader's own code notes that disabling the screensaver outright makes the t1 timeout misbehave.

Worth noting for anyone who lands here from the issue, nothing was needed on the KOReader plugin side. `autosuspend.koplugin` already makes this exact call every four minutes, and injected keys already reset its idle timer since the plugin hands the fd to `Device.input:fdopen()`. It just does nothing for people reading in the native framework, which is why this belongs in the daemon.

No config knob, it is on always.

Tested locally with a stubbed subprocess, 50 rapid reports collapse to a single poke and a second fires after the interval. Not yet verified against a live powerd, I could not reach the device. If you can give it a run, connect a remote and leave it sitting past the usual screensaver timeout while pressing a key every couple of minutes.

Fixes #136