### PR TITLE
test: build without LTO (measurement only, do not merge)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -79,7 +79,7 @@ RUN --mount=type=cache,target=/nuitka-cache \
     python3 -m nuitka \
     --mode=standalone \
     --jobs=$(nproc) \
-    --lto=yes \
+    --lto=no \
     --show-progress \
     --output-dir=/build/nuitka-out \
     --include-package=kindle_hid_passthrough \


### PR DESCRIPTION
Measurement branch. Not for merging.

LTO was measured as a win on 8-9 April, roughly 1600s down to 1250s. The ccache work landed 11 April, two days later.

LTO moves optimization work out of per-file compilation and into the link. When compilation was uncached, shrinking it paid off. Now compilation is cached to ~4s and the link is the only phase ccache cannot touch, so LTO moves work from the free phase into the expensive one.

Current hot-cache profile on main:

| Phase | Time |
|---|---|
| Nuitka analysis | 59s |
| Compile 199 C files | 4s |
| LTO link | 824s |
| Total | ~970s |

This flips `--lto=yes` to `--lto=no` to measure the link without it. Watching for total build time, and the `ls -lh output/dist/` output for any binary size regression.