### PR TITLE
feat(install): bundle kindle-button-mapper with the release

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -88,6 +88,24 @@ jobs:
           cp -r koreader-plugin/ output/
           cp kindle_hid_passthrough/config.ini output/
 
+      # Pinned rather than tracking latest, so a mapper release can't change
+      # what this tarball ships without a commit here.
+      - name: Bundle kindle-button-mapper
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KBM_VERSION: v1.4.1
+        run: |
+          mkdir -p output/button-mapper
+          gh release download "$KBM_VERSION" \
+            --repo zampierilucas/kindle-button-mapper-rs \
+            --pattern 'kindle-button-mapper-armv7.tar.gz' \
+            --output /tmp/kbm.tar.gz
+          tar -xzf /tmp/kbm.tar.gz -C output/button-mapper
+          echo "$KBM_VERSION" > output/button-mapper/VERSION
+          chmod +x output/button-mapper/kindle-button-mapper \
+                   output/button-mapper/install.sh \
+                   output/button-mapper/uninstall.sh
+
       - name: Show contents
         run: |
           echo "=== Top level ==="
@@ -116,7 +134,10 @@ jobs:
             koreader-plugin/hidpassthrough.koplugin/_meta.lua \
             koreader-plugin/hidpassthrough.koplugin/event_map_extra.lua \
             config.ini \
-            dist/main.bin; do
+            dist/main.bin \
+            button-mapper/kindle-button-mapper \
+            button-mapper/install.sh \
+            button-mapper/config.ini; do
             if ! tar -tzf kindle-hid-passthrough-armv7.tar.gz "./$f" >/dev/null 2>&1; then
               echo "MISSING: $f"
               MISSING=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Userspace Bluetooth HID host for Kindle with UHID passthrough.
 
+## Scope of the KOReader plugin
+
+`hidpassthrough.koplugin` handles the easy input cases only, meaning it opens the evdev node nothing else adopts and lets plain EV_KEY presses reach KOReader bindings.
+
+The hard cases belong in kindle-button-mapper, not here. That covers EV_ABS translation (D-pad hat axes, analog sticks), joystick mapping and keyboard layouts.
+
+This project does Bluetooth and produces a proper evdev node, the mapper gives the buttons meaning, and both stay usable alone.
+
 ## SSH Configuration
 
 The Kindle is accessed via SSH using the host alias `kindle`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 INSTALL_DIR="/mnt/us/kindle_hid_passthrough"
+MAPPER_DIR="/mnt/us/kindle-button-mapper"
 APP_ID="com.lzampier.btmanager"
 APPREG_DB="/var/local/appreg.db"
 SCRIPTLET_DEST="/mnt/us/documents/BTManager.sh"
@@ -153,6 +154,7 @@ installAll()
     installUpstart
   fi
   installWAFApp
+  installButtonMapper
   if ! installKOReaderPlugin; then
     startDaemon
     echo ""
@@ -221,6 +223,26 @@ installWAFApp()
     echo "ERROR: $INSTALL_DIR/illusion/install-waf-app.sh not found"
     return 1
   fi
+}
+
+# Installs into its own directory with its own upstart job, so an existing
+# standalone install is updated rather than duplicated, and it keeps working if
+# this one is removed. Its install.sh runs under `set -e` and ends by poking
+# upstart, which fails on a Kindle that never had the job, so a non-zero exit
+# here is a warning and not a failed install.
+installButtonMapper()
+{
+  if [ ! -f "$SRC_DIR/button-mapper/install.sh" ]; then
+    echo " -> Button Mapper not bundled in this build, skipping"
+    return 0
+  fi
+  echo " -> Installing Button Mapper"
+  if /bin/sh "$SRC_DIR/button-mapper/install.sh"; then
+    echo " -> Ready."
+  else
+    echo " -> WARNING: Button Mapper install failed, gamepad mapping will be unavailable"
+  fi
+  return 0
 }
 
 installKOReaderPlugin()
@@ -307,6 +329,11 @@ EOF
 
   echo ""
   echo "Uninstall complete. Reboot recommended."
+  # Left alone on purpose, it is a separate tool that may predate this install.
+  if [ -f "$MAPPER_DIR/uninstall.sh" ]; then
+    echo "Button Mapper was left installed. Remove it with:"
+    echo "  sh $MAPPER_DIR/uninstall.sh"
+  fi
 }
 
 print_menu()
@@ -319,9 +346,10 @@ print_menu()
   printf " 5) Install upstart (auto-start on boot)\n"
   printf " 6) Install BTManager app\n"
   printf " 7) Install KOReader plugin\n"
-  printf " 8) Uninstall everything\n"
-  printf " 9) Disable auto-start on boot (remove upstart)\n"
-  printf "10) Quit\n"
+  printf " 8) Install Button Mapper (gamepad mapping)\n"
+  printf " 9) Uninstall everything\n"
+  printf "10) Disable auto-start on boot (remove upstart)\n"
+  printf "11) Quit\n"
 }
 
 # Non-interactive entry point: `sh install.sh <action>` runs one action and exits.
@@ -334,6 +362,7 @@ if [ $# -gt 0 ]; then
     installMainFiles)   installMainFiles; exit $? ;;
     installWAFApp)      installWAFApp; exit $? ;;
     installKOReaderPlugin) installKOReaderPlugin; exit $? ;;
+    installButtonMapper) installButtonMapper; exit $? ;;
     uninstallAll)       uninstallAll; exit $? ;;
     *) echo "Unknown action: $1" >&2; exit 1 ;;
   esac
@@ -341,7 +370,7 @@ fi
 
 while :; do
   print_menu
-  printf "Enter choice [1-10]: "
+  printf "Enter choice [1-11]: "
   read choice
   case "$choice" in
     1)
@@ -366,12 +395,15 @@ while :; do
       installKOReaderPlugin
       ;;
     8)
-      uninstallAll
+      installButtonMapper
       ;;
     9)
-      removeUpstart
+      uninstallAll
       ;;
     10)
+      removeUpstart
+      ;;
+    11)
       echo "Exiting."
       break
       ;;


### PR DESCRIPTION
First step of the refactor in `docs/refactor-input-ownership.md`. Gamepad and D-pad mapping belongs in kindle-button-mapper, but installing it meant a second download, so in practice nobody has it and every joystick issue lands here instead.

The release now ships the mapper under `button-mapper/` and `scripts/install.sh` runs its installer as part of `installAll`, also available as menu item 8 or `sh install.sh installButtonMapper`.

It still installs into `/mnt/us/kindle-button-mapper` with its own upstart job, so an existing standalone install is updated rather than duplicated and it keeps working if this one is removed. Uninstall leaves it alone for the same reason and prints how to remove it. The mapper version is pinned in the workflow so a release over there cannot change what this tarball ships without a commit here, and its files are in the tarball manifest check so a broken bundle fails the build.

The docs commit also corrects two blockers that turned out to be already solved. The mapper has been multi-device since 1.4.x with one worker thread per `[device.NAME]` block, and `uinput.ko` is already bundled here for the Broadcom kernels that disable it. Nothing needs to write into the mapper's config either, its WAF app already lists every `/dev/input` node with name and uniq, so a connected device is pickable without typing a MAC.

## Testing

Verified locally, `sh -n` on the installer, YAML parse on the workflow, all three `installButtonMapper` branches dry-run (not bundled, installer ok, installer fails), the exact CI download and chmod snippet against v1.4.1, and the manifest paths resolving inside the tarball. Bundled weight is about 615 KB compressed. KindleForge drives the installer by action name and not menu number, so the renumber is safe.

Not yet run on device, my Kindle was unreachable while writing this. Wants a check that `installAll` lands the mapper with its upstart job started and the MapperManager icon in the library.

## Still open

Nothing in BT Manager mentions the mapper, so a bundled tool nobody is told about is dead weight. Grab semantics are undecided too, right now the plugin and the mapper can both act on the same press.