### PR TITLE
test: mold linker

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patch \
     patchelf \
     ccache \
+    mold \
     libffi-dev \
     zlib1g-dev \
     linux-libc-dev \
@@ -53,7 +54,7 @@ COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
 ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-Wl,--gc-sections"
+ENV LDFLAGS="-fuse-ld=mold -Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)


### PR DESCRIPTION
Replaces GNU ld for the final link. **No codegen effect** if it works. May fail outright on ARM32 + LTO plugin, which is itself a useful result.

Baseline to beat: link **795.2s** (the `took N seconds` on the `-o main.bin` line, **not** the first `took` line which is the slowest single compile).

Expect ~110 ccache misses since flags changed, so the total is inflated. Only the link number is comparable.

Part of a parallel sweep with #205 (-O2).