### PR TITLE
test: GCC 14 via trixie base (needs device test)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -7,7 +7,7 @@
 # completely bypassing the Kindle's ancient glibc 2.20 / dynamic linker.
 # No staticx needed — just a directory with everything.
 
-FROM arm32v7/python:3.11-slim-bookworm
+FROM arm32v7/python:3.11-slim-trixie
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Bookworm ships **GCC 12**; trixie ships **GCC 14.2**. GCC 14 has real LTO throughput improvements in the WPA and LTRANS stages — and WPA is the ~590s serial portion that partitioning, `-flto=N`, ThinLTO and a 45% input cut all failed to touch.

Potentially faster to build **and** better codegen, unlike `-O2` which trades one for the other.

`arm32v7/python:3.11-slim-trixie` keeps Python at **3.11**, so libpython, Nuitka and bumble compatibility are unchanged. Only the toolchain moves.

## Risk — this one does need a device test

glibc moves **2.36 to 2.41**. The dist bundles glibc and its dynamic linker, and the wrapper invokes that bundled linker directly, so the Kindle runs against 2.41 on a **4.9.77 kernel**. Newer glibc can reach for newer syscalls; the existing `preadv2`/`pwritev2` shim exists because of exactly that class of gap on this kernel.

So a green build is **not** sufficient here. It needs the same on-device check as #200 — start, open `/dev/stpbt`, pair.

Baseline: link **795.2s** (the `took N seconds` on the `-o main.bin` line, not the first one). Part of the parallel sweep with #205, #206, #207, #208.