### PR TITLE
ci: share the build cache across PRs via GHCR, stop cache thrashing

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
+      packages: write
 
     steps:
       - name: Checkout
@@ -25,9 +26,27 @@ jobs:
         uses: docker/setup-buildx-action@v4
         id: setup-buildx
 
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Restore Nuitka build cache
+        if: github.ref != 'refs/heads/main'
+        uses: actions/cache/restore@v4
+        with:
+          path: cache-nuitka
+          key: nuitka-cache-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            nuitka-cache-${{ runner.arch }}-
+            nuitka-cache-
+
+      - name: Restore and save Nuitka build cache
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache@v4
-        id: cache-nuitka
         with:
           path: cache-nuitka
           key: nuitka-cache-${{ runner.arch }}-${{ github.run_id }}
@@ -41,7 +60,7 @@ jobs:
           builder: ${{ steps.setup-buildx.outputs.name }}
           cache-dir: cache-nuitka
           dockerfile: .github/Dockerfile.arm
-          skip-extraction: ${{ steps.cache-nuitka.outputs.cache-hit }}
+          skip-extraction: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Stamp build SHA
         id: stamp
@@ -64,8 +83,8 @@ jobs:
           platforms: linux/arm/v7
           tags: kindle-hid-passthrough-builder
           load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/zampierilucas/kindle-hid-passthrough-buildcache
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=registry,ref=ghcr.io/zampierilucas/kindle-hid-passthrough-buildcache,mode=max' || '' }}
 
       - name: Extract binaries
         run: |


### PR DESCRIPTION
Makes PR builds benefit from each other instead of each one independently restoring whatever main last wrote.

## Why

GitHub's Actions cache scopes every entry to the branch that wrote it. A PR can read main's cache but never another PR's, so there is currently no cross-PR reuse at all. You can see it in the cache listing — everything useful is `refs/heads/main`, and PR #189 only has its own `refs/pull/189/merge` entry.

The repo is also at **7.38 GB across 502 entries** against GitHub's **10 GB cap**. Each `nuitka-cache-ARM64-<run_id>` is 168 MB, and after #193 every run wrote a new one. At ~38 builds/week that is ~6 GB of new entries weekly, pinning the repo against the ceiling and evicting the buildkit blobs by LRU. #193 fixed a dead cache and gave us a thrashing one.

## What changed

**Buildkit layer cache moves to GHCR.** `type=registry` has no branch scoping, so every PR reads the same layers, and it does not count against the 10 GB quota. Only main writes it, so a fork PR cannot poison it, and only main needs registry credentials.

**Nuitka/ccache split into read-only and read-write.** PRs restore and write nothing; main restores and saves. Cuts the write volume roughly 4x. `skip-extraction` is gated the same way so PRs skip the extract pass they no longer need.

Kept `actions/cache@v4` on main rather than `cache/save` because buildkit-cache-dance extracts in a post step, and the combined action's post-save ordering runs after it. A mid-job `cache/save` would write before the extraction happened.

## One manual step after merge

The first main build creates `ghcr.io/zampierilucas/kindle-hid-passthrough-buildcache` as a **private** package. It has to be flipped to public so fork PRs can read it anonymously — Profile → Packages → the package → Package settings → Change visibility.

Until that is done, `cache-from` on fork PRs will fail to authenticate. That degrades gracefully — buildx warns and builds without the cache — so nothing breaks, PRs just stay slow.

## Testing

This PR's own build is the first test, but note it will not exercise the main-only paths. Those only run once it is merged.