### PR TITLE
feat(koplugin): edit Button Mapper mappings from inside KOReader

### DIFF
--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -563,6 +563,201 @@ function HIDPassthrough:genKeyActionMenu(id)
     return sub_items
 end
 
+------------------------------------------------------------------------------
+-- Button Mapper frontend
+------------------------------------------------------------------------------
+-- Gamepads and remotes are the mapper's job (it grabs them and emits plain
+-- keys), so their mappings are edited in its config over its helper API
+-- rather than in KOReader's event path.
+
+function HIDPassthrough:_mapper()
+    if not self._mapper_client then
+        self._mapper_client = dofile(self.path .. "/mapper.lua")
+    end
+    return self._mapper_client
+end
+
+function HIDPassthrough:genMapperMenu()
+    local mapper = self:_mapper()
+    if not mapper.installed() then
+        return {{ text = _("Button Mapper is not installed"), enabled = false }}
+    end
+    local ok, err = mapper.ensureHelper()
+    if not ok then
+        return {{ text = T(_("Button Mapper unreachable: %1"), tostring(err)), enabled = false }}
+    end
+    local text = mapper.getConfig()
+    if not text then
+        return {{ text = _("Could not read the Button Mapper config"), enabled = false }}
+    end
+
+    local items = {}
+    for dummy, dev in ipairs(mapper.deviceBlocks(text)) do -- luacheck: ignore dummy
+        table.insert(items, {
+            text = dev.name or dev.id,
+            sub_item_table_func = function() return self:genMapperDeviceMenu(dev) end,
+        })
+    end
+    if #items == 0 then
+        table.insert(items, {
+            text = _("No devices registered yet. Pair one first."),
+            enabled = false,
+        })
+    end
+    return items
+end
+
+local MAPPER_KINDS = {
+    { section = "buttons",  label = _("Button") },
+    { section = "dpad",     label = _("D-pad") },
+    { section = "triggers", label = _("Trigger") },
+}
+
+function HIDPassthrough:genMapperDeviceMenu(dev)
+    local mapper = self:_mapper()
+    local items = {
+        {
+            text = _("Map a button…"),
+            keep_menu_open = true,
+            callback = function() self:mapperCapture(dev) end,
+            separator = true,
+        },
+    }
+
+    local text = mapper.getConfig() or ""
+    for dummy, kind in ipairs(MAPPER_KINDS) do -- luacheck: ignore dummy
+        local section = "device." .. dev.id .. "." .. kind.section
+        for dummy2, entry in ipairs(mapper.sectionKeys(text, section)) do -- luacheck: ignore dummy2
+            -- The script path is noise, show "koreader.sh next_page".
+            local action = entry.value:match("([^/]+)$") or entry.value
+            table.insert(items, {
+                text = T("%1 %2  →  %3", kind.label, entry.key, action),
+                keep_menu_open = true,
+                hold_callback = function(touchmenu_instance)
+                    UIManager:show(ConfirmBox:new{
+                        text = T(_("Remove the mapping for %1 %2?"), kind.label, entry.key),
+                        ok_text = _("Remove"),
+                        ok_callback = function()
+                            self:mapperEdit(function(cur)
+                                return mapper.removeKey(cur, section, entry.key)
+                            end)
+                            if touchmenu_instance then
+                                touchmenu_instance.item_table = self:genMapperDeviceMenu(dev)
+                                touchmenu_instance:updateItems()
+                            end
+                        end,
+                    })
+                end,
+                ignored_by_menu_search = true,
+            })
+        end
+    end
+
+    if #items == 1 then
+        table.insert(items, {
+            text = _("(defaults active — map a button to customize)"),
+            enabled = false,
+        })
+    end
+    items.refresh_func = function() return self:genMapperDeviceMenu(dev) end
+    return items
+end
+
+-- Re-fetch, transform, write back, reload. The helper serializes writers, but
+-- editing a stale text would still drop someone else's change, so keep the
+-- window small by fetching right before the edit.
+function HIDPassthrough:mapperEdit(transform)
+    local mapper = self:_mapper()
+    local text = mapper.getConfig()
+    if not text then
+        UIManager:show(InfoMessage:new{ text = _("Could not read the Button Mapper config.") })
+        return false
+    end
+    local ok, err = mapper.setConfig(transform(text))
+    if not ok then
+        UIManager:show(InfoMessage:new{ text = T(_("Saving failed: %1"), tostring(err)) })
+        return false
+    end
+    mapper.reload()
+    return true
+end
+
+function HIDPassthrough:mapperCapture(dev)
+    local mapper = self:_mapper()
+    local node = mapper.findNode(dev.uniq or "")
+    if not node then
+        UIManager:show(InfoMessage:new{
+            text = T(_("%1 is not connected."), dev.name or dev.id),
+        })
+        return
+    end
+
+    local msg = InfoMessage:new{
+        text = _("Press a button or D-pad direction on the controller…"),
+    }
+    UIManager:show(msg)
+    -- Painted first; the capture request then blocks the UI until a press
+    -- or the helper's timeout.
+    UIManager:scheduleIn(0.1, function()
+        local cap, err = mapper.capture(node, 8000)
+        UIManager:close(msg)
+        if not cap then
+            UIManager:show(InfoMessage:new{
+                text = T(_("Nothing captured: %1"), tostring(err or "timeout")),
+                timeout = 3,
+            })
+            return
+        end
+        local section, key, label = mapper.captureTarget(dev.id, cap)
+        if not section then
+            UIManager:show(InfoMessage:new{
+                text = _("That input isn't mappable here."),
+                timeout = 3,
+            })
+            return
+        end
+        self:mapperPickAction(section, key, label)
+    end)
+end
+
+function HIDPassthrough:mapperPickAction(section, key, label)
+    local mapper = self:_mapper()
+    local actions = mapper.actions()
+    if not actions then
+        UIManager:show(InfoMessage:new{ text = _("Could not fetch the action list.") })
+        return
+    end
+
+    local menu
+    local items = {}
+    for dummy, action in ipairs(actions) do -- luacheck: ignore dummy
+        table.insert(items, {
+            text = T("%1  (%2)", action.label, action.kind),
+            callback = function()
+                UIManager:close(menu)
+                if self:mapperEdit(function(cur)
+                    return mapper.setKey(cur, section, key, mapper.actionScript(action))
+                end) then
+                    UIManager:show(InfoMessage:new{
+                        text = T(_("Mapped %1 to %2."), label, action.label),
+                        timeout = 3,
+                    })
+                end
+            end,
+        })
+    end
+
+    menu = Menu:new{
+        title = T(_("Action for %1"), label),
+        item_table = items,
+        width = Screen:getWidth(),
+        height = Screen:getHeight(),
+        is_popout = false,
+        onClose = function() UIManager:close(menu) end,
+    }
+    UIManager:show(menu)
+end
+
 function HIDPassthrough:onFlushSettings()
     if self.updated then
         getKeymapSettings():flush()
@@ -1373,6 +1568,11 @@ function HIDPassthrough:addToMainMenu(menu_items)
                 text = _("Key mappings"),
                 keep_menu_open = true,
                 sub_item_table_func = function() return self:genKeymapMenu() end,
+            },
+            {
+                text = _("Button mappings (gamepads)"),
+                keep_menu_open = true,
+                sub_item_table_func = function() return self:genMapperMenu() end,
                 separator = true,
             },
             {

--- a/koreader-plugin/hidpassthrough.koplugin/mapper.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/mapper.lua
@@ -1,0 +1,278 @@
+--[[--
+Client for the kindle-button-mapper WAF helper API on 127.0.0.1:8322.
+
+The helper is the same process the MapperManager app talks to; it is spawned
+on demand with the same pidfile, so whichever frontend gets there first owns
+it. Config edits are line-based on the ini text, the file is hand-edited and
+a parser round-trip would eat comments.
+--]]
+
+local M = {
+    BIN     = "/mnt/us/kindle-button-mapper/kindle-button-mapper",
+    CONFIG  = "/mnt/us/kindle-button-mapper/config.ini",
+    SCRIPTS = "/mnt/us/kindle-button-mapper/scripts",
+    PIDFILE = "/tmp/kindle-button-mapper-waf.pid",
+    LOG     = "/var/log/kindle-button-mapper-waf.log",
+    HOST    = "127.0.0.1",
+    PORT    = 8322,
+    TIMEOUT = 3, -- seconds; capture calls pass their own
+}
+
+------------------------------------------------------------------------------
+-- Transport (requires KOReader's socket libs, loaded lazily so the pure
+-- config functions below stay testable under plain luajit)
+------------------------------------------------------------------------------
+
+local function request(method, path, body, timeout)
+    local socket = require("socket")
+    local http = require("socket.http")
+    local ltn12 = require("ltn12")
+
+    timeout = timeout or M.TIMEOUT
+    local chunks = {}
+    local saved = http.TIMEOUT
+    http.TIMEOUT = timeout
+    local req = {
+        url = string.format("http://%s:%d%s", M.HOST, M.PORT, path),
+        method = method,
+        sink = ltn12.sink.table(chunks),
+        create = function()
+            local s = socket.tcp()
+            s:settimeout(timeout)
+            return s
+        end,
+    }
+    if body then
+        req.source = ltn12.source.string(body)
+        req.headers = {
+            ["content-type"] = "text/plain",
+            ["content-length"] = tostring(#body),
+        }
+    end
+    local ok, code = http.request(req)
+    http.TIMEOUT = saved
+    if not ok then return nil, tostring(code) end
+    if code ~= 200 then return nil, "HTTP " .. tostring(code) end
+    return table.concat(chunks)
+end
+
+local function requestJson(method, path, body, timeout)
+    local text, err = request(method, path, body, timeout)
+    if not text then return nil, err end
+    local rapidjson = require("rapidjson")
+    local data, perr = rapidjson.decode(text)
+    if not data then return nil, "json decode: " .. tostring(perr) end
+    if data.ok == false then return nil, data.error or "helper error" end
+    return data
+end
+
+function M.installed()
+    local lfs = require("libs/libkoreader-lfs")
+    return lfs.attributes(M.BIN, "mode") == "file"
+end
+
+function M.health()
+    return requestJson("GET", "/health") ~= nil
+end
+
+-- Spawn the helper the way MapperManager.sh does if it isn't up yet.
+function M.ensureHelper()
+    if M.health() then return true end
+    if not M.installed() then return false, "Button Mapper is not installed" end
+    os.execute(string.format(
+        "sh -c '%s --waf-helper %s >>%s 2>&1 & echo $! > %s' 2>/dev/null",
+        M.BIN, M.CONFIG, M.LOG, M.PIDFILE))
+    local ffiutil = require("ffi/util")
+    for _ = 1, 10 do
+        ffiutil.usleep(200000)
+        if M.health() then return true end
+    end
+    return false, "helper did not come up"
+end
+
+function M.getConfig()
+    return request("GET", "/config")
+end
+
+function M.setConfig(text)
+    return requestJson("POST", "/config", text)
+end
+
+function M.reload()
+    return requestJson("POST", "/reload", "")
+end
+
+function M.actions()
+    local data, err = requestJson("GET", "/actions")
+    return data and data.actions, err
+end
+
+-- Evdev node path for a registered device, nil when it isn't connected.
+function M.findNode(uniq)
+    local data = requestJson("GET", "/devices")
+    if not data then return nil end
+    local want = M.bareAddr(uniq)
+    for _, dev in ipairs(data.devices or {}) do
+        if dev.uniq and dev.uniq ~= "" and M.bareAddr(dev.uniq) == want then
+            return dev.path
+        end
+    end
+end
+
+-- Blocks up to timeout_ms while the helper reads the device, so the caller
+-- must have painted its "press a button" message first.
+function M.capture(node, timeout_ms)
+    timeout_ms = timeout_ms or 8000
+    local path = string.format("/capture?device=%s&timeout=%d",
+        node:gsub("[^%w/%-_.]", function(c)
+            return string.format("%%%02X", c:byte())
+        end), timeout_ms)
+    return requestJson("GET", path, nil, timeout_ms / 1000 + 3)
+end
+
+------------------------------------------------------------------------------
+-- Config text handling (pure)
+------------------------------------------------------------------------------
+
+function M.bareAddr(addr)
+    return (addr or ""):match("^[^/]*"):upper()
+end
+
+local function splitLines(text)
+    local lines = {}
+    for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+        lines[#lines + 1] = line
+    end
+    -- The split adds a phantom empty line when text already ends in \n.
+    if lines[#lines] == "" then lines[#lines] = nil end
+    return lines
+end
+
+local function sectionOf(line)
+    return line:match("^%s*%[(.-)%]%s*$")
+end
+
+-- Ordered { id, name, uniq } for every [device.X] block.
+function M.deviceBlocks(text)
+    local out, byId, current = {}, {}, nil
+    for _, line in ipairs(splitLines(text)) do
+        local header = sectionOf(line)
+        if header then
+            local id = header:match("^device%.([^%.]+)$")
+            if id then
+                if not byId[id] then
+                    byId[id] = { id = id }
+                    out[#out + 1] = byId[id]
+                end
+                current = byId[id]
+            else
+                current = nil
+            end
+        elseif current then
+            local k, v = line:match("^%s*([%w_]+)%s*=%s*(.-)%s*$")
+            if k == "name" then current.name = v end
+            if k == "uniq" then current.uniq = v end
+        end
+    end
+    return out
+end
+
+-- Ordered { key = ..., value = ... } pairs inside [section].
+function M.sectionKeys(text, section)
+    local out, active = {}, false
+    for _, line in ipairs(splitLines(text)) do
+        local header = sectionOf(line)
+        if header then
+            active = (header == section)
+        elseif active then
+            local k, v = line:match("^%s*([^=%s]+)%s*=%s*(.-)%s*$")
+            if k and not k:match("^[#;]") then
+                out[#out + 1] = { key = k, value = v }
+            end
+        end
+    end
+    return out
+end
+
+-- Set key = value inside [section], creating either as needed.
+function M.setKey(text, section, key, value)
+    local lines = splitLines(text)
+    local current, last_in_section
+    for i, line in ipairs(lines) do
+        local header = sectionOf(line)
+        if header then current = header end
+        if current == section then
+            if not header then
+                local k = line:match("^%s*([^=%s]+)%s*=")
+                if k == key then
+                    lines[i] = key .. " = " .. value
+                    return table.concat(lines, "\n") .. "\n"
+                end
+            end
+            last_in_section = i
+        end
+    end
+    if last_in_section then
+        table.insert(lines, last_in_section + 1, key .. " = " .. value)
+    else
+        if #lines > 0 and lines[#lines] ~= "" then lines[#lines + 1] = "" end
+        lines[#lines + 1] = "[" .. section .. "]"
+        lines[#lines + 1] = key .. " = " .. value
+    end
+    return table.concat(lines, "\n") .. "\n"
+end
+
+function M.removeKey(text, section, key)
+    local lines = splitLines(text)
+    local current
+    for i, line in ipairs(lines) do
+        local header = sectionOf(line)
+        if header then current = header end
+        if current == section and not header then
+            local k = line:match("^%s*([^=%s]+)%s*=")
+            if k == key then
+                table.remove(lines, i)
+                return table.concat(lines, "\n") .. "\n"
+            end
+        end
+    end
+    return text
+end
+
+------------------------------------------------------------------------------
+-- Capture result -> config location
+------------------------------------------------------------------------------
+
+local DPAD_DIRECTION = {
+    [16] = { [-1] = "left", [1] = "right" },
+    [17] = { [-1] = "up",   [1] = "down" },
+}
+local TRIGGER_NAME = { [9] = "rt", [10] = "lt" }
+
+-- Section and key a captured press maps to, plus a human label.
+function M.captureTarget(dev_id, cap)
+    if cap.kind == "key" then
+        return "device." .. dev_id .. ".buttons", tostring(cap.code),
+            "button " .. tostring(cap.code)
+    end
+    if cap.kind == "dpad" then
+        local dir = DPAD_DIRECTION[cap.code]
+        dir = dir and dir[cap.value > 0 and 1 or -1]
+        if dir then
+            return "device." .. dev_id .. ".dpad", dir, "D-pad " .. dir
+        end
+    end
+    if cap.kind == "trigger" then
+        local name = TRIGGER_NAME[cap.code]
+        if name then
+            return "device." .. dev_id .. ".triggers", name, name:upper() .. " trigger"
+        end
+    end
+    return nil
+end
+
+function M.actionScript(action)
+    return string.format("%s/%s.sh %s", M.SCRIPTS, action.kind, action.id)
+end
+
+return M

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -244,7 +244,7 @@ installKOReaderPlugin()
     return 1
   fi
 
-  for f in main.lua _meta.lua event_map_extra.lua; do
+  for f in main.lua _meta.lua event_map_extra.lua mapper.lua; do
     if [ ! -f "$DEST/$f" ]; then
       echo "ERROR: $f is missing from $DEST" >&2
       return 1


### PR DESCRIPTION
Third leg of the mapper-as-backend rework, after #160 (ship the mapper in the release) and #161 (register paired devices with it). The plugin already drives the hid daemon over 8321, this gives it the same role for the mapper over its helper API on 8322, so pairing and remapping live in one frontend.

A Button mappings menu lists the devices registered in the mapper's config. Map a button captures a press through `GET /capture`, which pauses the mapper's grab while it reads, then offers the mapper's own action list and writes the result back through `POST /config` and a reload. Existing mappings show per device and hold-to-remove works like the Key mappings menu.

The helper is the same process the MapperManager app spawns, started on demand with the same pidfile, so whichever frontend gets there first owns it and the other reuses it. Config edits are line-based on the ini text since the file is hand-edited and a parser round-trip would eat comments.

The existing Key mappings menu is untouched. It binds KOReader actions to whatever key events arrive, which now includes the keys the mapper emits, so the two menus compose, the mapper decides what a button becomes, Key mappings decides what the key does in KOReader.

## Testing

The pure config-text functions run under a standalone luajit harness, all passing. Both files luacheck clean, zero new warnings.

Tested on my Basic 5 through KOReader's own luajit against the live helper, 11 checks passing end to end, `ensureHelper` cold-spawned the helper, `getConfig`/`deviceBlocks` listed the registered devices, a live `capture` caught a synthesized pad's hat-up while the mapper had it grabbed, `captureTarget` resolved it to `device.X.dpad up`, and the write went through `POST /config` plus reload and fired on the next press. KOReader restarted with the plugin and loaded clean. The menu taps themselves still want a finger.

## Known rough edge

The capture request blocks the UI thread for up to 8 seconds if nothing is pressed. Same behaviour the MapperManager app has, acceptable for a settings flow, and fixable later with a background poll if it grates.