### PR TITLE
Fix the Bluetooth toggle getting stuck on or off

### DIFF
--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -252,7 +252,7 @@ var BTManager = (function() {
             if (json === lastStatusJson) return;
             lastStatusJson = json;
 
-            var running = data.daemon_running || data.scanning || data.pairing;
+            var running = data.daemon_running;
             setToggleUI(running);
 
             var conns = getConnections(data);

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -149,19 +149,15 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def _handle_start(self):
         controller = self._controller
-        if controller.daemon.running and not controller.daemon._suspended:
-            self._send_json({"ok": True, "message": "Daemon already running"})
-            return
+        controller.bt_enabled = True
         controller.request_connect()
-        self._send_json({"ok": True, "message": "Daemon resuming"})
+        self._send_json({"ok": True, "message": "Bluetooth on"})
 
     def _handle_stop(self):
         controller = self._controller
-        if controller.daemon._suspended:
-            self._send_json({"ok": True, "message": "Already stopped"})
-            return
+        controller.bt_enabled = False
         controller.request_disconnect(suspend=True)
-        self._send_json({"ok": True, "message": "Daemon stopped"})
+        self._send_json({"ok": True, "message": "Bluetooth off"})
 
     def _handle_devices(self):
         status = self._controller.get_status()

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -35,6 +35,7 @@ class DaemonController:
 
         self._op_lock = asyncio.Lock()
         self._suspended_by_system = False
+        self.bt_enabled = True
 
         # Scan state
         self.scan_result = None
@@ -59,7 +60,7 @@ class DaemonController:
         devices = self._get_devices_cached()
 
         status = {
-            "daemon_running": self.daemon.running and not self.daemon._suspended,
+            "daemon_running": self.bt_enabled and self.daemon.running,
             "devices": devices,
             "device_count": len(devices),
             "scanning": self.is_scanning,
@@ -71,6 +72,11 @@ class DaemonController:
         status["connections"] = conn.get("connections", [])
 
         return status
+
+    async def _resume_if_enabled(self):
+        """Resume unless BT was toggled off while the op ran."""
+        if self.bt_enabled:
+            await self.daemon.resume()
 
     def _get_devices_cached(self) -> list:
         """Device list from devices.conf, cached by file mtime."""
@@ -138,7 +144,7 @@ class DaemonController:
                 self.scan_result = {"ok": False, "error": str(e)}
             finally:
                 self.is_scanning = False
-                await self.daemon.resume()
+                await self._resume_if_enabled()
 
     # ---- Pair ----
 
@@ -176,7 +182,7 @@ class DaemonController:
                 self.pair_result = {"ok": False, "address": address, "error": str(e)}
             finally:
                 self.is_pairing = False
-                await self.daemon.resume()
+                await self._resume_if_enabled()
 
     # ---- Connect / Resume ----
 
@@ -206,10 +212,10 @@ class DaemonController:
             try:
                 await self.daemon.suspend()
                 config.add_device(address, protocol)
-                await self.daemon.resume()
+                await self._resume_if_enabled()
             except Exception as e:
                 logger.error(f"Connect failed: {errstr(e)}")
-                await self.daemon.resume()
+                await self._resume_if_enabled()
 
     # ---- System suspend (powerd) ----
 
@@ -242,7 +248,7 @@ class DaemonController:
             if not self._suspended_by_system:
                 return
             self._suspended_by_system = False
-            if not self.daemon._suspended:
+            if not self.bt_enabled or not self.daemon._suspended:
                 return
             logger.info(f"System resume ({event}): restarting BT")
             await self.daemon.resume()

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -22,6 +22,8 @@ from scanner import Scanner
 
 logger = logging.getLogger(__name__)
 
+SUSPEND_TIMEOUT = 10.0
+
 
 class HIDDaemon:
     """Daemon that maintains persistent connection to an HID device."""
@@ -52,21 +54,32 @@ class HIDDaemon:
         # Cancel the host task first — this stops host.run()'s connect loop
         if self._host_task and not self._host_task.done():
             self._host_task.cancel()
-            try:
-                await self._host_task
-            except (asyncio.CancelledError, Exception):
-                pass
+            await self._abandon_after_timeout(self._host_task, "host task")
             self._host_task = None
 
         # Then clean up any remaining resources
         if self.host:
-            try:
-                await self.host.cleanup()
-            except Exception:
-                pass
+            await self._abandon_after_timeout(
+                asyncio.ensure_future(self.host.cleanup()), "host cleanup")
             self.host = None
 
         logger.info("Daemon suspended")
+
+    @staticmethod
+    async def _abandon_after_timeout(task, what):
+        """Wait out a teardown task, then leave it behind if it will not end.
+
+        asyncio.wait() is deliberate: wait_for() re-cancels and awaits, which
+        hangs forever on a task that ignores cancellation.
+        """
+        done, _ = await asyncio.wait({task}, timeout=SUSPEND_TIMEOUT)
+        if not done:
+            logger.warning(f"Suspend: {what} did not finish, abandoning it")
+            return
+        try:
+            task.result()
+        except (asyncio.CancelledError, Exception):
+            pass
 
     async def scan(self, duration=10.0, on_device_found=None):
         """Scan for BT devices. Must be called while suspended."""


### PR DESCRIPTION
Two bugs behind the toggle being unreliable, both found on a Kindle Basic 4.

`daemon._suspended` meant both "detached for a scan" and "user turned Bluetooth off", so stop during a scan replied `Already stopped` and did nothing, and the scan turned the radio back on when it finished. The controller now tracks what the user asked for, and scan, pair, connect and powerd wake only resume if it is still on.

Turning Bluetooth off with a device connected could hang the daemon at `Daemon suspending...`, taking every later scan, pair and sleep with it. bumble leaves a pending HCI future nothing resolves, `cleanup()` sits in `channels.disconnect()` with no timeout, and `suspend()` had no bound either. Both teardowns are bounded now and get abandoned if they will not finish. `asyncio.wait` and not `wait_for`, since `wait_for` re-cancels and awaits, which hangs in exactly this case.

Tested on device. Scan then stop no longer leaves Bluetooth on, off then scan stays off, state is right the moment the request returns, rapid toggling holds up, and connect then stop with a gamepad connected suspends in about 350ms instead of hanging.
