### PR TITLE
fix(classic): log what the error actually was

### DIFF
--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -14,7 +14,7 @@ from bumble.l2cap import ClassicChannelSpec
 from bumble.sdp import Client as SDPClient
 
 from config import Protocol, config, normalize_addr, clean_device_name
-from logging_utils import log
+from logging_utils import errstr, log
 
 FALLBACK_HID_DESCRIPTOR = bytes([
     0x05, 0x01, 0x09, 0x05, 0xa1, 0x01, 0x85, 0x01,
@@ -189,7 +189,7 @@ class ClassicMixin:
                 await asyncio.wait_for(connection.switch_role(Role.CENTRAL), timeout=5.0)
                 log.success("[Classic] Role switch complete, now central")
             except Exception as e:
-                log.warning(f"[Classic] Role switch failed: {e!r}")
+                log.warning(f"[Classic] Role switch failed: {errstr(e)}")
 
         if not connection.is_encrypted:
             log.info("[Classic] Restoring bonding (authenticate + encrypt)...")
@@ -198,7 +198,7 @@ class ClassicMixin:
                 await asyncio.wait_for(connection.encrypt(enable=True), timeout=5.0)
                 log.success("[Classic] Bonding restored")
             except Exception as e:
-                log.warning(f"[Classic] Bonding restore failed: {e!r}")
+                log.warning(f"[Classic] Bonding restore failed: {errstr(e)}")
 
         channels = session.channels
 
@@ -208,7 +208,7 @@ class ClassicMixin:
                 await asyncio.wait_for(channels.connect_control_channel(), timeout=5.0)
                 log.success("[Classic] HID control channel connected")
             except Exception as e:
-                log.warning(f"[Classic] Control channel: {e!r}")
+                log.warning(f"[Classic] Control channel: {errstr(e)}")
 
         if not channels.intr_channel:
             log.info("[Classic] Connecting to HID interrupt channel...")
@@ -216,7 +216,7 @@ class ClassicMixin:
                 await asyncio.wait_for(channels.connect_interrupt_channel(), timeout=5.0)
                 log.success("[Classic] HID interrupt channel connected")
             except Exception as e:
-                log.warning(f"[Classic] Interrupt channel: {e!r}")
+                log.warning(f"[Classic] Interrupt channel: {errstr(e)}")
 
         if not channels.intr_channel:
             raise InvalidStateError("[Classic] HID channels not opened by peer")
@@ -412,7 +412,7 @@ class ClassicMixin:
                 await asyncio.wait_for(connection.authenticate(), timeout=30.0)
                 log.success("[Classic] Authentication complete")
             except Exception as e:
-                log.warning(f"[Classic] Authentication: {e!r}")
+                log.warning(f"[Classic] Authentication: {errstr(e)}")
 
             log.info("[Classic] Waiting for link key...")
             try:
@@ -429,7 +429,7 @@ class ClassicMixin:
                         timeout=10.0
                     )
                 except Exception as e:
-                    log.warning(f"[Classic] Encryption: {e!r}")
+                    log.warning(f"[Classic] Encryption: {errstr(e)}")
 
             await self._query_classic_sdp(session)
 
@@ -507,14 +507,14 @@ class ClassicMixin:
             await asyncio.wait_for(channels.connect_control_channel(), timeout=5.0)
             log.success("[Classic] HID control channel connected")
         except Exception as e:
-            log.warning(f"[Classic] Control channel: {e!r}")
+            log.warning(f"[Classic] Control channel: {errstr(e)}")
 
         log.info("[Classic] Connecting to HID interrupt channel...")
         try:
             await asyncio.wait_for(channels.connect_interrupt_channel(), timeout=5.0)
             log.success("[Classic] HID interrupt channel connected")
         except Exception as e:
-            log.warning(f"[Classic] Interrupt channel: {e!r}")
+            log.warning(f"[Classic] Interrupt channel: {errstr(e)}")
 
         if not channels.intr_channel:
             log.error("[Classic] Failed to connect HID interrupt channel")

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from bumble.core import InvalidStateError
-from bumble.hci import HCI_LE_SET_PRIVACY_MODE_COMMAND, HCI_LE_Set_Privacy_Mode_Command, HCI_Write_Class_Of_Device_Command, HCI_Write_Local_Name_Command
+from bumble.hci import HCI_Constant, HCI_LE_SET_PRIVACY_MODE_COMMAND, HCI_LE_Set_Privacy_Mode_Command, HCI_Write_Class_Of_Device_Command, HCI_Write_Local_Name_Command
 
 from ble import BLEMixin
 from bt_setup import ensure_uhid
@@ -373,7 +373,8 @@ class HIDHost(ClassicMixin, BLEMixin):
 
     def _on_session_disconnection(self, session: DeviceSession, reason):
         proto = session.protocol.value.upper()
-        log.warning(f"[{proto}] Device disconnected: {session.address} (reason={reason})")
+        log.warning(f"[{proto}] Device disconnected: {session.address} "
+                    f"(reason={reason} {HCI_Constant.error_name(reason)})")
 
         if reason == 5 and session.protocol == Protocol.CLASSIC:
             log.info("[Classic] Authentication failure - will clear stale key and retry")


### PR DESCRIPTION
bumble's `HCI_Error.__repr__` returns the empty `HCI_Error()`, so every `{e!r}` in `classic.py` logged nothing useful. `str()` gives `HCI_Error(hci/COMMAND_DISALLOWED_ERROR [0xC])`. `errstr()` in `logging_utils` already does this and was used in every other module.

Disconnect reasons get decoded too, so `reason=19` reads `reason=19 REMOTE_USER_TERMINATED_CONNECTION_ERROR`. Unknown codes come back as hex instead of raising.

No behaviour change, 8 call sites plus the one in `host.py`. Raised in #203.