### PR TITLE
fix(cache,classic): key lookups on the address, not the address plus its type

### DIFF
--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -407,7 +407,7 @@ class ClassicMixin:
             await self._query_classic_sdp(address)
 
             if self.keystore:
-                keys = await self.keystore.get(address)
+                keys = await self.keystore.get(str(self.connection.peer_address))
                 if keys and keys.link_key:
                     log.success("[Classic] Link key verified")
                 else:

--- a/kindle_hid_passthrough/device_cache.py
+++ b/kindle_hid_passthrough/device_cache.py
@@ -6,6 +6,8 @@ import logging
 import os
 from typing import Dict, Optional
 
+from config import normalize_addr
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,7 +32,7 @@ class DeviceCache:
         Returns:
             Path to cache file
         """
-        safe_addr = address.replace(':', '_').replace('/', '_')
+        safe_addr = normalize_addr(address).replace(':', '_')
         return os.path.join(self.cache_dir, f"{safe_addr}.json")
 
     def load(self, address: str) -> Optional[Dict]:

--- a/tests/test_device_cache.py
+++ b/tests/test_device_cache.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'kindle_hid_passthrough'))
+
+from device_cache import DeviceCache
+
+
+def test_suffixed_and_bare_addresses_share_one_file(tmp_path):
+    cache = DeviceCache(str(tmp_path))
+    cache.save('8A:76:5A:2F:36:23/P', {'report_map': 'aabb'})
+    assert cache.load('8a:76:5a:2f:36:23') == {'report_map': 'aabb'}
+    assert cache.clear('8A:76:5A:2F:36:23') == 1
+    assert cache.load('8A:76:5A:2F:36:23/P') is None


### PR DESCRIPTION
Fallout from sweeping for the same suffix leak as #172, two lookups that key on the address plus its type instead of just the address.

`DeviceCache` built its filename from the raw address, so `/P` turned into `_P` and one device ended up with two cache files. Callers feed both forms and disagree about which, the daemon saves under the suffixed peer address while `request_remove()` clears the normalized one. Remove a device and its descriptor survives, then comes back on the next pair, which is a nasty one to hit if the cached descriptor is what you were trying to get rid of. Classic also re-queried SDP on every single connect, because it went looking for the filename pairing had written and never found it.

The Classic post-pair check read the keystore with the bare address, but bumble keys its entries by `str(peer_address)`. So it never found the key it had just stored and every successful Classic pairing logged `Link key not found in keystore!`. Cosmetic, but it has been sending triage the wrong way. Reads it the way the BLE side already does now.

One test, it fails on the old code and passes on the new. Suite is 28.

Existing `*_P.json` caches go orphaned and get re-queried once, then land under the bare name.
