### PR TITLE
docs: add community video guide to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Kernels without UHID support are handled automatically: the daemon loads a bundl
 
 ### Video guide
 
-Community walkthrough by [@jencaps89](https://www.tiktok.com/@jencaps89) showing the whole setup as a Bluetooth page turner, [watch it on TikTok](https://www.tiktok.com/@jencaps89/video/7658167614736223496) or through the [embedded player](https://www.tiktok.com/player/v1/7658167614736223496) if you'd rather not log in. Made by the community rather than by me, so it can drift from the current release.
+Community walkthrough by [@jencaps89](https://www.tiktok.com/@jencaps89) showing the whole setup as a Bluetooth page turner, [watch it on TikTok](https://www.tiktok.com/@jencaps89/video/7658167614736223496) or through the [embedded player](https://www.tiktok.com/player/v1/7658167614736223496) if you'd rather not log in.
 
 ### KindleForge (recommended)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Kernels without UHID support are handled automatically: the daemon loads a bundl
 
 ## Installation
 
+### Video guide
+
+Community walkthrough by [@jencaps89](https://www.tiktok.com/@jencaps89) showing the whole setup as a Bluetooth page turner, [watch it on TikTok](https://www.tiktok.com/@jencaps89/video/7658167614736223496) or through the [embedded player](https://www.tiktok.com/player/v1/7658167614736223496) if you'd rather not log in. Made by the community rather than by me, so it can drift from the current release.
+
 ### KindleForge (recommended)
 
 Install directly from [KindleForge](https://github.com/KindleTweaks/KindleForge) — search for "Kindle HID Passthrough" in the on-device app store.


### PR DESCRIPTION
@jencaps89 made a TikTok walkthrough of the full page turner setup and linked the repo in it, so adding it to the README under Installation.

Credited as a community guide rather than official docs, since it can drift as the install flow changes. Also included TikTok's embed player URL as a second link, it plays without an account. The other frontends I checked are dead, vxtiktok is gone on a legal request and tnktok just bounces browsers back to tiktok.com.

Docs only, nothing to test beyond clicking the two links.