### PR TITLE
feat: register paired devices with kindle-button-mapper

### DIFF
--- a/kindle_hid_passthrough/button_mapper.py
+++ b/kindle_hid_passthrough/button_mapper.py
@@ -1,0 +1,99 @@
+"""Register paired devices with kindle-button-mapper.
+
+Appends a [device.X] block with the device's MAC to the mapper's config, so
+its daemon picks the uhid node up by uniq the moment it connects. The mapper
+decides from the node's capabilities whether a default layout applies, so
+registering a keyboard is harmless.
+
+Append-only on purpose: the config is hand-edited and edited by the mapper's
+own app, a parser round-trip would eat comments and formatting.
+"""
+
+import logging
+import os
+import re
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+MAPPER_CONFIG = "/mnt/us/kindle-button-mapper/config.ini"
+
+
+def _bare_addr(value: str) -> str:
+    return value.split('/')[0].strip().upper()
+
+
+def _known_uniqs(text: str) -> set:
+    uniqs = set()
+    for line in text.splitlines():
+        key, sep, value = line.partition('=')
+        if sep and key.strip() == 'uniq':
+            uniqs.add(_bare_addr(value))
+    return uniqs
+
+
+def _slug(name: str, address: str, text: str) -> str:
+    base = re.sub(r'[^a-z0-9]+', '_', (name or '').lower()).strip('_')
+    if not base:
+        base = 'dev_' + address.replace(':', '')[-4:].lower()
+    slug, n = base, 1
+    while f'[device.{slug}]' in text:
+        n += 1
+        slug = f'{base}_{n}'
+    return slug
+
+
+def register_device(address: str, name: str = None, restart: bool = True) -> bool:
+    """Add a device block to the mapper config. True if one was added."""
+    try:
+        with open(MAPPER_CONFIG) as f:
+            text = f.read()
+    except OSError:
+        return False  # mapper not installed
+
+    address = _bare_addr(address)
+    if address in _known_uniqs(text):
+        return False
+
+    slug = _slug(name, address, text)
+    block = f'\n[device.{slug}]\n'
+    if name:
+        block += f'name = {name}\n'
+    block += f'uniq = {address}\n'
+
+    try:
+        with open(MAPPER_CONFIG, 'a') as f:
+            if not text.endswith('\n'):
+                f.write('\n')
+            f.write(block)
+    except OSError as e:
+        logger.warning(f"Could not register {address} with button-mapper: {e}")
+        return False
+
+    logger.info(f"Registered {address} as [device.{slug}] with button-mapper")
+    if restart:
+        _restart_mapper()
+    return True
+
+
+def register_all(devices) -> None:
+    """Register every (address, protocol, name) tuple, skipping wildcards."""
+    added = False
+    for address, _proto, name in devices:
+        if address == '*':
+            continue
+        added |= register_device(address, name, restart=False)
+    if added:
+        _restart_mapper()
+
+
+def _restart_mapper() -> None:
+    # Restart only: if the user stopped the job, starting it behind their
+    # back would be rude, and the next start reads the new block anyway.
+    if not os.path.exists('/sbin/initctl'):
+        return
+    try:
+        subprocess.run(['/sbin/initctl', 'restart', 'kindle-button-mapper'],
+                       capture_output=True, timeout=15)
+    except Exception as e:
+        logger.debug(f"button-mapper restart skipped: {e}")

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -341,6 +341,8 @@ class Config:
                 else:
                     f.write(f"{addr_norm} {protocol.value}\n")
             logger.info(f"Added: {addr_norm} {protocol.value} ({name or 'unnamed'})")
+            import button_mapper
+            button_mapper.register_device(addr_norm, name)
         except Exception as e:
             logger.error(f"Failed to save device: {e}")
 

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -9,6 +9,7 @@ import threading
 
 sys.path.insert(0, '/mnt/us/kindle_hid_passthrough')
 
+import button_mapper
 from api_server import PORT, APIServer, RequestHandler
 from bt_setup import chip, prepare_bt
 from config import config, get_version
@@ -241,6 +242,10 @@ class HIDDaemon:
 
 async def main():
     setup_daemon_logging(config.log_file)
+
+    # Devices paired before the mapper was installed (or before this existed)
+    # get their block on the next daemon start.
+    button_mapper.register_all(config.get_all_devices())
 
     prepare_bt()
 

--- a/tests/test_button_mapper.py
+++ b/tests/test_button_mapper.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'kindle_hid_passthrough'))
+
+import button_mapper
+
+
+def use_config(monkeypatch, tmp_path, text=None):
+    cfg = tmp_path / 'config.ini'
+    if text is not None:
+        cfg.write_text(text)
+    monkeypatch.setattr(button_mapper, 'MAPPER_CONFIG', str(cfg))
+    monkeypatch.setattr(button_mapper, '_restart_mapper', lambda: None)
+    return cfg
+
+
+def test_no_mapper_installed(monkeypatch, tmp_path):
+    use_config(monkeypatch, tmp_path)
+    assert button_mapper.register_device('AA:BB:CC:DD:EE:FF', 'Pad') is False
+
+
+def test_registers_a_new_device(monkeypatch, tmp_path):
+    cfg = use_config(monkeypatch, tmp_path, '[settings]\nkeep_awake = true\n')
+    assert button_mapper.register_device('AA:BB:CC:DD:EE:FF', 'My Pad 2') is True
+    text = cfg.read_text()
+    assert '[device.my_pad_2]' in text
+    assert 'uniq = AA:BB:CC:DD:EE:FF' in text
+    assert 'name = My Pad 2' in text
+
+
+def test_existing_uniq_is_not_duplicated(monkeypatch, tmp_path):
+    cfg = use_config(
+        monkeypatch, tmp_path,
+        '[device.pad]\nuniq = aa:bb:cc:dd:ee:ff/P\n',
+    )
+    assert button_mapper.register_device('AA:BB:CC:DD:EE:FF', 'Pad') is False
+    assert cfg.read_text().count('uniq') == 1
+
+
+def test_slug_collision_gets_a_suffix(monkeypatch, tmp_path):
+    cfg = use_config(
+        monkeypatch, tmp_path,
+        '[device.pad]\nuniq = 11:22:33:44:55:66\n',
+    )
+    assert button_mapper.register_device('AA:BB:CC:DD:EE:FF', 'Pad') is True
+    assert '[device.pad_2]' in cfg.read_text()
+
+
+def test_nameless_device_uses_mac_tail(monkeypatch, tmp_path):
+    cfg = use_config(monkeypatch, tmp_path, '')
+    assert button_mapper.register_device('AA:BB:CC:DD:EE:FF') is True
+    assert '[device.dev_eeff]' in cfg.read_text()
+
+
+def test_register_all_skips_wildcard_and_restarts_once(monkeypatch, tmp_path):
+    use_config(monkeypatch, tmp_path, '')
+    calls = []
+    monkeypatch.setattr(button_mapper, '_restart_mapper', lambda: calls.append(1))
+    button_mapper.register_all([
+        ('*', None, None),
+        ('AA:BB:CC:DD:EE:FF', None, 'Pad'),
+        ('11:22:33:44:55:66', None, None),
+    ])
+    assert len(calls) == 1


### PR DESCRIPTION
Second leg of the mapper-as-backend rework, after #160 ships the mapper in the release. Pairing a pad used to be half the job, the mapper only picks a device up once someone writes its MAC into its config.ini by hand or through the MapperManager app.

The daemon now appends the `[device.X]` block itself when a device is paired, from the one choke point every pair path routes through, so BTManager and the KOReader plugin both get it for free. A sweep at daemon start covers devices paired before the mapper was installed. The block carries only name and uniq, the mapper decides from the node's capabilities whether the default gamepad layout applies (zampierilucas/kindle-button-mapper-rs#37), so registering a keyboard is harmless.

Appends rather than rewrites, the config is hand-edited and a parser round-trip would eat comments. The mapper job is restarted only if already running, a stopped one reads the new block on its next start.

With #160, kindle-button-mapper-rs#37 and this, the flow becomes pair a pad, block gets written, mapper grabs it by uniq and emits arrows/Enter/page turns on its keyboard node, KOReader adopts that natively. No plugin involvement.

## Testing

6 new pytest cases cover registration, dedup against a `/P`-suffixed uniq, slug collisions, the nameless fallback and the wildcard skip. Full suite 20 passing, ruff clean.

Tested on my Basic 5. The startup sweep registered both already-paired devices as `[device.keychron_m6]` and `[device.bt_keyboard]` with correct names and uniqs, restarted the mapper, and the mapper's caps gate left both alone since neither is a gamepad. Needs #163 on devices whose python bundle lacks termios.