### PR TITLE
test: clang + ThinLTO (measurement, needs on-device check)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patch \
     patchelf \
     ccache \
+    clang \
     libffi-dev \
     zlib1g-dev \
     linux-libc-dev \
@@ -52,7 +53,7 @@ COPY kindle_hid_passthrough/BUILD_SHA /build/kindle_hid_passthrough/
 COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
-ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
+ENV CFLAGS="-O3 -mlong-calls -ffunction-sections -fdata-sections"
 ENV LDFLAGS="-Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
@@ -80,6 +81,8 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --mode=standalone \
     --jobs=$(nproc) \
     --lto=yes \
+    --clang \
+    --experimental=thin-lto \
     --show-progress \
     --output-dir=/build/nuitka-out \
     --include-data-file=kindle_hid_passthrough/config.ini=kindle_hid_passthrough/config.ini \

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -27,7 +27,7 @@ jobs:
         id: setup-buildx
 
       - name: Log in to GHCR
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.head_ref == 'test/clang-thinlto'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore Nuitka build cache
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.head_ref != 'test/clang-thinlto'
         uses: actions/cache/restore@v4
         with:
           path: cache-nuitka
@@ -45,7 +45,7 @@ jobs:
             nuitka-cache-
 
       - name: Restore and save Nuitka build cache
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.head_ref == 'test/clang-thinlto'
         uses: actions/cache@v4
         with:
           path: cache-nuitka
@@ -60,7 +60,7 @@ jobs:
           builder: ${{ steps.setup-buildx.outputs.name }}
           cache-dir: cache-nuitka
           dockerfile: .github/Dockerfile.arm
-          skip-extraction: ${{ github.ref != 'refs/heads/main' }}
+          skip-extraction: ${{ github.ref != 'refs/heads/main' && github.head_ref != 'test/clang-thinlto' }}
 
       - name: Stamp build SHA
         id: stamp


### PR DESCRIPTION
Measurement branch. Based on main so the only variable is the compiler and LTO mode — compare the link against the **824.4s** baseline.

## Why

`--jobs=1` measured the link at **1526.3s** vs **824.4s** at `--jobs=4`. That is a 1.85x speedup from 4 cores, so ~61% parallelises and **~590s is irreducibly serial**. Amdahl caps any machine at ~11 min, and every rentable AArch32 core is slower per-core than the Cobalt 100 runner. Cutting LTO input 199 -> 110 in #200 only moved the link 824s -> 795s, confirming the cost is the serial stage, not file count.

ThinLTO is the only remaining lever that attacks that stage directly.

## Changes

- `clang` added to apt
- `--clang --experimental=thin-lto` — Nuitka requires **both**; `SconsCompilerSettings.py:250-262` only emits `-flto=thin` when clang mode and the experimental tag are set, otherwise `-flto=$job_count`
- `-mword-relocations` dropped — **GCC-only, clang errors with `unknown argument`**

## Risk

Roughly 50/50 it builds. `-mword-relocations` was added in 2fdd725 for "ARM conditional branch out of range". `-mlong-calls` is the flag that actually addresses branch range and clang keeps it, but dropping the other is plausible rather than proven. There is also a known pattern of LTO plus ARM flags breaking under LLD.

**Green CI is not sufficient here.** A clang-built binary has different runtime characteristics on a 2-core Kindle than a GCC one, and runtime is the whole reason LTO stays on. Needs on-device verification before this is considered.