### PR TITLE
fix(host): stop rebuilding the transport every 60s while idle

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -322,19 +322,26 @@ class HIDHost(ClassicMixin, BLEMixin):
                         pass
 
     async def _session_watchdog(self):
-        """Ask the daemon for a transport rebuild when idle too long."""
+        """Ask the daemon for a transport rebuild if nothing ever connects.
+
+        Once a device has connected, an empty session set is a device that
+        went to sleep, not a broken transport: the handlers keep initiating
+        on the open radio, so rebuilding would only make us deaf for a while.
+        """
+        had_session = False
         while True:
             self._sessions_changed.clear()
-            if not self.sessions:
-                try:
-                    await asyncio.wait_for(
-                        self._sessions_changed.wait(),
-                        timeout=self.FIRST_SESSION_TIMEOUT)
-                except asyncio.TimeoutError:
-                    log.warning("Connection timeout - no device connected")
-                    raise InvalidStateError("No device connected within timeout")
-            else:
+            if self.sessions or had_session:
+                had_session = True
                 await self._sessions_changed.wait()
+                continue
+            try:
+                await asyncio.wait_for(
+                    self._sessions_changed.wait(),
+                    timeout=self.FIRST_SESSION_TIMEOUT)
+            except asyncio.TimeoutError:
+                log.warning("Connection timeout - no device connected")
+                raise InvalidStateError("No device connected within timeout")
 
     def _notify_sessions_changed(self):
         if self._sessions_changed:


### PR DESCRIPTION
Refs #100

`_session_watchdog` re-arms `FIRST_SESSION_TIMEOUT` on every idle gap, not just the first, so any time nothing is connected it tears down the transport, the uhid node and the chip, then rebuilds. On a Basic 5 that is a rebuild every 65.8s, radio down for six of every sixty six seconds, so a remote that wakes into that window gets missed.

The connect loops already run forever, so the timeout now only covers the never connected case.

Tested on a Basic 5. Zero rebuilds in 3.5 min after a session ended where the old code did three, with Classic paging carrying on throughout, and the never connected path still rebuilds on schedule.