### PR TITLE
perf(ci): drop unreachable bumble transports and the duplicate package build

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -82,7 +82,6 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --lto=yes \
     --show-progress \
     --output-dir=/build/nuitka-out \
-    --include-package=kindle_hid_passthrough \
     --include-data-file=kindle_hid_passthrough/config.ini=kindle_hid_passthrough/config.ini \
     --include-data-file=kindle_hid_passthrough/BUILD_SHA=kindle_hid_passthrough/BUILD_SHA \
     --include-data-dir=kindle_hid_passthrough/modules=kindle_hid_passthrough/modules \
@@ -92,6 +91,21 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --nofollow-import-to=grpc \
     --nofollow-import-to=google \
     --nofollow-import-to=usb \
+    --nofollow-import-to=bumble.transport.usb \
+    --nofollow-import-to=bumble.transport.pyusb \
+    --nofollow-import-to=bumble.transport.android_emulator \
+    --nofollow-import-to=bumble.transport.android_netsim \
+    --nofollow-import-to=bumble.transport.grpc_protobuf \
+    --nofollow-import-to=bumble.transport.ws_client \
+    --nofollow-import-to=bumble.transport.ws_server \
+    --nofollow-import-to=bumble.transport.tcp_client \
+    --nofollow-import-to=bumble.transport.tcp_server \
+    --nofollow-import-to=bumble.transport.udp \
+    --nofollow-import-to=bumble.transport.unix \
+    --nofollow-import-to=bumble.transport.vhci \
+    --nofollow-import-to=bumble.transport.hci_socket \
+    --nofollow-import-to=bumble.transport.pty \
+    --nofollow-import-to=platformdirs \
     kindle_hid_passthrough/main.py
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.


### PR DESCRIPTION
Cuts the Nuitka build from **199 C files to 110 (-45%)**, which is the input to the 824s LTO link that dominates the build.

Measured, not inferred — the candidate set was reproduced locally against real `bumble==0.0.226` and Nuitka 4.1.3, matching CI's 199 exactly, then rebuilt at 110 with zero new Nuitka warnings and nothing added.

## What is removed and why

**14 bumble transports (-58 C files).** `bumble/transport/__init__.py::_open_transport` imports each backend inside its own `if scheme == ...` branch. `config.py::_detect_transport()` only ever produces `serial:` or `file:`, and `config.ini` only documents `file:/dev/stpbt`. `bumble.transport.serial`, `.file` and `.common` are untouched. Cascades: ws_* removes 24 `websockets` modules, usb removes `usb1`, pyusb removes `libusb_package`, android_* removes 16 `grpc_protobuf` stubs.

**platformdirs (-6).** Only reachable via `bumble.drivers.project_data_dir()`, called from the intel/rtk firmware dir helpers, both gated behind `Driver.check(host)` which needs `hci_metadata` carrying vendor/product ids. That is only populated by `transport/usb.py` or an explicit `[driver=...]` tag — neither applies here.

**`--include-package=kindle_hid_passthrough` (-25).** This compiled every app module a *second* time under its package name, alongside the flat modules the code actually imports. Nothing anywhere does `import kindle_hid_passthrough.X` — `__init__.py` states outright that modules load via sys.path injection. The `--include-data-file`/`--include-data-dir` flags are independent and still stage `config.ini`, `BUILD_SHA` and `modules/`.

## Risk

Excluded transports fail at **runtime, not build time** — `_open_transport` dispatches on scheme name through function-local imports, so a build with a missing backend succeeds silently and only throws `ImportError` when opened. If anyone ever sets `hci_transport = usb:0` or `tcp-client:...` in config.ini, that goes from working to crashing on startup.

**Needs a device smoke test before merge**, specifically that the daemon starts, opens its transport, and pairs.

## Not done

Stdlib exclusions (`email`, `urllib`, `http.server`, …) contribute **zero** C files — Nuitka ships the stdlib as bytecode, so none of it reaches gcc. The existing `unittest`/`pytest`/`setuptools` lines are harmless no-ops. Also noted: `aiofiles` is pip-installed but imported by nothing.