### PR TITLE
perf(ci): -fno-schedule-insns, halves the LTO link

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -52,8 +52,8 @@ COPY kindle_hid_passthrough/BUILD_SHA /build/kindle_hid_passthrough/
 COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
-ENV CFLAGS="-O3 -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-Wl,--gc-sections"
+ENV CFLAGS="-O3 -fno-schedule-insns -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
+ENV LDFLAGS="-fno-schedule-insns -Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)


### PR DESCRIPTION
Cuts the LTO link **795.2s -> 396.1s**, roughly halving it. Projected build ~8 min, down from ~15.

## Why this works when nothing else did

`-ftime-report` (#210) found the real shape of the link: **129 compiler invocations, 1118 CPU-s total**, distributed **min 1.0s / median 2.8s / max 586.7s**. One LTRANS partition is ~200x the median and owns 586 of 872 wall seconds, using 966MB.

Inside that partition:

| Pass | Time | Share |
|---|---|---|
| scheduling (pre-RA) | 213.7s | 36% |
| tree PTA | 145.2s | 25% |
| tree VRP | 35.5s | 6% |
| tree FRE | 35.3s | 6% |

This removes the largest pass. The saving (399s) exceeds what the profile attributes to scheduling alone (213.7s), because removing it also shrinks the work downstream passes do in that partition.

Binary is **225 KB smaller** (20,776,532 vs 21,001,812 bytes).

## Everything else that was tried and failed

| Attempt | Link | vs 795.2s |
|---|---|---|
| `-flto-partition=max` | 868.9s | +74s |
| `-flto=8` | 909.1s | +114s |
| clang `-flto=thin` | 814.8s | +20s |
| `-flto-compression-level=0` | 823.9s | +29s |
| tmpfs for /tmp | 834.7s | +40s |
| mold linker | fails | ARM32 + LTO plugin unsupported |
| GCC 14 (trixie) | 1352.8s | +558s |
| `-fno-ipa-icf` | 847.6s | +52s |
| `--param lto-max-partition=50000` | 820.8s | +26s |
| `-O2` | 636.6s | -159s but build fails, `conditional branch out of range` |

`--param lto-max-partition` failing to help proves the giant partition's bulk is **one function**, not a module — GCC will not split a single function across partitions. That rules out partition tuning entirely.

## Known risk, accepted

The Kindle's Cortex-A53 is **in-order dual-issue**, the microarchitecture that depends most on compile-time instruction scheduling since the hardware cannot reorder around stalls itself.

**Runtime impact is unmeasured.** The binary was verified to start and open `/dev/stpbt` via `--diagnostics` on a Basic 4, but has never had a controller connected to it. Merging on the build-time win; this is a one-line revert if input latency regresses in real use.

Total build time on a hot cache is also projected (~8.5 min), not observed — this PR's run showed 110 ccache misses because changing CFLAGS invalidates the cache.