### PR TITLE
fix(uhid): keep the digitizer, pad only what the kernel cannot take (#172)

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -16,7 +16,7 @@ from device_cache import DeviceCache
 from logging_utils import log
 from pairing import create_keystore, create_pairing_config
 from transport import create_bumble_device
-from uhid_handler import Bus, UHIDDevice, descriptor_is_pointer, strip_digitizer_collections
+from uhid_handler import Bus, UHIDDevice, descriptor_is_pointer, sanitize_digitizer
 
 __all__ = ['HIDHost']
 
@@ -521,7 +521,7 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         try:
             name = self._configured_name(session.address) or session.name or "HID Device"
-            descriptor = strip_digitizer_collections(session.report_map)
+            descriptor = sanitize_digitizer(session.report_map)
             session.uhid_device = UHIDDevice(
                 name=name,
                 report_descriptor=descriptor,

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -6,29 +6,32 @@ import os
 import struct
 from typing import Optional
 
-__all__ = ['UHIDDevice', 'UHIDError', 'Bus', 'strip_digitizer_collections']
+__all__ = ['UHIDDevice', 'UHIDError', 'Bus', 'sanitize_digitizer']
 
 logger = logging.getLogger(__name__)
 
-def strip_digitizer_collections(descriptor: bytes) -> bytes:
-    """Drop any top-level collection that contains a Digitizer (0x0D) usage.
+def sanitize_digitizer(descriptor: bytes) -> bytes:
+    """Make a Digitizer usable on the Kindle instead of discarding it.
 
-    Two reasons a Digitizer must never reach the Kindle:
-      * The kernel lacks CONFIG_HID_MULTITOUCH, so hid-core silently drops the
-        whole UHID device when a Digitizer collection is present.
-      * Digitizer Tip Pressure surfaces as EV_ABS:ABS_PRESSURE, which KOReader's
-        Kindle gyro decoders read as a screen-rotation event and use to flip the
-        reader into the opposite landscape (issue #83).
+    Tip Pressure is turned into padding, because EV_ABS:ABS_PRESSURE is what
+    KOReader's gyro decoders read as a screen-rotation event (issue #83). The
+    field keeps its bits so the report layout still matches what the device
+    sends, it just stops producing an event.
 
-    A Digitizer usage page anywhere inside a top-level collection taints the
-    whole collection, so a digitizer nested in a keyboard/pointer combo is
-    caught too, not only a digitizer declared at the collection's top.
+    Only genuine multitouch collections (Contact Identifier / Contact Count)
+    are dropped, since the kernel has no CONFIG_HID_MULTITOUCH to parse them.
+    Single-touch digitizers are left alone: hid-generic handles them and gives
+    us BTN_TOUCH plus ABS_X/ABS_Y, which is what page turners report on and
+    what gesture mapping needs.
     """
+    out = bytearray(descriptor)
     kept = []
     i = 0
     seg_start = 0
     depth = 0
-    seg_has_digitizer = False
+    usage_page = None
+    usages = []
+    seg_multitouch = False
 
     while i < len(descriptor):
         b = descriptor[i]
@@ -50,29 +53,36 @@ def strip_digitizer_collections(descriptor: bytes) -> bytes:
         else:
             val = 0
 
-        # Global Usage Page item, at any depth: 0x0D taints the segment.
-        if item_type == 1 and tag == 0 and val == 0x0D:
-            seg_has_digitizer = True
-        if item_type == 0 and tag == 10:
-            depth += 1
-        if item_type == 0 and tag == 12:
-            depth -= 1
-            if depth == 0:
-                end = i + 1 + size
-                if not seg_has_digitizer:
-                    kept.append(descriptor[seg_start:end])
-                seg_start = end
-                seg_has_digitizer = False
+        if item_type == 1 and tag == 0:                 # Global: Usage Page
+            usage_page = val
+        elif item_type == 2 and tag == 0:               # Local: Usage
+            page = (val >> 16) if size == 4 else usage_page
+            usage = (val & 0xFFFF) if size == 4 else val
+            usages.append((page, usage))
+            if page == 0x0D and usage in (0x51, 0x54):  # Contact ID / Count
+                seg_multitouch = True
+        elif item_type == 0:                            # Main item
+            if tag == 8 and usages and all(u == (0x0D, 0x30) for u in usages):
+                out[i + 1] |= 0x01                      # Input: set Constant
+            if tag == 10:
+                depth += 1
+            elif tag == 12:
+                depth -= 1
+                if depth == 0:
+                    end = i + 1 + size
+                    if not seg_multitouch:
+                        kept.append(bytes(out[seg_start:end]))
+                    seg_start = end
+                    seg_multitouch = False
+            usages = []
 
         i += 1 + size
 
-    if not kept:
-        return descriptor
-
-    result = b''.join(kept)
+    result = b''.join(kept) if kept else bytes(out)
     if result != descriptor:
-        logger.info(f"Stripped digitizer collection(s) ({len(descriptor)} -> {len(result)} bytes)")
+        logger.info(f"Sanitized digitizer ({len(descriptor)} -> {len(result)} bytes)")
     return result
+
 
 def descriptor_is_pointer(descriptor: bytes) -> bool:
     """True if the descriptor's first top-level Application collection is a

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -13,25 +13,22 @@ logger = logging.getLogger(__name__)
 def sanitize_digitizer(descriptor: bytes) -> bytes:
     """Make a Digitizer usable on the Kindle instead of discarding it.
 
-    Tip Pressure is turned into padding, because EV_ABS:ABS_PRESSURE is what
-    KOReader's gyro decoders read as a screen-rotation event (issue #83). The
-    field keeps its bits so the report layout still matches what the device
-    sends, it just stops producing an event.
+    Three fields are turned into padding rather than removed, so the report
+    layout still matches what the device sends and only the events change:
+    Tip Pressure, because EV_ABS:ABS_PRESSURE is what KOReader's gyro decoders
+    read as a screen rotation (issue #83), and Contact Identifier and Contact
+    Count, because the kernel has no CONFIG_HID_MULTITOUCH to parse them and
+    drops the whole device when they are present.
 
-    Only genuine multitouch collections (Contact Identifier / Contact Count)
-    are dropped, since the kernel has no CONFIG_HID_MULTITOUCH to parse them.
-    Single-touch digitizers are left alone: hid-generic handles them and gives
-    us BTN_TOUCH plus ABS_X/ABS_Y, which is what page turners report on and
+    What is left is a single-touch digitizer, which hid-generic handles: it
+    gives BTN_TOUCH plus ABS_X/ABS_Y, which is what page turners report on and
     what gesture mapping needs.
     """
+    NEUTRALIZE = {(0x0D, 0x30), (0x0D, 0x51), (0x0D, 0x54)}
     out = bytearray(descriptor)
-    kept = []
     i = 0
-    seg_start = 0
-    depth = 0
     usage_page = None
     usages = []
-    seg_multitouch = False
 
     while i < len(descriptor):
         b = descriptor[i]
@@ -53,34 +50,22 @@ def sanitize_digitizer(descriptor: bytes) -> bytes:
         else:
             val = 0
 
-        if item_type == 1 and tag == 0:                 # Global: Usage Page
+        if item_type == 1 and tag == 0:
             usage_page = val
-        elif item_type == 2 and tag == 0:               # Local: Usage
+        elif item_type == 2 and tag == 0:
             page = (val >> 16) if size == 4 else usage_page
-            usage = (val & 0xFFFF) if size == 4 else val
-            usages.append((page, usage))
-            if page == 0x0D and usage in (0x51, 0x54):  # Contact ID / Count
-                seg_multitouch = True
-        elif item_type == 0:                            # Main item
-            if tag == 8 and usages and all(u == (0x0D, 0x30) for u in usages):
-                out[i + 1] |= 0x01                      # Input: set Constant
-            if tag == 10:
-                depth += 1
-            elif tag == 12:
-                depth -= 1
-                if depth == 0:
-                    end = i + 1 + size
-                    if not seg_multitouch:
-                        kept.append(bytes(out[seg_start:end]))
-                    seg_start = end
-                    seg_multitouch = False
+            usages.append((page, val & 0xFFFF if size == 4 else val))
+        elif item_type == 0:
+            if tag == 8 and usages and all(u in NEUTRALIZE for u in usages):
+                out[i + 1] |= 0x01
             usages = []
 
         i += 1 + size
 
-    result = b''.join(kept) if kept else bytes(out)
+    result = bytes(out)
     if result != descriptor:
-        logger.info(f"Sanitized digitizer ({len(descriptor)} -> {len(result)} bytes)")
+        logger.info(f"Sanitized digitizer ({len(descriptor)} bytes, "
+                    f"pressure and contact fields padded)")
     return result
 
 


### PR DESCRIPTION
Fixes the zero-input half of #172.

Deleting Digitizer collections leaves devices with no axes, so reports the kernel has no definition for are discarded. The node looks healthy and no input ever arrives, which is what #172 reports and what an S18 in mouse mode does here.

Instead of deleting, three fields are marked Constant so the descriptor stays the size the device reports and only the events change:

- **Tip Pressure**, because `ABS_PRESSURE` is what KOReader's gyro decoders read as a screen rotation (#83)
- **Contact Identifier** and **Contact Count**, because the kernel has no `CONFIG_HID_MULTITOUCH` to parse them and drops the whole device when they are present

What is left is a single-touch digitizer, which hid-generic handles and which gives `BTN_TOUCH` plus `ABS_X`/`ABS_Y`.

## Verified on device

An S18 in mouse mode, its real cached descriptor and a real report:

| | descriptor | node | events |
|---|---|---|---|
| before | 124 → 37 | `EV=13`, no axes | none |
| after | 124 → 124 | `EV=1b`, `ABS=3` | `BTN_TOUCH`, `ABS_X=500`, `ABS_Y=250` |

Synthetic descriptors, on a Basic 4:

| descriptor | node | events |
|---|---|---|
| digitizer, no pressure | yes | BTN_TOUCH, ABS_X, ABS_Y |
| digitizer + pressure | yes | X/Y kept, no ABS_PRESSURE |
| keyboard + multitouch | yes | keyboard still works |

An earlier version of this dropped collections containing Contact Identifier or Count. That still killed the S18, since those are exactly the fields it uses, so it now pads them rather than dropping anything.

Also unblocks swipe gesture mapping in kindle-button-mapper, which needs the coordinate stream this used to throw away.

## Before merging

Worth confirming against the #172 reporter's own descriptor. His Classic mode may be a separate bug: that run used a different 162-byte descriptor with no stripping and never logged a forwarded report.