### PR TITLE
fix(uhid): give the node the bare MAC as uniq, not the suffixed address

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -379,7 +379,7 @@ class HIDHost(ClassicMixin, BLEMixin):
                 bus=Bus.BLUETOOTH,
                 vendor=0,
                 product=0,
-                uniq=self.current_device_address or "",
+                uniq=normalize_addr(self.current_device_address or ""),
             )
             log.success(f"UHID device created: {name}")
             asyncio.get_event_loop().call_later(


### PR DESCRIPTION
`button_mapper.register_device()` writes `uniq = 8A:76:5A:2F:36:23` into the mapper config, but `_create_uhid_device` handed the node bumble's address-type notation, `8A:76:5A:2F:36:23/P`. The mapper's released matcher compares those exactly, so it never bound the node, parked on "Waiting for device to appear...", and with no worker there is no virtual keyboard, so every mapping injects into nothing. That's #171 in full, and the first half of #172.

Everything else the daemon exposes already goes through `normalize_addr`, the node's uniq was the last place the suffix leaked out.

The mapper has its own fix for this on master (`uniq_matches`, kindle-button-mapper-rs#37) plus one for its WAF app in kindle-button-mapper-rs#38, but `KBM_VERSION` here is pinned to v1.4.1 and that predates both, so nothing reaches users until we cut a mapper release and bump the pin. This one line fixes it on the build people are actually running.

Worth knowing if you hand-edited your config to `/P` as the #172 workaround, put it back to the bare MAC after this, or pick it up from a mapper release once one is out since `uniq_matches` takes either form.

Tests pass, 27.

The second half of #172, zero raw events reaching the node, is untouched here and still open.
