### PR TITLE
fix(power): watch powerd on every chip, bracket the real suspend on MTK (#180)

### DIFF
--- a/justfile
+++ b/justfile
@@ -150,6 +150,7 @@ check:
 test:
     python3 {{src_dir}}/tests/test_hci_parser.py
     python3 {{src_dir}}/tests/test_cpu_latency.py
+    python3 {{src_dir}}/tests/test_power_policy.py
 
 # Run mock API server for local WAF app testing
 mock-server:

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -219,12 +219,19 @@ class DaemonController:
 
     async def _do_system_suspend(self, event):
         async with self._op_lock:
+            keeps_radio = chip().survives_suspend
+            # A chip that outlives the screensaver keeps serving the remote
+            # with the screen off; only a real suspend has to detach, and it
+            # must, or the peer holds a dead link and stops page scanning.
+            if keeps_radio and event != 'readyToSuspend':
+                return
             if self.daemon._suspended:
                 return
-            logger.info(f"System suspend ({event}): powering BT off")
+            logger.info(f"System suspend ({event}): releasing BT")
             self._suspended_by_system = True
             await self.daemon.suspend()
-            chip().power_off()
+            if not keeps_radio:
+                chip().power_off()
 
     def on_system_resume(self, event):
         """From power monitor thread: re-warm BT after wake."""

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -259,11 +259,9 @@ async def main():
     server_thread.start()
     log.info(f"API server listening on port {PORT}")
 
-    monitor = None
-    if not chip().survives_suspend:
-        monitor = PowerMonitor(controller)
-        monitor.start()
-        log.info("Watching powerd for system suspend")
+    monitor = PowerMonitor(controller)
+    monitor.start()
+    log.info("Watching powerd for system suspend")
 
     # Signal handling
     shutdown = asyncio.Event()
@@ -293,8 +291,7 @@ async def main():
             except asyncio.CancelledError:
                 pass
 
-    if monitor:
-        monitor.stop()
+    monitor.stop()
     server.shutdown()
     logger.info("Daemon stopped")
 

--- a/tests/test_power_policy.py
+++ b/tests/test_power_policy.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for the powerd suspend policy (issue #180). Run: python3 tests/test_power_policy.py"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'kindle_hid_passthrough'))
+
+import controller as controller_mod  # noqa: E402
+from controller import DaemonController  # noqa: E402
+
+
+class FakeDaemon:
+    def __init__(self):
+        self._suspended = False
+        self.running = True
+        self.calls = []
+
+    async def suspend(self):
+        self.calls.append('suspend')
+        self._suspended = True
+
+    async def resume(self):
+        self.calls.append('resume')
+        self._suspended = False
+
+
+class FakeChip:
+    def __init__(self, survives_suspend):
+        self.survives_suspend = survives_suspend
+        self.calls = []
+
+    def power_off(self):
+        self.calls.append('power_off')
+
+
+def drive(survives_suspend, events):
+    """Feed powerd events to a fresh controller; return (daemon, chip)."""
+    daemon = FakeDaemon()
+    chip = FakeChip(survives_suspend)
+    controller_mod.chip = lambda: chip
+
+    async def run():
+        ctrl = DaemonController(daemon)
+        for event in events:
+            if event in ('goingToScreenSaver', 'readyToSuspend'):
+                await ctrl._do_system_suspend(event)
+            else:
+                await ctrl._do_system_resume(event)
+
+    asyncio.run(run())
+    return daemon, chip
+
+
+def test_broadcom_brackets_screen_off():
+    daemon, chip = drive(False, ['goingToScreenSaver', 'outOfScreenSaver'])
+    assert daemon.calls == ['suspend', 'resume'], daemon.calls
+    assert chip.calls == ['power_off'], chip.calls
+
+
+def test_mtk_keeps_radio_up_across_the_screensaver():
+    daemon, chip = drive(True, ['goingToScreenSaver', 'outOfScreenSaver'])
+    assert daemon.calls == [], daemon.calls
+    assert chip.calls == [], chip.calls
+
+
+def test_mtk_detaches_for_a_real_suspend_without_powering_off():
+    daemon, chip = drive(
+        True, ['goingToScreenSaver', 'readyToSuspend', 'wakeupFromSuspend'])
+    assert daemon.calls == ['suspend', 'resume'], daemon.calls
+    assert chip.calls == [], chip.calls
+    assert not daemon._suspended
+
+
+def test_mtk_resumes_once_when_both_wake_events_arrive():
+    daemon, _ = drive(
+        True, ['readyToSuspend', 'wakeupFromSuspend', 'outOfScreenSaver'])
+    assert daemon.calls == ['suspend', 'resume'], daemon.calls
+
+
+def test_mtk_resumes_when_only_the_screensaver_wake_arrives():
+    daemon, _ = drive(True, ['readyToSuspend', 'outOfScreenSaver'])
+    assert daemon.calls == ['suspend', 'resume'], daemon.calls
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Refs #180.

`PowerMonitor` only started on Broadcom, so on MTK nothing bracketed sleep. We suspend holding a live session and come back still thinking we hold it. On the KPW6 in #180 no disconnect ever arrives, so the session stays alive, `/status` keeps saying connected, and both connect loops skip the address because it is still in `self.sessions`. No logs, no retries.

Now the monitor runs on every chip and the policy comes from the chip. Broadcom is unchanged. MTK keeps the link up through the screensaver and only brackets `readyToSuspend`, without powering the radio off.

Tested on a Basic 4/5. The detach now goes out while the handle is valid, before it failed with `INVALID_COMMAND_PARAMETERS_ERROR` at wake. Stack is back 1.4s after the resume event, paging at 3.4s, held over four sleep cycles.

That device recovers on its own either way, so the reconnect fix is unverified and needs the KPW6 in #180. Broadcom path untested, no device available.
