### PR TITLE
fix(classic): SET_PROTOCOL never reached the device (#172)

### DIFF
--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -72,7 +72,7 @@ class ClassicHIDChannels:
 
     def set_report_protocol(self):
         """Send HIDP SET_PROTOCOL(Report) on the control channel."""
-        self.ctrl_channel.write(
+        self.ctrl_channel.send_pdu(
             bytes(SetProtocolMessage(protocol_mode=Message.ProtocolMode.REPORT_PROTOCOL)))
 
     async def disconnect(self):

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -45,6 +45,8 @@ class DeviceSession:
         self.uhid_device = None
         self.is_pointer = False
         self.last_report = None
+        self.forwarded_report = False
+        self.dropped_report = False
         self.setup_task = None
         self.closed = False
         self.teardown_done = asyncio.Event()
@@ -492,11 +494,20 @@ class HIDHost(ClassicMixin, BLEMixin):
         if data != session.last_report:
             log.debug(f"Report: {data.hex()}")
             session.last_report = data
+        proto = session.protocol.value.upper()
         if session.uhid_device:
+            if not session.forwarded_report:
+                session.forwarded_report = True
+                log.info(f"[{proto}] first report forwarded to UHID from "
+                         f"{session.address}: {data.hex()}")
             try:
                 session.uhid_device.send_input(data)
             except Exception as e:
                 log.warning(f"UHID send failed: {e}")
+        elif not session.dropped_report:
+            session.dropped_report = True
+            log.warning(f"[{proto}] {session.address} sent a report before its UHID node "
+                        f"existed; that input is dropped")
 
     def _load_cached_descriptor(self, session: DeviceSession) -> bool:
         """Load report descriptor and device name from cache. Returns True if found."""


### PR DESCRIPTION
Refs #172 (the zero-raw-events half; the `/P` suffix half is already fixed by #173).

Two commits: the fix is one line, the logging is separate and droppable.

## The bug (1 line)

`ClassicHIDChannels.set_report_protocol()` called `ctrl_channel.write(...)`, but bumble's `ClassicChannel` has no `write()`, only `send_pdu()`. Every call raised `AttributeError`, and the call site catches `Exception` and logs a warning, so it failed silently:

```
WARNING [Classic] SET_PROTOCOL failed: 'ClassicChannel' object has no attribute 'write'
```

Regression from 3a29be8 (the refactor that dropped `bumble.hid.Host`). Since then **no Classic device has ever been sent SET_PROTOCOL(Report)**.

Verified on an Xbox controller, before and after:

```
01:25:39  SET_PROTOCOL failed: 'ClassicChannel' object has no attribute 'write'
01:34:08  Sent SET_PROTOCOL (Report)
01:34:09  first report forwarded to UHID from 98:B9:EA:01:67:68: 01008000800080008000000000000000
```

## Why the second commit exists (11 lines)

This sat unnoticed because the report path fails silently at INFO: nothing distinguished "input reached the node" from "input was dropped". Two log lines in `_forward_report` fix that, no debug build needed.

The dropped-report warning fires on every connect here, which is a **second, separate bug** left unfixed: the peer starts sending ~200ms before the UHID node is created, and that input is lost.

```
01:34:09,015 WARNING 98:B9:EA:01:67:68 sent a report before its UHID node existed; that input is dropped
01:34:09,202 INFO    UHID device created: Xbox Wireless Controller
```

For a page turner that is the press the user actually made, so it likely deserves its own issue.

## Testing

Most likely cause of the dead input on the PW12 in #172. Once this lands, the new lines will say whether reports reach the node. Also worth checking whether that log shows `Using fallback descriptor` (SDP parse failure), since a fallback descriptor that does not match the device produces the same "node looks right, no usable events" symptom.