### PR TITLE
fix(koplugin): adopt joysticks again, not just INPUT_KEY

### DIFF
--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -232,9 +232,20 @@ local function excludeTypes()
     return exclude_types
 end
 
+-- INPUT_JOYSTICK too: FBInk's test_key only looks below BTN_MISC and in
+-- KEY_OK..BTN_TRIGGER_HAPPY, so a pad with nothing but BTN_A..BTN_THUMBR
+-- (304-319) is never INPUT_KEY.
+local match_types
+local function matchTypes()
+    if not match_types then
+        match_types = bit.bor(C.INPUT_KEY, C.INPUT_JOYSTICK)
+    end
+    return match_types
+end
+
 local function checkKeyDevice(path)
     local FBInkInput = ffi.loadlib("fbink_input", 1)
-    local dev = FBInkInput.fbink_input_check(path, C.INPUT_KEY, excludeTypes(), 0)
+    local dev = FBInkInput.fbink_input_check(path, matchTypes(), excludeTypes(), 0)
     local info
     if dev ~= nil then
         if dev.matched then


### PR DESCRIPTION
Fixes #151, and the gamepad half of #152.

`c81a3eb` swapped the match from `INPUT_JOYSTICK` to `INPUT_KEY` so media remotes would get adopted, and took gamepads out with it. FBInk's `test_key` only scans keycodes below `BTN_MISC` and the `KEY_OK..BTN_TRIGGER_HAPPY` high block, so a pad whose whole capability bitmap is `BTN_A..BTN_THUMBR` (304-319) falls in the gap between the two and never gets `INPUT_KEY`. `checkKeyDevice` declined it, nothing opened the node, no press reached any plugin. First shipped in v3.12.0, which is exactly when the reporter's Joy-Con stopped working. v3.11.0 matched `INPUT_JOYSTICK` and was fine.

Match either one.

## The report

Their log has the entire chain in it. `evtest` on the uhid node prints BtnA/BtnB/BtnX as they press, `lsof` on that same node prints nothing, and KOReader holds only the touchscreen. The daemon was doing its job the whole time, the `/dev/stpbt` busy errors earlier in that log are just the upstart-respawned daemon fighting a foreground run.

## Verification

Kindle Basic 5 (MT8110), against a synthesized uinput pad carrying the same capability profile as the Joy-Con in the report, driving the plugin's own `fbink_input_check` call over every node:

```
node               name                  type                        3.13    patched
/dev/input/event0  bd71828-pwrkey        KEY,power                   false   false
/dev/input/event1  goodix-ts             touchscreen,KEY,power       false   false
/dev/input/event2  kindle-button-mapper  KEY,keyboard,dpad,volume    false   false
/dev/input/event3  BT Keyboard           mouse,KEY,keyboard,dpad,..  false   false
/dev/input/event4  Fake-Pad (R)          JOYSTICK                    false   true
```

Only the pad flips. The touchscreen, the button-mapper node and the keyboard externalkeyboard owns all stay declined.

End to end under KOReader, on the startup scan and on hot-plug both:

```
HIDPassthrough: attached input Fake-Pad (R) @ /dev/input/event4
key event => code: 304 (BtnA), value: 1
HIDPassthrough: executing binding for BtnA
```

with `reader.lua` holding the fd. Same test before the change gave zero attach lines, zero key events and no holder on the node. Unplugging logs a clean `detached input` and re-plugging re-attaches.

## Not fixed here

Sticks and the D-pad hat are `EV_ABS` and still never become key events, so @ZongbingHou's `Hat0X`/`Hat0Y` request in #152 needs its own change. Face buttons work after this.