### PR TITLE
test: --jobs=1, measure LTO serial fraction (do not merge)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -78,7 +78,7 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --mount=type=cache,target=/ccache \
     python3 -m nuitka \
     --mode=standalone \
-    --jobs=$(nproc) \
+    --jobs=1 \
     --lto=yes \
     --show-progress \
     --output-dir=/build/nuitka-out \


### PR DESCRIPTION
Measurement only.

Forces `-flto=1`, a single LTO partition, fully serial. Compare the `took N seconds` link figure against the **824.4s** baseline at `-flto=4`.

If the link is roughly the same, the work is serial and no amount of cores will help — renting hardware is wasted money. If it is ~4x longer, LTRANS parallelises well and a 16 core box should scale.

Expect 199 ccache misses, since `-flto=N` is part of the compile flags. Only the link number matters.