### PR TITLE
docs: note the Hotfix requirement for the BTManager home screen entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As this project replaces the original Bluetooth stack, you can't use the default
 ## Requirements
 
 - Jailbroken Kindle
+- [Hotfix](https://github.com/KindleModding/Hotfix/releases/tag/v2.3.7) (only for BTManager) — it's what gives the Kindle scriptlet support, and without it the BTManager entry never shows up on the home screen. Kindles jailbroken with older methods don't have scriptlets at all.
 
 Kernels without UHID support are handled automatically: the daemon loads a bundled `uhid.ko` at startup (see [Kernel Modules](#kernel-modules)).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,6 +92,12 @@ sh /mnt/us/kindle_hid_passthrough/illusion/install-waf-app.sh
 
 udev rules are not installed. Install them (see above) so the system recognizes the device as a keyboard.
 
+### BTManager doesn't show up on the home screen
+
+BTManager is launched by a scriptlet, and scriptlets need the [Hotfix](https://github.com/KindleModding/Hotfix/releases/tag/v2.3.7) package. Kindles jailbroken with older methods don't support them at all, so the app installs fine and then never appears. Install the hotfix as an mrpi package and the entry shows up.
+
+Everything else works without it — start the daemon over SSH or from the KOReader plugin and page turns behave normally.
+
 ### Daemon won't start
 
 Check if the Bluetooth module is loaded:


### PR DESCRIPTION
BTManager is launched by a scriptlet, and Kindles jailbroken with older methods have no scriptlet support at all, so the app installs fine and then never shows up on the home screen. Nothing to fix in code, it just wasn't written down anywhere.

Adds a line under Requirements and a troubleshooting entry pointing at the [Hotfix](https://github.com/KindleModding/Hotfix/releases/tag/v2.3.7) mrpi package, with 2.3.7 as the version since that's the one people report as most reliable.

Thanks @brynnecho for tracking it down and @mergen3107 for the version call.

Reported in #127