### PR TITLE
fix(ble): report ID framing, LE supervision timeout, volume key codes

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -470,7 +470,8 @@ class BLEMixin:
 
     def _on_ble_hid_report(self, session, value, report_id):
         """Handle BLE HID report."""
-        self._forward_report(session, bytes([report_id]) + bytes(value))
+        prefix = bytes([report_id]) if report_id else b''
+        self._forward_report(session, prefix + bytes(value))
 
     async def _pair_ble(self, address: str) -> bool:
         """Pair with a BLE device."""

--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -181,7 +181,7 @@ class BLEMixin:
                     connection_interval_min=12,
                     connection_interval_max=24,
                     max_latency=0,
-                    supervision_timeout=72,
+                    supervision_timeout=500,
                     min_ce_length=0,
                     max_ce_length=0,
                 ), check_result=True)

--- a/koreader-plugin/hidpassthrough.koplugin/event_map_extra.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/event_map_extra.lua
@@ -20,6 +20,8 @@ return {
 
     -- Editing / application keys
     [113] = "Mute",
+    [114] = "VMinus",
+    [115] = "VPlus",
     [128] = "Stop",
     [129] = "Again",
     [130] = "Props",


### PR DESCRIPTION
Three BLE fixes out of #179, all found by @vitorroman17.

`_on_ble_hid_report` always prepended `report_id`, which `_process_ble_report_char` leaves at 0 when the Report Reference descriptor is missing. Report ID 0 means the device declares none, so its Report Map has none either and the extra byte shifts every field. A remote that sends one byte loses everything, hid-core reads the 0x00 as the whole report and emits no EV_KEY.

`supervision_timeout=72` is bumble's default copied into an HCI command we build by hand, which is also why nothing ever widens it. 720ms against the 30ms interval max we ask for is 24 missed events. Costs 5s to notice a device left the room instead of 720ms.

114 and 115 were missing from `event_map_extra.lua` while 113 was already there, and touch models never load the map that defines them. VMinus/VPlus to match externalkeyboard, since `_extendEventMap` reapplies over whatever map is live.

Not taking the Classic peripheral patch from that thread. A later commit on their branch reverses the premise and says the controller accepts the role switch most of the time, and it rewrites the #117 path.