### PR TITLE
test: tmpfs for /tmp during Nuitka build

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -76,6 +76,7 @@ RUN printf '%s\n' \
 # Build with Nuitka in standalone mode (creates directory with all deps)
 RUN --mount=type=cache,target=/nuitka-cache \
     --mount=type=cache,target=/ccache \
+    --mount=type=tmpfs,target=/tmp \
     python3 -m nuitka \
     --mode=standalone \
     --jobs=$(nproc) \


### PR DESCRIPTION
Puts GCC's LTO intermediate files in RAM instead of the overlay filesystem. Runner has 16GB. **No codegen effect.** No device test needed.

Baseline to beat: link **795.2s** (the `took N seconds` on the `-o main.bin` line, **not** the first `took` line which is the slowest single compile).

Expect ~110 ccache misses since flags changed, so the total is inflated. Only the link number is comparable.

Part of a parallel sweep with #205 (-O2).