### PR TITLE
docs: write down who owns input mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 Userspace Bluetooth HID host for Kindle with UHID passthrough.
 
+## Scope of the KOReader plugin
+
+`hidpassthrough.koplugin` handles the easy input cases only: opening the evdev node nothing else adopts, and letting plain EV_KEY presses reach KOReader bindings.
+
+The hard cases belong in kindle-button-mapper, not here: EV_ABS translation (D-pad hat axes, analog sticks), joystick mapping, keyboard layouts.
+
 ## SSH Configuration
 
 The Kindle is accessed via SSH using the host alias `kindle`.


### PR DESCRIPTION
The plugin has been quietly growing a second mapping layer inside KOReader, and #152 nearly added a third copy of the hat translation that already exists in kindle-button-mapper at `src/mapper.rs:185`. This writes the intended split down so it stops drifting.

`docs/refactor-input-ownership.md` has the target. This project does Bluetooth and hands over a proper evdev node, the mapper gives the buttons meaning, both stay usable alone, and the plugin shrinks to a control panel for the daemon. CLAUDE.md gets the short version and points at the doc.

Two things that came out of looking at both repos side by side.

The interface already exists without anyone having wired it up. The uhid node carries the Bluetooth address as `uniq` (`U: Uniq=E0:F6:B5:BC:1C:7F/P`), the mapper matches devices on `uniq` at `src/input.rs:51` because it survives renames and reconnects, and `wait_for_matching_device` already watches `/dev/input` with inotify `IN_CREATE`, which is exactly what a BT connect looks like.

And the devices KOReader refuses to adopt are the same devices that need mapping. A real keyboard has keycodes 1..31, so FBInk calls it INPUT_KEYBOARD and stock externalkeyboard opens it unaided. What falls through is gamepads, remotes and page-turners, which fall through because they speak in buttons and axes, which is also why they need mapping.

The one real gap is that the mapper is single-device today (`matches_device` / `scan_for_device` / `wait_for_matching_device` are all singular).

Docs only, no behaviour change. #156 still ships as a bridge, and the doc says so.