### PR TITLE
Add a close action to the KOReader plugin

### DIFF
--- a/koreader-plugin/README.md
+++ b/koreader-plugin/README.md
@@ -30,7 +30,7 @@ Tap "Add a key…", press the key you want to bind, then pick an action for it. 
   <img src="screenshots/key-actions.png" width="48%" alt="Choosing an action">
 </p>
 
-The action list opens on a short block of common ones — next/previous page, frontlight, night mode, menu, table of contents, bookmarks, rotate, back — because the full list runs to seven pages and the everyday bindings shouldn't need a hunt. Everything else is underneath, grouped exactly as KOReader groups it for gestures and profiles: anything you can bind to a gesture you can bind to a key.
+The action list opens on a short block of common ones — next/previous page, close, frontlight, night mode, menu, table of contents, bookmarks, rotate, back — because the full list runs to seven pages and the everyday bindings shouldn't need a hunt. Everything else is underneath, grouped exactly as KOReader groups it for gestures and profiles: anything you can bind to a gesture you can bind to a key.
 
 To drop a mapping, hold its row in the list, or use "Remove this key" at the bottom of that key's action list.
 

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -132,6 +132,7 @@ local MOD_ORDER = { "Shift", "Ctrl", "Alt", "Meta", "Sym", "ScreenKB" }
 local COMMON_ACTIONS = {
     "hidpassthrough_next_page",
     "hidpassthrough_prev_page",
+    "hidpassthrough_close",
     "toggle_frontlight",
     "night_mode",
     "show_menu",
@@ -1116,6 +1117,39 @@ function HIDPassthrough:onDispatcherRegisterActions()
         title    = _("Previous page"),
         reader   = true,
     })
+
+    Dispatcher:registerAction("hidpassthrough_close", {
+        category = "none",
+        event    = "HIDPassthroughClose",
+        title    = _("Close menu or dialog"),
+        general  = true,
+    })
+end
+
+-- Stops one short of ReaderUI/FileManager, whose onClose exits the book.
+function HIDPassthrough:onHIDPassthroughClose()
+    local target, reached_base
+    for widget in UIManager:topdown_widgets_iter() do
+        if widget == self.ui then
+            reached_base = true
+            break
+        end
+        if not target and not widget.toast and not widget.invisible then
+            target = widget
+        end
+    end
+    if not target or not reached_base then return true end
+
+    -- Deferred: we're inside UIManager's walk down the stack we're mutating.
+    UIManager:nextTick(function()
+        if not UIManager:isWidgetShown(target) then return end
+        if target.onClose then
+            target:onClose()
+        else
+            UIManager:close(target)
+        end
+    end)
+    return true
 end
 
 -- start() can block up to 15s, so toast now and do the work next tick.
@@ -1133,12 +1167,15 @@ function HIDPassthrough:_runActionAsync(label, fn)
     end)
 end
 
+-- true, or UIManager hands these to us again as an active widget.
 function HIDPassthrough:onHIDPassthroughStart()
     self:_runActionAsync(_("Starting HID Passthrough daemon…"), self.start)
+    return true
 end
 
 function HIDPassthrough:onHIDPassthroughStop()
     self:_runActionAsync(_("Stopping HID Passthrough daemon…"), self.stop)
+    return true
 end
 
 function HIDPassthrough:onHIDPassthroughToggle()
@@ -1146,6 +1183,7 @@ function HIDPassthrough:onHIDPassthroughToggle()
         and _("Stopping HID Passthrough daemon…")
         or  _("Starting HID Passthrough daemon…")
     self:_runActionAsync(label, self.toggle)
+    return true
 end
 
 function HIDPassthrough:init()
@@ -1153,6 +1191,10 @@ function HIDPassthrough:init()
     self.ui.menu:registerToMainMenu(self)
     self:_extendEventMap()
     self:registerKeyEvents()
+    -- Or no binding fires while a menu covers us. Same trick as Screenshoter.
+    if self.ui.active_widgets then
+        table.insert(self.ui.active_widgets, self)
+    end
     -- A pad may already be connected.
     self:_scanJoysticks()
 end


### PR DESCRIPTION
Closes #137.

Adds a "Close menu or dialog" action, right under next/previous page in the shortcut block at the top of the action list. It walks the window stack top-down and dismisses the first real widget, calling its `onClose` where it has one. It stops one short of ReaderUI/FileManager, whose `onClose` exits the book or KOReader itself, and skips toasts so a stray notification doesn't eat the press.

That alone does nothing, though, which is the more interesting half. `UIManager:sendEvent` hands an event to the topmost widget and afterwards only revisits widgets registered as active or flagged `is_always_active`. A plugin is an ordinary child of ReaderUI, so with a menu open *no* binding fires at all — you could open the bottom menu with a key and then nothing you pressed did anything. Registering ourselves in `ui.active_widgets` is the same mechanism Screenshoter uses to keep working over a dialog. Side effect worth knowing, every binding now stays live over menus, not just close. Start/stop/toggle return true now, or UIManager runs them twice.

Tested on a Basic 5 with a uinput keyboard KOReader adopted, key bound to the new action:

- reader with the bottom config menu open, closes, book stays open
- reader with reading statistics open, closes, book stays open
- file browser with the main menu open, closes
- FrontLightWidget, an `is_always_active` one, closes
- nothing open, no-op, KOReader stays alive