### PR TITLE
test: lto-partition-max (measurement, keeps LTO)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -53,7 +53,7 @@ COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
 ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-Wl,--gc-sections"
+ENV LDFLAGS="-Wl,--gc-sections -flto-partition=max"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)


### PR DESCRIPTION
Measurement branch, keeps `--lto=yes`. Not for merging.

Target is the 824s LTO link, which is ~85% of a hot-cache build. LTO stays on because the output runs on a 2-core Kindle.