### PR TITLE
test: --param lto-max-partition=50000 (split the giant partition)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -53,7 +53,7 @@ COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
 ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-Wl,--gc-sections"
+ENV LDFLAGS="--param lto-max-partition=50000 -Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)


### PR DESCRIPTION
`-ftime-report` on #210 found the real bottleneck: the link runs **129 invocations, 1118 CPU-s total**, distributed **min 1.0s / median 2.8s / max 586.7s**. One LTRANS partition is ~200x the median and owns 586 of 872 wall seconds, using 966MB.

That explains why every prior attempt failed — more cores, more partitions and faster I/O cannot help when a single thread owns two thirds of the time.

This caps partition size so the balancer splits it. **Changes only how work is divided, not what optimisation runs**, so no device test needed if it works.

Baseline: link **795.2s**.