### PR TITLE
Drop the auto-suspend setting gate on the t1 reset

### DIFF
--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -1189,14 +1189,12 @@ function HIDPassthrough:onHIDPassthroughToggle()
     return true
 end
 
--- AutoSuspend stops re-arming powerd's t1 timeout when auto-suspend is off (#136).
+-- AutoSuspend is the only thing re-arming powerd's t1 timeout, and it can be off (#136).
 local T1_RESET_INTERVAL = 4 * 60
 local last_t1_reset = nil
 
 function HIDPassthrough:onInputEvent()
-    if not PowerD.resetT1Timeout then return end
-    local auto_suspend = G_reader_settings:readSetting("auto_suspend_timeout_seconds")
-    if auto_suspend == nil or auto_suspend > 0 or PluginShare.keepalive then return end
+    if not PowerD.resetT1Timeout or PluginShare.keepalive then return end
     if PowerD:isCharging() and not PowerD:isCharged() then return end
 
     local now = UIManager:getElapsedTimeSinceBoot()


### PR DESCRIPTION
Follow-up to #140. `auto_suspend_timeout_seconds` is not a reliable proxy for
AutoSuspend actually running. The plugin can sit in `plugins_disabled` with the
timeout left at its 15 minute default, and then nothing re-arms t1 while we no-op
for exactly the reason we exist.

So it always re-arms now, still throttled to 4 minutes. When AutoSuspend is up that
costs one duplicate lipc call every 4 minutes and it is idempotent.

This is the variant that was verified on device. The gate slipped into #140 because
the amend that removed it only rewrote the commit message.

Refs #136