### PR TITLE
test: -flto-compression-level=0

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -52,8 +52,8 @@ COPY kindle_hid_passthrough/BUILD_SHA /build/kindle_hid_passthrough/
 COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
-ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-Wl,--gc-sections"
+ENV CFLAGS="-O3 -flto-compression-level=0 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
+ENV LDFLAGS="-flto-compression-level=0 -Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)


### PR DESCRIPTION
Cuts LTO bytecode compression I/O. **No codegen effect** — only changes how the intermediate representation is stored on disk, so a green build plus a link delta is sufficient evidence. No device test needed.

Baseline to beat: link **795.2s** (the `took N seconds` on the `-o main.bin` line, **not** the first `took` line which is the slowest single compile).

Expect ~110 ccache misses since flags changed, so the total is inflated. Only the link number is comparable.

Part of a parallel sweep with #205 (-O2).