### PR TITLE
fix(transport): make termios optional, MTK never uses it

### DIFF
--- a/kindle_hid_passthrough/transport.py
+++ b/kindle_hid_passthrough/transport.py
@@ -3,7 +3,13 @@
 
 import asyncio
 import os
-import termios
+
+# Not in every cross-compiled python bundle, and only the Broadcom UART path
+# needs it.
+try:
+    import termios
+except ImportError:
+    termios = None
 
 from bumble.device import Device
 from bumble.hci import HCI_LE_ADD_DEVICE_TO_RESOLVING_LIST_COMMAND, LeFeatureMask
@@ -49,6 +55,10 @@ def _apply_hci_termios(transport, device_path):
     pyserial clears IGNBRK on every open, so a line break arrives as a literal
     0x00 in the HCI stream and desyncs the parser (issue #120).
     """
+    if termios is None:
+        log.warning("No termios module; leaving HCI UART flags alone "
+                    "(issue #120 may resurface)")
+        return
     fd = _tty_fd(transport, device_path)
     if fd is None:
         return


### PR DESCRIPTION
Found while testing the mapper rework on my Basic 5. `transport.py` imports `termios` at module level since the #120 fix, and the cross-compiled python bundle on the device doesn't ship the module, so a dev deploy of current main kills the daemon on import, on hardware whose transport never touches a UART.

The import is now guarded and `_apply_hci_termios` skips with a warning when the module is missing. The Broadcom path keeps the IGNBRK fix whenever termios exists, which includes every binary release, so #120 stays fixed where it matters. `diagnostics.py` already guarded its own import.

Verified on device, the daemon starts and runs on the Basic 5 with this guard (tested as a live shim first, this is the same change). Full suite 20 passing, ruff clean.