### PR TITLE
fix(install,waf): update an existing install without uninstalling first

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,32 @@ Install directly from [KindleForge](https://github.com/KindleTweaks/KindleForge)
 
 ### Manual install
 
-1. Download the latest release from [GitHub Releases](https://github.com/zampierilucas/kindle-hid-passthrough/releases):
+1. Download the latest release from [GitHub Releases](https://github.com/zampierilucas/kindle-hid-passthrough/releases) and unpack it somewhere other than the install directory:
    ```bash
    wget https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest/download/kindle-hid-passthrough-armv7.tar.gz
-   tar -xzf kindle-hid-passthrough-armv7.tar.gz -C /mnt/us/kindle_hid_passthrough/
+   mkdir -p /mnt/us/khp-release
+   tar -xzf kindle-hid-passthrough-armv7.tar.gz -C /mnt/us/khp-release
    ```
 
    The release contains a `dist/` directory with a bundled Python runtime and all dependencies — no Python installation required on the Kindle.
 
 2. Run the interactive installer:
    ```bash
-   cd /mnt/us/kindle_hid_passthrough
-   sh scripts/install.sh
+   sh /mnt/us/khp-release/scripts/install.sh
    ```
 
    This lets you pair devices, install udev rules, set up autostart, install the BTManager app, and set keyboard layouts.
+
+### Updating
+
+Same two steps, option 1 handles both cases. It notices an existing install, stops the daemon, replaces the program files and leaves your `config.ini`, paired devices and pairing keys alone. A new default config is written to `config.ini.new` so you can diff it against yours. There is no need to uninstall first.
+
+Non-interactive, for scripts:
+```bash
+sh /mnt/us/khp-release/scripts/install.sh update
+```
+
+Unpacking to a staging directory is preferred because it lets the installer replace the program files wholesale, so anything dropped between releases goes with them. If you unpack straight over `/mnt/us/kindle_hid_passthrough` instead, stop the daemon first with `stop hid-passthrough`. A running daemon holds `dist/ld-linux-armhf.so.3` open, tar stops at that file, and the update is left half applied.
 
 ### BTManager
 

--- a/illusion/BTManager.sh
+++ b/illusion/BTManager.sh
@@ -31,12 +31,11 @@ alert() {
 install_waf() {
     log_msg "Installing BTManager WAF"
 
-    # Register in appreg.db if not already registered
+    # Rewritten every launch so an update that moves the app or changes the
+    # command line takes effect without a reinstall.
     if [ -f "$APPREG_DB" ]; then
-        existing=$(sqlite3 "$APPREG_DB" "SELECT handlerId FROM handlerIds WHERE handlerId='$APP_ID';" 2>/dev/null)
-        if [ -z "$existing" ]; then
-            log_msg "Registering $APP_ID in appreg.db"
-            sqlite3 "$APPREG_DB" <<EOF
+        log_msg "Registering $APP_ID in appreg.db"
+        sqlite3 "$APPREG_DB" <<EOF
 INSERT OR IGNORE INTO interfaces (interface) VALUES ('application');
 INSERT OR IGNORE INTO handlerIds (handlerId) VALUES ('$APP_ID');
 INSERT OR IGNORE INTO associations (handlerId, interface, contentId, defaultAssoc)
@@ -48,10 +47,7 @@ INSERT OR REPLACE INTO properties (handlerId, name, value)
 INSERT OR REPLACE INTO properties (handlerId, name, value)
     VALUES ('$APP_ID', 'supportedOrientation', 'U');
 EOF
-            log_msg "Registration complete"
-        else
-            log_msg "$APP_ID already registered"
-        fi
+        log_msg "Registration complete"
     fi
 }
 

--- a/illusion/install-waf-app.sh
+++ b/illusion/install-waf-app.sh
@@ -50,9 +50,9 @@ echo "   Done"
 
 echo "3. Registering app..."
 if [ -f "$APPREG_DB" ]; then
-    existing=$(sqlite3 "$APPREG_DB" "SELECT handlerId FROM handlerIds WHERE handlerId='$APP_ID';" 2>/dev/null)
-    if [ -z "$existing" ]; then
-        sqlite3 "$APPREG_DB" <<EOF
+    # Rewritten every time, an existing registration can still be pointing at a
+    # stale command or app path after an update.
+    sqlite3 "$APPREG_DB" <<EOF
 INSERT OR IGNORE INTO interfaces (interface) VALUES ('application');
 INSERT OR IGNORE INTO handlerIds (handlerId) VALUES ('$APP_ID');
 INSERT OR IGNORE INTO associations (handlerId, interface, contentId, defaultAssoc)
@@ -64,10 +64,7 @@ INSERT OR REPLACE INTO properties (handlerId, name, value)
 INSERT OR REPLACE INTO properties (handlerId, name, value)
     VALUES ('$APP_ID', 'supportedOrientation', 'U');
 EOF
-        echo "   Registered $APP_ID in appreg.db"
-    else
-        echo "   Already registered"
-    fi
+    echo "   Registered $APP_ID in appreg.db"
 else
     echo "   WARNING: appreg.db not found at $APPREG_DB"
 fi
@@ -83,11 +80,17 @@ echo "   Installed to $SCRIPTLET_DEST"
 
 echo "5. Starting daemon..."
 # Stop existing instances
+/sbin/stop hid-passthrough 2>/dev/null
 pkill -f "ld-linux-armhf." 2>/dev/null
 sleep 1
-"$BINARY" --daemon >/dev/null 2>&1 &
-sleep 1
-echo "   Daemon started"
+if [ -f /etc/upstart/hid-passthrough.conf ] && \
+   /sbin/start hid-passthrough >/dev/null 2>&1; then
+    echo "   Daemon started via upstart"
+else
+    "$BINARY" --daemon >/dev/null 2>&1 &
+    sleep 1
+    echo "   Daemon started"
+fi
 
 echo ""
 echo "=== Installation Complete ==="

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,80 @@
 #!/bin/sh
 
 INSTALL_DIR="/mnt/us/kindle_hid_passthrough"
+APP_ID="com.lzampier.btmanager"
+APPREG_DB="/var/local/appreg.db"
+SCRIPTLET_DEST="/mnt/us/documents/BTManager.sh"
 
 SRC_DIR=$(cd "$(dirname "$0")/.." && pwd)
 
-# True when source == destination, so the cp commands below would be a no-op.
+# True when the tree is already sitting at its destination, so the copies below
+# would be a no-op. Probe with a sentinel instead of comparing path strings,
+# /mnt/us is case-insensitive and also reachable through the /mnt/base-us alias
+# mount, and a false negative here would delete the source before copying it.
+SAME_DIR=0
+SENTINEL=".khp-install-probe.$$"
+mkdir -p "$INSTALL_DIR" 2>/dev/null
+if : > "$INSTALL_DIR/$SENTINEL" 2>/dev/null; then
+  [ -e "$SRC_DIR/$SENTINEL" ] && SAME_DIR=1
+  rm -f "$INSTALL_DIR/$SENTINEL"
+fi
+
 in_install_dir()
 {
-  [ "$SRC_DIR" = "$INSTALL_DIR" ]
+  [ "$SAME_DIR" = 1 ]
+}
+
+daemonRunning()
+{
+  pgrep -f "ld-linux-armhf." >/dev/null 2>&1 || \
+    pgrep -f "main.py --daemon" >/dev/null 2>&1
+}
+
+stopDaemon()
+{
+  echo " -> Stopping daemon"
+  lipc-set-prop com.lab126.appmgrd start app://com.lab126.booklet.home 2>/dev/null
+  /sbin/stop hid-passthrough 2>/dev/null
+  pkill -f "kindle-hid-passthrough" 2>/dev/null
+  pkill -f "main.py --daemon" 2>/dev/null
+  pkill -f "ld-linux-armhf." 2>/dev/null
+
+  # dist/ld-linux-armhf.so.3 stays busy while the loader runs, and writing to a
+  # busy binary fails with ETXTBSY, so wait for it to go before copying over it.
+  i=0
+  while [ "$i" -lt 15 ]; do
+    daemonRunning || return 0
+    sleep 1
+    i=$((i + 1))
+  done
+  echo " -> WARNING: daemon is still running, files may not update cleanly"
+}
+
+startDaemon()
+{
+  daemonRunning && return 0
+  echo " -> Starting daemon"
+  if [ -f /etc/upstart/hid-passthrough.conf ] && \
+     /sbin/start hid-passthrough >/dev/null 2>&1; then
+    return 0
+  fi
+  (cd "$INSTALL_DIR" && ./kindle-hid-passthrough --daemon >/dev/null 2>&1 &)
+}
+
+# mesquite caches the app's html and js, without this the UI stays on the old version.
+clearWafCache()
+{
+  rm -rf "/var/local/mesquite/$APP_ID" /var/local/mesquite/BTManager 2>/dev/null
+}
+
+# Files that shipped in earlier releases and would otherwise be left behind when
+# the release is unpacked straight over the install dir.
+removeStaleFiles()
+{
+  rm -f "$INSTALL_DIR/scripts/setlayout.sh" \
+        "$INSTALL_DIR/assets/menu_setlayout.json" \
+        "$INSTALL_DIR/koreader-plugin/hidpassthrough.koplugin/event_map_keyboard.lua" \
+        /usr/local/bin/dev_is_keyboard.sh 2>/dev/null
 }
 
 koreaderPluginDir()
@@ -24,14 +91,41 @@ koreaderPluginDir()
 installMainFiles()
 {
   echo " -> Installing main program files"
-  mkdir -p "$INSTALL_DIR/dist" "$INSTALL_DIR/illusion/BTManager" "$INSTALL_DIR/cache"
-  if ! in_install_dir; then
-    cp -r "$SRC_DIR/dist/"* "$INSTALL_DIR/dist/"
-    cp "$SRC_DIR/kindle-hid-passthrough" "$INSTALL_DIR/"
-    cp "$SRC_DIR/libsyscall_wrapper.so" "$INSTALL_DIR/"
-    cp "$SRC_DIR/config.ini" "$INSTALL_DIR/"
-    cp -r "$SRC_DIR/scripts" "$SRC_DIR/assets" "$INSTALL_DIR/"
+  mkdir -p "$INSTALL_DIR/cache"
+  if in_install_dir; then
+    removeStaleFiles
+    chmod +x "$INSTALL_DIR/kindle-hid-passthrough"
+    echo " -> Ready."
+    return 0
   fi
+
+  if [ ! -f "$SRC_DIR/dist/main.bin" ]; then
+    echo "ERROR: release files not found at $SRC_DIR" >&2
+    echo "       Run this script from the extracted release, not a partial copy." >&2
+    return 1
+  fi
+
+  # Replaced outright rather than merged, files dropped between releases would
+  # otherwise linger and still get loaded.
+  rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/scripts" "$INSTALL_DIR/assets" \
+         "$INSTALL_DIR/koreader-plugin"
+  mkdir -p "$INSTALL_DIR/dist"
+  cp -r "$SRC_DIR/dist/"* "$INSTALL_DIR/dist/"
+  cp -r "$SRC_DIR/scripts" "$SRC_DIR/assets" "$INSTALL_DIR/"
+  if [ -d "$SRC_DIR/koreader-plugin" ]; then
+    cp -r "$SRC_DIR/koreader-plugin" "$INSTALL_DIR/"
+  fi
+  cp "$SRC_DIR/kindle-hid-passthrough" "$INSTALL_DIR/"
+  cp "$SRC_DIR/libsyscall_wrapper.so" "$INSTALL_DIR/"
+
+  if [ -f "$INSTALL_DIR/config.ini" ]; then
+    cp "$SRC_DIR/config.ini" "$INSTALL_DIR/config.ini.new"
+    echo " -> Kept your config.ini, new defaults written to config.ini.new"
+  else
+    cp "$SRC_DIR/config.ini" "$INSTALL_DIR/"
+  fi
+
+  removeStaleFiles
   chmod +x "$INSTALL_DIR/kindle-hid-passthrough"
   echo " -> Ready."
 }
@@ -39,16 +133,30 @@ installMainFiles()
 installAll()
 {
   echo ""
-  echo "=== Full Install ==="
+  if [ -f "$INSTALL_DIR/kindle-hid-passthrough" ]; then
+    echo "=== Install / Update ==="
+    echo "Existing install found at $INSTALL_DIR, updating it in place."
+  else
+    echo "=== Full Install ==="
+  fi
+
+  stopDaemon
+  if ! installMainFiles; then
+    echo ""
+    echo "Install FAILED: main program files were not installed."
+    startDaemon
+    return 1
+  fi
   installUdevRules
   installUpstart
-  installMainFiles
   installWAFApp
   if ! installKOReaderPlugin; then
+    startDaemon
     echo ""
     echo "Install finished WITH ERRORS: the KOReader plugin was not installed."
     return 1
   fi
+  startDaemon
   echo ""
   echo "Installation complete. Open 'BT Manager' from the Kindle library."
 }
@@ -69,6 +177,9 @@ installUpstart()
   /usr/sbin/mntroot rw
   cp "$SRC_DIR/assets/hid-passthrough.upstart" /etc/upstart/hid-passthrough.conf
   /usr/sbin/mntroot ro
+  # upstart only picks up a newly dropped .conf after a config reload, without
+  # this the job stays unknown and the start below fails until a reboot.
+  /sbin/initctl reload-configuration 2>/dev/null || true
   echo " -> Ready."
 }
 
@@ -86,15 +197,16 @@ installWAFApp()
 {
   echo " -> Installing BTManager app"
   if ! in_install_dir; then
-    mkdir -p "$INSTALL_DIR/illusion/BTManager"
-    cp -r "$SRC_DIR/illusion/BTManager/"* "$INSTALL_DIR/illusion/BTManager/"
-    cp "$SRC_DIR/illusion/BTManager.sh" "$INSTALL_DIR/illusion/BTManager.sh"
-    cp "$SRC_DIR/illusion/install-waf-app.sh" "$INSTALL_DIR/illusion/install-waf-app.sh"
+    rm -rf "$INSTALL_DIR/illusion"
+    mkdir -p "$INSTALL_DIR/illusion"
+    cp -r "$SRC_DIR/illusion/." "$INSTALL_DIR/illusion/"
   fi
+  clearWafCache
   if [ -f "$INSTALL_DIR/illusion/install-waf-app.sh" ]; then
     /bin/sh "$INSTALL_DIR/illusion/install-waf-app.sh"
   else
     echo "ERROR: $INSTALL_DIR/illusion/install-waf-app.sh not found"
+    return 1
   fi
 }
 
@@ -133,23 +245,18 @@ uninstallAll()
   echo ""
   echo "=== Uninstall ==="
   printf "This will stop the daemon, remove udev/upstart/WAF app, and delete the install directory.\n"
-  printf "Continue? [y/N]: "
-  read confirm
-  case "$confirm" in
-    y|Y|yes|YES) ;;
-    *) echo "Aborted."; return ;;
-  esac
+  # Only prompt when there is someone to answer. Package managers run this
+  # without a tty and have already asked in their own UI.
+  if [ -t 0 ]; then
+    printf "Continue? [y/N]: "
+    read confirm
+    case "$confirm" in
+      y|Y|yes|YES) ;;
+      *) echo "Aborted."; return ;;
+    esac
+  fi
 
-  APP_ID="com.lzampier.btmanager"
-  INSTALL_DIR="/mnt/us/kindle_hid_passthrough"
-  SCRIPTLET_DEST="/mnt/us/documents/BTManager.sh"
-  APPREG_DB="/var/local/appreg.db"
-
-  echo " -> Stopping daemon"
-  /sbin/stop hid-passthrough 2>/dev/null
-  pkill -f "kindle-hid-passthrough" 2>/dev/null
-  pkill -f "main.py --daemon" 2>/dev/null
-  pkill -f "ld-linux-armhf." 2>/dev/null
+  stopDaemon
 
   /usr/sbin/mntroot rw
 
@@ -164,6 +271,7 @@ uninstallAll()
   /usr/sbin/udevadm control --reload-rules 2>/dev/null
 
   echo " -> Unregistering WAF app"
+  clearWafCache
   if [ -f "$APPREG_DB" ]; then
     sqlite3 "$APPREG_DB" <<EOF 2>/dev/null
 DELETE FROM properties WHERE handlerId='$APP_ID';
@@ -174,6 +282,11 @@ EOF
   rm -f "$SCRIPTLET_DEST"
 
   /usr/sbin/mntroot ro
+
+  if PLUGINS_DIR=$(koreaderPluginDir); then
+    echo " -> Removing KOReader plugin"
+    rm -rf "$PLUGINS_DIR/hidpassthrough.koplugin"
+  fi
 
   echo " -> Removing install directory $INSTALL_DIR"
   cd /tmp
@@ -186,7 +299,7 @@ EOF
 print_menu()
 {
   printf "\nSelect an option:\n"
-  printf " 1) Install everything (recommended)\n"
+  printf " 1) Install or update everything (recommended)\n"
   printf " 2) Pair Bluetooth keyboard\n"
   printf " 3) List paired devices\n"
   printf " 4) Install udev rules (keyboard service)\n"
@@ -200,7 +313,7 @@ print_menu()
 # Non-interactive entry point: `sh install.sh <action>` runs one action and exits.
 if [ $# -gt 0 ]; then
   case "$1" in
-    installAll)         installAll; exit $? ;;
+    installAll|update)  installAll; exit $? ;;
     installUdevRules)   installUdevRules; exit $? ;;
     installUpstart)     installUpstart; exit $? ;;
     installMainFiles)   installMainFiles; exit $? ;;


### PR DESCRIPTION
Updating meant uninstalling first, because re-running the installer over a live install did not work. Refs #146.

The daemon holds `dist/ld-linux-armhf.so.3` open, so writes to it come back ETXTBSY, and busybox tar stops at the first entry it cannot replace. That file is entry 8 of 120, so unpacking over a live install lands six `.so` files and abandons the rest, and the KindleForge script exits there under `set -e` while still reporting success.

Now it stops the daemon first and restarts it after, replaces the program files instead of merging over them, keeps your `config.ini` and puts new defaults in `config.ini.new`, rewrites the appreg registration, clears the mesquite cache, and reloads the upstart config before starting. Same dir detection uses the sentinel probe from kindle-button-mapper, since `/mnt/us` is case insensitive and also reachable via `/mnt/base-us`, and a false negative wipes the install dir then fails the copy.

Tested on a Basic 5 with the daemon running, plus install and update cycles in a sandbox. KindleForge side is KindleTweaks/Repository#24.