### PR TITLE
test: -O2 instead of -O3 (measurement, needs on-device check)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -52,7 +52,7 @@ COPY kindle_hid_passthrough/BUILD_SHA /build/kindle_hid_passthrough/
 COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
-ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
+ENV CFLAGS="-O2 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
 ENV LDFLAGS="-Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility


### PR DESCRIPTION
Based on main, so it stacks with #200's pruning. Compare the link against the current **795.2s** baseline at `-O3` with 110 files.

## Why this and not the others

Everything tried on the link so far redistributed work rather than reducing it, and all of it failed:

| Attempt | Link | vs 824.4s baseline |
|---|---|---|
| `-flto-partition=max` | 868.9s | +44s |
| `-flto=8` | 909.1s | +85s |
| clang `-flto=thin` | 1086.9s | +262s |
| prune 199 -> 110 files | 795.2s | -29s |

`--jobs=1` measured the link at 1526.3s vs 824.4s at `--jobs=4`, so only ~61% parallelises and **~590s is irreducibly serial**. `-O2` is the one remaining lever that shrinks that serial work instead of trying to spread it.

## The trade

Nuitka passes the inherited `-O` to both the per-TU compile and the LTO link, so this cuts link-time optimisation directly. It also produces a less optimised binary on a **2-core Kindle**, which is the whole reason LTO is on.

**A green build and a faster link are not sufficient evidence here.** This needs an on-device measurement of input responsiveness before it can be considered, the same way #200 was device-tested.

## What to read

- Link time from the `took N seconds` line attached to the `-o main.bin` command — **not** the first `took` line, which is the slowest single compile. I misread exactly that on #201 and reported a 37% win that was not real.
- `ls -lh output/dist/` for the binary size delta.