### PR TITLE
Make auto-start opt-in with a Start on boot toggle in BT Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Paired list, scanning for nearby BLE and Classic HID devices, and the per-device
 
 Installed automatically via KindleForge. For manual installs, use option 6 in `scripts/install.sh`.
 
+The **Start on boot** toggle at the bottom installs or removes the upstart job. It is off by default, so the daemon only runs while you use it, which leaves the Bluetooth radio free for audio. Turn it on if you want your keyboard connected right after a reboot.
+
 ### KOReader plugin
 
 If you use KOReader, a bundled plugin gives you the same scan / pair / connect / disconnect / logs / cache controls from inside KOReader — no need to exit. Open via **cog icon (Settings) → Network → BT Manager - HID Passthrough**.

--- a/illusion/BTManager/index.html
+++ b/illusion/BTManager/index.html
@@ -56,6 +56,14 @@
         <div class="off-hint">Turn on to manage devices</div>
     </div>
 
+    <!-- Start on boot toggle -->
+    <div class="toggle-row">
+        <span class="toggle-label">Start on boot</span>
+        <button id="btnAutostart" class="toggle" aria-label="Toggle start on boot">
+            <span class="toggle-knob"></span>
+        </button>
+    </div>
+
     <!-- Footer -->
     <div id="footer" class="footer">
         <span id="footerVersion">BT Manager</span> &middot; <span id="footerDebug" class="footer-link">Debug</span>

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -27,6 +27,7 @@ var BTManager = (function() {
     var logsVisible = false;
     var pairLogTimer = null;
     var btOn = false;
+    var autostartOn = false;
     var scanResultCount = 0;
 
     // Currently viewed device in detail overlay
@@ -197,6 +198,31 @@ var BTManager = (function() {
         }
     }
 
+    // ---- Autostart ----
+
+    function setAutostartUI(on) {
+        autostartOn = on;
+        getEl("btnAutostart").className = on ? "toggle on" : "toggle";
+    }
+
+    function toggleAutostart() {
+        var want = autostartOn ? "0" : "1";
+        showMessage(autostartOn ? "Disabling autostart..." : "Enabling autostart...", false);
+        request("/autostart?enable=" + want, function(data, err) {
+            if (err) {
+                showMessage("Error: " + err, true);
+                return;
+            }
+            setAutostartUI(!!(data && data.enabled));
+            if (data && data.ok) {
+                showMessage(data.enabled ? "Starts on boot" : "Won't start on boot", false);
+            } else {
+                showMessage(data && data.error ? data.error : "Failed", true);
+            }
+            lastStatusJson = "";
+        });
+    }
+
     // ---- Status Polling ----
 
     function updateStatus() {
@@ -222,6 +248,8 @@ var BTManager = (function() {
             if (data.version) {
                 getEl("footerVersion").innerHTML = "v" + escapeHtml(data.version);
             }
+
+            setAutostartUI(!!data.autostart);
 
             lastStatus = data;
 
@@ -716,6 +744,7 @@ var BTManager = (function() {
 
     function bindEvents() {
         bindBtn("btnToggle", toggleBluetooth);
+        bindBtn("btnAutostart", toggleAutostart);
         bindBtn("btnScan", toggleScan);
         bindBtn("footerDebug", showLogs);
         bindBtn("btnDetailClose", hideDeviceDetail);

--- a/justfile
+++ b/justfile
@@ -27,7 +27,8 @@ deploy:
         --transform='s|^kindle_hid_passthrough/hid-passthrough-dev.upstart|etc/upstart/hid-passthrough.conf|' \
         --transform='s|^kindle_hid_passthrough/|mnt/us/kindle_hid_passthrough/|' \
         --transform='s|^assets/99-hid-keyboard.rules|etc/udev/rules.d/99-hid-keyboard.rules|' \
-        --transform='s|^scripts/dev_is_keyboard.sh|mnt/us/kindle_hid_passthrough/scripts/dev_is_keyboard.sh|' \
+        --transform='s|^assets/|mnt/us/kindle_hid_passthrough/assets/|' \
+        --transform='s|^scripts/|mnt/us/kindle_hid_passthrough/scripts/|' \
         --transform='s|^illusion/BTManager/|mnt/us/kindle_hid_passthrough/illusion/BTManager/|' \
         --transform='s|^illusion/BTManager.sh|mnt/us/kindle_hid_passthrough/illusion/BTManager.sh|' \
         kindle_hid_passthrough/*.py \
@@ -36,7 +37,9 @@ deploy:
         kindle_hid_passthrough/hid-passthrough-dev.upstart \
         kindle_hid_passthrough/modules/*.ko \
         assets/99-hid-keyboard.rules \
+        assets/hid-passthrough.upstart \
         scripts/dev_is_keyboard.sh \
+        scripts/install.sh \
         illusion/BTManager/* \
         illusion/BTManager.sh \
     ) | ssh {{host}} "tar xf - -C /"

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -11,6 +11,7 @@ Port 8321 on localhost.
 import json
 import os
 import socket
+import subprocess
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from urllib.parse import parse_qs, urlparse
@@ -20,6 +21,7 @@ from config import Protocol, config, get_version, normalize_addr
 __all__ = ['APIServer', 'RequestHandler', 'PORT']
 
 PORT = 8321
+UPSTART_CONF = '/etc/upstart/hid-passthrough.conf'
 
 
 class APIServer(ThreadingMixIn, HTTPServer):
@@ -78,6 +80,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_remove(param('addr'))
             case '/clear-cache':
                 self._handle_clear_cache()
+            case '/autostart':
+                self._handle_autostart(param('enable'))
             case '/scan':
                 self._handle_scan()
             case '/scan-status':
@@ -104,7 +108,30 @@ class RequestHandler(BaseHTTPRequestHandler):
         status = self._controller.get_status()
         status["ok"] = True
         status["version"] = get_version()
+        status["autostart"] = os.path.exists(UPSTART_CONF)
         self._send_json(status)
+
+    def _handle_autostart(self, enable):
+        if enable is None:
+            self._send_json({"ok": True, "enabled": os.path.exists(UPSTART_CONF)})
+            return
+
+        want = enable not in ('0', 'false', 'off')
+        script = os.path.join(config.base_path, 'scripts', 'install.sh')
+        action = 'installUpstart' if want else 'removeUpstart'
+        try:
+            result = subprocess.run(['/bin/sh', script, action],
+                                    capture_output=True, text=True, timeout=30)
+        except (OSError, subprocess.TimeoutExpired) as e:
+            self._send_json({"ok": False, "error": str(e)})
+            return
+
+        enabled = os.path.exists(UPSTART_CONF)
+        if enabled == want:
+            self._send_json({"ok": True, "enabled": enabled})
+        else:
+            err = (result.stderr or result.stdout or 'failed').strip()
+            self._send_json({"ok": False, "enabled": enabled, "error": err[-200:]})
 
     def _handle_start(self):
         controller = self._controller

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -148,7 +148,10 @@ installAll()
     return 1
   fi
   installUdevRules
-  installUpstart
+  # Auto-start is opt-in, only refresh a job the user already enabled.
+  if [ -f /etc/upstart/hid-passthrough.conf ]; then
+    installUpstart
+  fi
   installWAFApp
   if ! installKOReaderPlugin; then
     startDaemon
@@ -179,6 +182,16 @@ installUpstart()
   /usr/sbin/mntroot ro
   # upstart only picks up a newly dropped .conf after a config reload, without
   # this the job stays unknown and the start below fails until a reboot.
+  /sbin/initctl reload-configuration 2>/dev/null || true
+  echo " -> Ready."
+}
+
+removeUpstart()
+{
+  echo " -> Removing upstart service"
+  /usr/sbin/mntroot rw
+  rm -f /etc/upstart/hid-passthrough.conf
+  /usr/sbin/mntroot ro
   /sbin/initctl reload-configuration 2>/dev/null || true
   echo " -> Ready."
 }
@@ -307,7 +320,8 @@ print_menu()
   printf " 6) Install BTManager app\n"
   printf " 7) Install KOReader plugin\n"
   printf " 8) Uninstall everything\n"
-  printf " 9) Quit\n"
+  printf " 9) Disable auto-start on boot (remove upstart)\n"
+  printf "10) Quit\n"
 }
 
 # Non-interactive entry point: `sh install.sh <action>` runs one action and exits.
@@ -316,6 +330,7 @@ if [ $# -gt 0 ]; then
     installAll|update)  installAll; exit $? ;;
     installUdevRules)   installUdevRules; exit $? ;;
     installUpstart)     installUpstart; exit $? ;;
+    removeUpstart)      removeUpstart; exit $? ;;
     installMainFiles)   installMainFiles; exit $? ;;
     installWAFApp)      installWAFApp; exit $? ;;
     installKOReaderPlugin) installKOReaderPlugin; exit $? ;;
@@ -326,7 +341,7 @@ fi
 
 while :; do
   print_menu
-  printf "Enter choice [1-9]: "
+  printf "Enter choice [1-10]: "
   read choice
   case "$choice" in
     1)
@@ -354,6 +369,9 @@ while :; do
       uninstallAll
       ;;
     9)
+      removeUpstart
+      ;;
+    10)
       echo "Exiting."
       break
       ;;

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -31,6 +31,7 @@ state = {
     "connected_protocol": None,
     "connected_name": None,
     "hid_ready": True,
+    "autostart": False,
     "version": "3.0.0",
     "scan_results": [
         {"address": "AA:BB:CC:DD:EE:01", "name": "BT Keyboard", "protocol": "classic", "rssi": -45},
@@ -62,6 +63,7 @@ class MockHandler(SimpleHTTPRequestHandler):
                 "version": state["version"],
                 "scanning": state["scanning"],
                 "pairing": state["pairing"],
+                "autostart": state["autostart"],
             }
             if state["connected_device"]:
                 resp["connected_device"] = state["connected_device"]
@@ -148,6 +150,12 @@ class MockHandler(SimpleHTTPRequestHandler):
                 "2026-03-01 12:00:02 INFO ble_hid: API server listening on port 8321",
                 "2026-03-01 12:00:03 INFO daemon: Waiting for connection...",
             ]})
+
+        elif self.path.startswith("/autostart"):
+            enable = _parse_param(self.path, "enable")
+            if enable is not None:
+                state["autostart"] = enable not in ("0", "false", "off")
+            self._json({"ok": True, "enabled": state["autostart"]})
 
         elif self.path == "/clear-cache":
             self._json({"ok": True, "message": "Cache cleared"})


### PR DESCRIPTION
@kbarni is right, installing shouldn't silently take over boot. The upstart job now only gets installed if you ask for it.

installAll stops creating /etc/upstart/hid-passthrough.conf. It only refreshes the file when it's already there, so anyone who enabled auto-start keeps it across an update, while a fresh install (KindleForge included) leaves boot alone and the daemon only runs while you're using it. The BTManager scriptlet already starts the daemon when you open the app, and the KOReader plugin spawns it too, so nothing else changes for the common cases.

BT Manager gets a Start on boot toggle at the bottom of the main screen. It hits a new /autostart endpoint which shells out to install.sh installUpstart or removeUpstart and reports back the real file state, so the toggle can't drift from reality. /status carries the flag so the switch renders right on open. For the SSH crowd there's a new removeUpstart action and menu option 9.

just deploy now also ships scripts/install.sh and assets/hid-passthrough.upstart, otherwise the toggle only works on release installs since dev deploys never had either file on the device.

Tested on a Kindle Basic 4. Tapping the toggle on writes /etc/upstart/hid-passthrough.conf and `initctl status hid-passthrough` goes from `Unknown job` to `stop/waiting`, tapping it off removes the file and the job goes unknown again, with the switch tracking the real state on both. Also drove /autostart directly over curl on the device, and the handler locally against a stub install.sh covering query, enable, disable and a missing script.

Fixes #155