### PR TITLE
fix(koplugin): adopt a keyboard externalkeyboard raced and dropped

### DIFF
--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -211,7 +211,9 @@ end
 -- Key device attach
 ------------------------------------------------------------------------------
 -- externalkeyboard matches INPUT_KEYBOARD, which FBInk only sets when keycodes
--- 1..31 are all present, so a remote or gamepad is opened by nobody.
+-- 1..31 are all present, so a remote or gamepad is opened by nobody. Keyboards
+-- are skipped by ownership below, not by type: externalkeyboard checks 0.5s
+-- after the uevent and declines outright if the node isn't there yet.
 
 -- Lazy: the fbink_input cdef above is a pcall, so C.INPUT_* at module scope
 -- would take the plugin down when it isn't there.
@@ -219,7 +221,6 @@ local exclude_types
 local function excludeTypes()
     if not exclude_types then
         exclude_types = bit.bor(
-            C.INPUT_KEYBOARD,
             C.INPUT_TOUCHSCREEN,
             C.INPUT_TABLET,
             C.INPUT_SCALED_TABLET,


### PR DESCRIPTION
Found while diagnosing why a BT keyboard cannot be mapped after a reconnect. Captured on a PW12 with debug logging on:

```
20:38:46  key event => code: 10040 (UsbDevicePlugIn), value: 3
20:38:47  [FBInk] [fbink_input_check] open `/dev/input/event3`: No such file or directory!
20:38:47  ExternalKeyboard:setupKeyboard: /dev/input/event3 doesn't look like a keyboard
20:38:48  [FBInk] /dev/input/event3: `BT Keyboard` = MOUSE|KEY|KEYBOARD|POWER_BUTTON|...
```

`externalkeyboard` schedules its check 0.5s after the uevent. On this device the `/dev/input/eventN` node does not exist yet at that point, `fbink_input_check` fails to open it, and the plugin declines the device permanently. It only retries on the next insert event.

We check at 1s. By then the node exists and FBInk reports `KEYBOARD`, so my exclude mask from #139 dropped it as well. Result: `/dev/input/event3` open by nobody.

```
$ ls -l /proc/<koreader>/fd | grep event
10 -> /dev/input/event2     # kindle-button-mapper
11 -> /dev/input/event4     # test device
9  -> /dev/input/event1     # touchscreen
                            # event3, the BT keyboard, is absent
```

That matches the symptom exactly: the keyboard types fine right after a KOReader start, because the startup scan sees a node that already exists and adopts it, and it is dead after any disconnect and reconnect.

Excluding keyboards by classification was the wrong test. The real question is ownership, and `_attachInput` already answers it one line earlier:

```lua
if Device.input.opened_devices[path] and not input_fds[path] then return end
```

So `INPUT_KEYBOARD` comes out of the mask. If `externalkeyboard` holds the device we still return early and it keeps it; if it lost the race, we take it instead of leaving it unowned. Our check runs after theirs (1s against 0.5s, and their init scan runs before ours alphabetically), so their decision is always already made when we look.

## Verified

The diagnosis is hardware-confirmed on a PW12, including that the capture dialog itself works correctly for an `externalkeyboard`-adopted keyboard (instrumented `KeyCapture:onKeyPress` fires). The fix itself is **not** yet confirmed on hardware; the device went unreachable before I could redeploy. Reproducing needs a real BT keyboard disconnect and reconnect, which the synthetic uinput devices I was testing with do not exhibit, since their nodes appear synchronously.

## Known gap

If `externalkeyboard` loses this race on a device where it holds no other keyboard, we now adopt the keyboard but its scancodes are not in `Device.input.event_map`, because `externalkeyboard` merges that map only for devices it adopted itself and a PW12 ships two page-turn codes. The keys would reach KOReader and still do nothing. That is the case the bundled keyboard map would have covered. Worth deciding separately.