### PR TITLE
fix(koplugin,install): adopt non-keyboard HID devices, install from any cwd

### DIFF
--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -175,16 +175,24 @@ local function getKeymapSettings()
     return keymap_settings
 end
 
+-- Declared above _attachInput, which fills it.
+local input_fds = {}
+
 -- KOReader drops EV_KEY events whose code isn't in event_map. Fill the gaps
 -- additively; re-applied on connect/disconnect since externalkeyboard swaps
 -- the whole map on attach and restores its snapshot on detach.
 function HIDPassthrough:_extendEventMap()
     local map = Device.input and Device.input.event_map
-    if not map then return end
+    if not map then
+        self._event_map_status = _("KOReader exposes no input event map")
+        return
+    end
 
-    local ok, extra = pcall(dofile, ffiutil.joinPath(self.path, "event_map_extra.lua"))
+    local path = ffiutil.joinPath(self.path, "event_map_extra.lua")
+    local ok, extra = pcall(dofile, path)
     if not ok or type(extra) ~= "table" then
         logger.warn("HIDPassthrough: could not load event_map_extra:", extra)
+        self._event_map_status = T(_("FAILED to load %1"), path)
         return
     end
 
@@ -195,20 +203,38 @@ function HIDPassthrough:_extendEventMap()
             added = added + 1
         end
     end
+    self._event_map_status = T(_("%1 extra key codes registered"), tostring(added))
     logger.dbg("HIDPassthrough: added", added, "extra key codes to the event map")
 end
 
 ------------------------------------------------------------------------------
--- Gamepad attach
+-- Key device attach
 ------------------------------------------------------------------------------
--- externalkeyboard only checks INPUT_KEYBOARD, so a gamepad (JOYSTICK to
--- FBInk) never gets opened. Buttons only, sticks and the hat are EV_ABS.
+-- externalkeyboard matches INPUT_KEYBOARD, which FBInk only sets when keycodes
+-- 1..31 are all present, so a remote or gamepad is opened by nobody.
 
-local joystick_fds = {}
+-- Lazy: the fbink_input cdef above is a pcall, so C.INPUT_* at module scope
+-- would take the plugin down when it isn't there.
+local exclude_types
+local function excludeTypes()
+    if not exclude_types then
+        exclude_types = bit.bor(
+            C.INPUT_KEYBOARD,
+            C.INPUT_TOUCHSCREEN,
+            C.INPUT_TABLET,
+            C.INPUT_SCALED_TABLET,
+            C.INPUT_ACCELEROMETER,
+            C.INPUT_ROTATION_EVENT,
+            C.INPUT_KINDLE_FRAME_TAP,
+            C.INPUT_POWER_BUTTON,
+            C.INPUT_SLEEP_COVER)
+    end
+    return exclude_types
+end
 
-local function checkJoystick(path)
+local function checkKeyDevice(path)
     local FBInkInput = ffi.loadlib("fbink_input", 1)
-    local dev = FBInkInput.fbink_input_check(path, C.INPUT_JOYSTICK, 0, 0)
+    local dev = FBInkInput.fbink_input_check(path, C.INPUT_KEY, excludeTypes(), 0)
     local info
     if dev ~= nil then
         if dev.matched then
@@ -223,47 +249,121 @@ local function checkJoystick(path)
     return info
 end
 
-function HIDPassthrough:_attachJoystick(path, force)
-    if joystick_fds[path] and not force then return end
-    local info = checkJoystick(path)
+function HIDPassthrough:_attachInput(path, force)
+    if input_fds[path] and not force then return end
+    if Device.input.opened_devices[path] and not input_fds[path] then return end
+
+    local info = checkKeyDevice(path)
     if not info then return end
 
     -- uhid recreates the node on reconnect; a stale fd makes the input poll
     -- fail with ENODEV and then nothing reaches any plugin.
-    if joystick_fds[info.path] then
+    if input_fds[info.path] then
         pcall(Device.input.close, Device.input, info.path)
-        joystick_fds[info.path] = nil
+        input_fds[info.path] = nil
     end
 
-    joystick_fds[info.path] = Device.input:fdopen(info.fd, info.path, info.name)
-    logger.info("HIDPassthrough: attached gamepad", info.name, "@", info.path)
-    -- Bindings may have been registered before the pad showed up.
+    input_fds[info.path] = Device.input:fdopen(info.fd, info.path, info.name)
+    logger.info("HIDPassthrough: attached input", info.name, "@", info.path)
+    -- Bindings may have been registered before the device showed up.
     self:_extendEventMap()
     self:registerKeyEvents()
 end
 
-function HIDPassthrough:_detachJoystick(path)
-    if not joystick_fds[path] then return end
+function HIDPassthrough:_detachInput(path)
+    if not input_fds[path] then return end
     Device.input:close(path)
-    joystick_fds[path] = nil
-    logger.info("HIDPassthrough: detached gamepad", path)
+    input_fds[path] = nil
+    logger.info("HIDPassthrough: detached input", path)
 end
 
-function HIDPassthrough:_scanJoysticks()
+function HIDPassthrough:_scanInputs()
     for name in lfs.dir("/dev/input") do
         if name:match("^event%d+$") then
-            self:_attachJoystick("/dev/input/" .. name)
+            self:_attachInput("/dev/input/" .. name)
         end
     end
 end
 
--- An insert is always a new device, so force the re-open.
+local type_names
+local function typeNames()
+    if not type_names then
+        type_names = {
+            { C.INPUT_POINTINGSTICK, "pointingstick" },
+            { C.INPUT_MOUSE, "mouse" },
+            { C.INPUT_TOUCHPAD, "touchpad" },
+            { C.INPUT_TOUCHSCREEN, "touchscreen" },
+            { C.INPUT_JOYSTICK, "joystick" },
+            { C.INPUT_TABLET, "tablet" },
+            { C.INPUT_KEY, "key" },
+            { C.INPUT_KEYBOARD, "keyboard" },
+            { C.INPUT_ACCELEROMETER, "accelerometer" },
+            { C.INPUT_DPAD, "dpad" },
+            { C.INPUT_VOLUME_BUTTONS, "volume" },
+        }
+    end
+    return type_names
+end
+
+local function describeInput(path)
+    local FBInkInput = ffi.loadlib("fbink_input", 1)
+    local dev = FBInkInput.fbink_input_check(path, C.INPUT_KEY, 0, C.SCAN_ONLY)
+    if dev == nil then return nil end
+    local name, dtype = ffi.string(dev.name), dev.type
+    C.free(dev)
+
+    local types = {}
+    for dummy, pair in ipairs(typeNames()) do -- luacheck: ignore dummy
+        if bit.band(dtype, pair[1]) ~= 0 then table.insert(types, pair[2]) end
+    end
+    return name, #types > 0 and table.concat(types, ",") or "unknown"
+end
+
+function HIDPassthrough:showInputDiagnostics()
+    local lines = {
+        T(_("Extra event map: %1"), self._event_map_status or _("not loaded")),
+        T(_("Plugin directory: %1"), tostring(self.path)),
+        "",
+        _("Input devices:"),
+    }
+
+    local paths = {}
+    for name in lfs.dir("/dev/input") do
+        if name:match("^event%d+$") then
+            table.insert(paths, "/dev/input/" .. name)
+        end
+    end
+    table.sort(paths)
+
+    for dummy, path in ipairs(paths) do -- luacheck: ignore dummy
+        local name, types = describeInput(path)
+        local owner
+        if input_fds[path] then
+            owner = _("open (this plugin)")
+        elseif Device.input.opened_devices[path] then
+            owner = _("open (KOReader)")
+        else
+            owner = _("NOT OPEN - keys are ignored")
+        end
+        table.insert(lines, T("%1  %2\n    [%3]  %4",
+            path, name or "?", types or "?", owner))
+    end
+
+    UIManager:show(TextViewer:new{
+        title = _("Input diagnostics"),
+        text = table.concat(lines, "\n"),
+        justified = false,
+    })
+end
+
+-- An insert is always a new device, so force the re-open. One second, not
+-- externalkeyboard's half, so a real keyboard reaches it first.
 function HIDPassthrough:onEvdevInputInsert(path)
-    UIManager:scheduleIn(0.5, function() self:_attachJoystick(path, true) end)
+    UIManager:scheduleIn(1, function() self:_attachInput(path, true) end)
 end
 
 function HIDPassthrough:onEvdevInputRemove(path)
-    UIManager:scheduleIn(0.5, function() self:_detachJoystick(path) end)
+    UIManager:scheduleIn(1, function() self:_detachInput(path) end)
 end
 
 function HIDPassthrough:registerKeyEvents()
@@ -290,7 +390,7 @@ end
 -- Overrides InputContainer's handler, which drops key_events outright.
 function HIDPassthrough:onPhysicalKeyboardDisconnected()
     self:_extendEventMap()
-    if Device:hasKeys() then
+    if Device:hasKeys() or next(input_fds) ~= nil then
         self:registerKeyEvents()
     else
         self.key_events = {}
@@ -1216,8 +1316,8 @@ function HIDPassthrough:init()
         table.insert(self.ui.active_widgets, self)
     end
     UIManager.event_hook:registerWidget("InputEvent", self)
-    -- A pad may already be connected.
-    self:_scanJoysticks()
+    -- A device may already be connected.
+    self:_scanInputs()
 end
 
 function HIDPassthrough:onCloseWidget()
@@ -1288,6 +1388,11 @@ function HIDPassthrough:addToMainMenu(menu_items)
                         text = _("Recent logs"),
                         keep_menu_open = true,
                         callback = function() self:showLogs() end,
+                    },
+                    {
+                        text = _("Input diagnostics"),
+                        keep_menu_open = true,
+                        callback = function() self:showInputDiagnostics() end,
                     },
                     {
                         text = _("Clear descriptor cache"),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,12 +2,23 @@
 
 INSTALL_DIR="/mnt/us/kindle_hid_passthrough"
 
-# True when the script is running from the install dir itself, so the
-# cp commands below would be a no-op (source == destination).
+SRC_DIR=$(cd "$(dirname "$0")/.." && pwd)
+
+# True when source == destination, so the cp commands below would be a no-op.
 in_install_dir()
 {
-  [ "$(cd "$(dirname "$0")/.." && pwd)" = "$INSTALL_DIR" ] || \
-    [ "$(pwd)" = "$INSTALL_DIR" ]
+  [ "$SRC_DIR" = "$INSTALL_DIR" ]
+}
+
+koreaderPluginDir()
+{
+  for base in /mnt/us/koreader /mnt/base-us/koreader; do
+    if [ -d "$base/plugins" ]; then
+      echo "$base/plugins"
+      return 0
+    fi
+  done
+  return 1
 }
 
 installMainFiles()
@@ -15,10 +26,11 @@ installMainFiles()
   echo " -> Installing main program files"
   mkdir -p "$INSTALL_DIR/dist" "$INSTALL_DIR/illusion/BTManager" "$INSTALL_DIR/cache"
   if ! in_install_dir; then
-    cp -r dist/* "$INSTALL_DIR/dist/"
-    cp kindle-hid-passthrough "$INSTALL_DIR/"
-    cp libsyscall_wrapper.so "$INSTALL_DIR/"
-    cp config.ini "$INSTALL_DIR/"
+    cp -r "$SRC_DIR/dist/"* "$INSTALL_DIR/dist/"
+    cp "$SRC_DIR/kindle-hid-passthrough" "$INSTALL_DIR/"
+    cp "$SRC_DIR/libsyscall_wrapper.so" "$INSTALL_DIR/"
+    cp "$SRC_DIR/config.ini" "$INSTALL_DIR/"
+    cp -r "$SRC_DIR/scripts" "$SRC_DIR/assets" "$INSTALL_DIR/"
   fi
   chmod +x "$INSTALL_DIR/kindle-hid-passthrough"
   echo " -> Ready."
@@ -32,8 +44,10 @@ installAll()
   installUpstart
   installMainFiles
   installWAFApp
-  if [ -d /mnt/us/koreader/plugins/ ]; then
-    installKOReaderPlugin
+  if ! installKOReaderPlugin; then
+    echo ""
+    echo "Install finished WITH ERRORS: the KOReader plugin was not installed."
+    return 1
   fi
   echo ""
   echo "Installation complete. Open 'BT Manager' from the Kindle library."
@@ -43,7 +57,7 @@ installUdevRules()
 {
   echo " -> Installing udev rules"
   /usr/sbin/mntroot rw
-  cp assets/99-hid-keyboard.rules /etc/udev/rules.d
+  cp "$SRC_DIR/assets/99-hid-keyboard.rules" /etc/udev/rules.d
   /usr/sbin/udevadm control --reload-rules
   /usr/sbin/mntroot ro
   echo " -> Ready."
@@ -53,19 +67,19 @@ installUpstart()
 {
   echo " -> Installing upstart service"
   /usr/sbin/mntroot rw
-  cp assets/hid-passthrough.upstart /etc/upstart/hid-passthrough.conf
+  cp "$SRC_DIR/assets/hid-passthrough.upstart" /etc/upstart/hid-passthrough.conf
   /usr/sbin/mntroot ro
   echo " -> Ready."
 }
 
 pairDevice()
 {
-  ./kindle-hid-passthrough --pair 2>&1 | grep -v "libenvload.so"
+  (cd "$INSTALL_DIR" && ./kindle-hid-passthrough --pair 2>&1 | grep -v "libenvload.so")
 }
 
 listDevices()
 {
-  cat devices.conf
+  cat "$INSTALL_DIR/devices.conf"
 }
 
 installWAFApp()
@@ -73,9 +87,9 @@ installWAFApp()
   echo " -> Installing BTManager app"
   if ! in_install_dir; then
     mkdir -p "$INSTALL_DIR/illusion/BTManager"
-    cp -r illusion/BTManager/* "$INSTALL_DIR/illusion/BTManager/"
-    cp illusion/BTManager.sh "$INSTALL_DIR/illusion/BTManager.sh"
-    cp illusion/install-waf-app.sh "$INSTALL_DIR/illusion/install-waf-app.sh"
+    cp -r "$SRC_DIR/illusion/BTManager/"* "$INSTALL_DIR/illusion/BTManager/"
+    cp "$SRC_DIR/illusion/BTManager.sh" "$INSTALL_DIR/illusion/BTManager.sh"
+    cp "$SRC_DIR/illusion/install-waf-app.sh" "$INSTALL_DIR/illusion/install-waf-app.sh"
   fi
   if [ -f "$INSTALL_DIR/illusion/install-waf-app.sh" ]; then
     /bin/sh "$INSTALL_DIR/illusion/install-waf-app.sh"
@@ -86,14 +100,32 @@ installWAFApp()
 
 installKOReaderPlugin()
 {
-  if [ ! -d /mnt/us/koreader/plugins/ ]; then
+  PLUGINS_DIR=$(koreaderPluginDir) || {
     echo " -> KOReader not found, skipping plugin install"
-    return
+    return 0
+  }
+  SRC_PLUGIN="$SRC_DIR/koreader-plugin/hidpassthrough.koplugin"
+  if [ ! -f "$SRC_PLUGIN/main.lua" ]; then
+    echo "ERROR: plugin source not found at $SRC_PLUGIN" >&2
+    echo "       Run this script from the extracted release, not a partial copy." >&2
+    return 1
   fi
-  echo " -> Installing KOReader plugin"
-  rm -rf /mnt/us/koreader/plugins/hidpassthrough.koplugin
-  cp -r koreader-plugin/hidpassthrough.koplugin /mnt/us/koreader/plugins/hidpassthrough.koplugin
-  echo " -> Ready."
+
+  echo " -> Installing KOReader plugin into $PLUGINS_DIR"
+  DEST="$PLUGINS_DIR/hidpassthrough.koplugin"
+  rm -rf "$DEST"
+  if ! cp -r "$SRC_PLUGIN" "$DEST"; then
+    echo "ERROR: failed to copy the plugin to $DEST" >&2
+    return 1
+  fi
+
+  for f in main.lua _meta.lua event_map_extra.lua; do
+    if [ ! -f "$DEST/$f" ]; then
+      echo "ERROR: $f is missing from $DEST" >&2
+      return 1
+    fi
+  done
+  echo " -> Ready. Restart KOReader to load it."
 }
 
 uninstallAll()
@@ -168,13 +200,13 @@ print_menu()
 # Non-interactive entry point: `sh install.sh <action>` runs one action and exits.
 if [ $# -gt 0 ]; then
   case "$1" in
-    installAll)         installAll; exit 0 ;;
-    installUdevRules)   installUdevRules; exit 0 ;;
-    installUpstart)     installUpstart; exit 0 ;;
-    installMainFiles)   installMainFiles; exit 0 ;;
-    installWAFApp)      installWAFApp; exit 0 ;;
-    installKOReaderPlugin) installKOReaderPlugin; exit 0 ;;
-    uninstallAll)       uninstallAll; exit 0 ;;
+    installAll)         installAll; exit $? ;;
+    installUdevRules)   installUdevRules; exit $? ;;
+    installUpstart)     installUpstart; exit $? ;;
+    installMainFiles)   installMainFiles; exit $? ;;
+    installWAFApp)      installWAFApp; exit $? ;;
+    installKOReaderPlugin) installKOReaderPlugin; exit $? ;;
+    uninstallAll)       uninstallAll; exit $? ;;
     *) echo "Unknown action: $1" >&2; exit 1 ;;
   esac
 fi


### PR DESCRIPTION
Fixes #135.

The three symptoms in the issue are one failure plus its knock-on effects.

## The installer never installed the plugin

`installKOReaderPlugin` copied from the relative path `koreader-plugin/hidpassthrough.koplugin`, resolved against the caller's working directory rather than the extracted release. Run it as `sh /mnt/us/kindle_hid_passthrough/scripts/install.sh` from anywhere else and the copy fails, and it had already run `rm -rf` on the destination.

Reproduced on a PW12 with the v3.11.0 script:

```
$ cd / && sh /tmp/old_install.sh installKOReaderPlugin
 -> Installing KOReader plugin
 -> Ready.
exit=0
--- plugin dir after the v3.11.0 installer ---
total 16
drwxrwxrwx    2 root     root          8192 Jul 30 19:56 .
drwxrwxrwx   45 root     root          8192 Jul 30 19:56 ..
```

An empty directory, reported as success. That is symptom 1, and symptom 2 follows from it: `event_map_extra.lua` does ship in the release tarball, it just never got copied, and putting it in `koreader/settings/` does not help because the plugin loads it from its own directory.

`installUdevRules` and `installUpstart` had the same working-directory dependency. Everything now copies out of the tree the script lives in, the plugin source is checked before the destination is removed, the three plugin files are verified afterwards, and failures reach the exit status. `scripts/` and `assets/` are copied into the install dir too, since the udev rule references `dev_is_keyboard.sh` there and nothing was putting it in place for an out-of-tree install.

## Nothing ever opened the remote

This is the real cause of symptom 3. KOReader's `externalkeyboard` calls `fbink_input_check(path, INPUT_KEYBOARD, 0, 0)`, and FBInk only sets `INPUT_KEYBOARD` when *every* keycode from 1 to 31 is present (Esc, the number row, Q through D):

```c
/* the first 32 bits are ESC, numbers, and Q to D;
 * if we have all of those, consider it a full keyboard */
unsigned long mask = 0xFFFFFFFE;
if ((bitmask_key[0] & mask) == mask) {
        dev->type |= INPUT_KEYBOARD;
}
```

A media remote has none of them, so `externalkeyboard` logs "doesn't look like a keyboard" and closes the fd. This plugin only picked up `INPUT_JOYSTICK`, which FBInk gates behind `ABS_X && ABS_Y` anyway. Nobody held the device open, so no press ever became an event. The capture modal was correct; it genuinely received nothing.

We now take `INPUT_KEY` instead, excluding keyboards, touchscreens, tablets, accelerometers, the Kindle frame-tap node and the power button, and skipping anything already in `Input.opened_devices`. Hotplug waits a second rather than half of one so `externalkeyboard` still gets first claim on real keyboards.

## The event map was empty for those devices

`externalkeyboard` merges KOReader's keyboard event map only once it has adopted a keyboard of its own, and a PW12's stock map is two page-turn codes. So even after opening the remote, Enter, the arrows and the volume keys would still have been unmapped. We now merge it for devices we hold.

## Testing

On a PW12 (KOReader 2026.07), a consumer-control-only uinput device synthesized to match the reporter's remote (KEY_VOLUMEDOWN/UP, PREVIOUSSONG, PLAYPAUSE, NEXTSONG, HOMEPAGE, BACK, and nothing below 114):

```
/dev/input/event0  bd71828-pwrkey         type=0x10040   [key,power]
    ek_adopts=false  we_adopt=false
/dev/input/event1  goodix-ts              type=0x10048   [touchscreen,key,power]
    ek_adopts=false  we_adopt=false
/dev/input/event2  kindle-button-mapper   type=0x26d00c0 [key,keyboard,dpad,volume,power,pagination,home,menu]
    ek_adopts=true   we_adopt=false
/dev/input/event3  E2 Control (fake)      type=0x2000040 [key,volume]
    ek_adopts=false  we_adopt=true
```

The remote is adopted, and the three built-in nodes are untouched, including the full uinput keyboard that `externalkeyboard` correctly keeps.

Event map merge, on-device, against the PW12 stock map:

```
base keyboard map: ok=true type=table entries=101
extra map: ok=true type=table entries=124
merged: 99 keyboard + 124 extra
  code 114 -> VMinus      code 164 -> PlayPause    code 183 -> F13
  code 115 -> VPlus       code 165 -> PreviousSong code 304 -> BtnA
  code 163 -> NextSong    code 172 -> Homepage     code  28 -> Press
stock keys preserved: 104=LPgBack 109=LPgFwd
```

Also: the fixed installer verified from `/` on the device and in a sandbox for the partial-copy and KOReader-absent cases; `main.lua` compiles under the device's LuaJIT; luacheck reports no new warnings.

## Also

Adds **Debug -> Input diagnostics**, listing every `/dev/input/event*` node, its FBInk classification, and whether anything holds it open, so the next report of this shape answers itself.