### PR TITLE
test: lto-jobs8 (measurement, keeps LTO)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -78,7 +78,7 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --mount=type=cache,target=/ccache \
     python3 -m nuitka \
     --mode=standalone \
-    --jobs=$(nproc) \
+    --jobs=8 \
     --lto=yes \
     --show-progress \
     --output-dir=/build/nuitka-out \


### PR DESCRIPTION
Measurement branch, keeps `--lto=yes`. Not for merging.

Target is the 824s LTO link, which is ~85% of a hot-cache build. LTO stays on because the output runs on a 2-core Kindle.