### PR TITLE
ci: roll the Nuitka cache key so it saves on every run

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -30,8 +30,10 @@ jobs:
         id: cache-nuitka
         with:
           path: cache-nuitka
-          key: nuitka-cache-${{ runner.arch }}
-          restore-keys: nuitka-cache-
+          key: nuitka-cache-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            nuitka-cache-${{ runner.arch }}-
+            nuitka-cache-
 
       - name: Inject buildkit cache
         uses: reproducible-containers/buildkit-cache-dance@v3


### PR DESCRIPTION
The Nuitka/ccache cache has been dead since April.

`actions/cache` only writes a new entry when the primary key misses. The key was static (`nuitka-cache-${{ runner.arch }}`), so every run restored the entry saved on 11 April and then logged:

```
Cache hit occurred on the primary key nuitka-cache-ARM64, not saving cache
```

The cache froze there while the sources moved on. Current builds report:

```
Cached C files (using ccache) with result 'cache miss': 199
```

All 199 files miss, every build.

Adding `github.run_id` to the key makes each run save a fresh entry, and the restore-keys prefixes pick up the most recent one. This also flips `skip-extraction` to false, so buildkit-cache-dance actually extracts the mounts back out for saving.

Expected saving is around 4 minutes on the ~210s C compile phase. The 826s LTO link is not cacheable, so this does not touch the main cost.