### PR TITLE
test: Cirun provisioned Oracle Ampere A1 runner (needs credentials to run)

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,0 +1,8 @@
+runners:
+  - name: arm-builder
+    cloud: oracle
+    instance_type: VM.Standard.A1.Flex
+    machine_image: <OCID-of-Ubuntu-24.04-aarch64-image>
+    region: <your-oci-region>
+    labels:
+      - cirun-arm-builder

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build ARMv7
-    runs-on: ubuntu-24.04-arm
+    runs-on: "cirun-arm-builder--${{ github.run_id }}"
     permissions:
       contents: write
       packages: write
@@ -21,6 +21,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Ensure Docker is present
+        run: |
+          if ! command -v docker >/dev/null; then
+            curl -fsSL https://get.docker.com | sudo sh
+            sudo usermod -aG docker "$USER" || true
+          fi
+          docker version
+          echo "=== cpu ==="
+          nproc; lscpu | grep -E "Model name|MHz|^CPU\(s\)" || true
+          echo "=== can this CPU run 32-bit ARM? ==="
+          grep -o "32-bit EL0 Support" /var/log/dmesg 2>/dev/null || dmesg 2>/dev/null | grep -o "32-bit EL0 Support" || echo "(dmesg unavailable)"
+          docker run --rm --platform linux/arm/v7 arm32v7/debian:bookworm-slim uname -m || echo "ARM32 EXEC FAILED"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Draft scaffold. **Will not run until the Cirun app is installed and OCI credentials are added**, and the two placeholders in `.cirun.yml` are filled in.

## Why Oracle A1

Every rentable core that still executes 32-bit ARM is slower than the 3.4 GHz Cobalt 100 you get free from GitHub. Oracle's Ampere A1 at **3.0 GHz** is the closest, ahead of Hetzner CAX (2.0 GHz) and AWS Graviton3 (2.6 GHz). Graviton4 and 5 are ruled out entirely — AWS documents them as having no 32-bit support, so an `arm32v7` container cannot execute.

## Expected result, stated up front

**Probably ~11-12 minutes, not under 10.** `--jobs=1` measured the link at 1526s vs 824s at `--jobs=4`, so ~61% parallelises and **~590s is irreducibly serial** at 3.4 GHz. On a 3.0 GHz core that serial portion grows to roughly 670s no matter how many cores are added. More cores only compress the other 39%.

This is worth running because it is free, not because it is likely to hit the target on its own. Combined with ThinLTO (#201), if that works, it could.

## To make it run

1. Install the Cirun GitHub App on this repo
2. Add OCI credentials in the Cirun dashboard (user OCID, fingerprint, tenancy, compartment, API private key)
3. Fill in `region` and the Ubuntu 24.04 aarch64 image OCID in `.cirun.yml`
4. `VM.Standard.A1.Flex` is a flexible shape — OCPU count and memory may need setting via `extra_config`; Cirun's docs do not cover Oracle shape specifics, so this may need a round of adjustment

## The probe

A step before the build prints `nproc`, the CPU model and clock, checks dmesg for `32-bit EL0 Support`, and runs `docker run --platform linux/arm/v7 arm32v7/debian uname -m`. If Ampere Altra does not execute AArch32 on this shape, that step says so plainly instead of the build failing later for an unclear reason.

Also installs Docker, since Oracle's stock Ubuntu cloud image does not ship it.

## Note

Cirun is free for open source, but you still pay Oracle for the compute. Oracle's always-free A1 tier was cut to 2 OCPU / 12 GB in June 2026 — **fewer cores than the 4 you have now**, so the free tier would be slower. Paid A1 is $0.01/OCPU-hour, about $0.16/hour for 16 cores.