### PR TITLE
test: -ftime-report to profile the WPA stage

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -53,7 +53,7 @@ COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
 ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-Wl,--gc-sections"
+ENV LDFLAGS="-ftime-report -Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)


### PR DESCRIPTION
Profiling only, no codegen change. Makes GCC print per-pass wall clock for the LTO link.

Everything so far has inferred why the link is slow. `--jobs=1` showed ~590s is serial, but not **which pass**. This should show whether it is inlining, IPA-CP, ICF, devirtualisation or streaming.

Read the `-ftime-report` table in the link step output, not the build total.