### PR TITLE
test: -fno-ipa-icf (skip identical code folding)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -52,8 +52,8 @@ COPY kindle_hid_passthrough/BUILD_SHA /build/kindle_hid_passthrough/
 COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
-ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-Wl,--gc-sections"
+ENV CFLAGS="-O3 -fno-ipa-icf -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
+ENV LDFLAGS="-fno-ipa-icf -Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)


### PR DESCRIPTION
ICF is documented at ~15% of WPA time. Disabling it trades binary size (~10% larger in LibreOffice's numbers) for analysis time.

Keeps LTO and all other optimisation on. Baseline to beat: link **795.2s**.