### PR TITLE
chore(ci): move the four Node 20 actions to their Node 24 majors

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Restore Nuitka build cache
         if: github.ref != 'refs/heads/main'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: cache-nuitka
           key: nuitka-cache-${{ runner.arch }}-${{ github.run_id }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Restore and save Nuitka build cache
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: cache-nuitka
           key: nuitka-cache-${{ runner.arch }}-${{ github.run_id }}
@@ -73,7 +73,7 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build ARMv7 binary with Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         env:
           DOCKER_BUILD_SUMMARY: "false"
           DOCKER_BUILD_RECORD_UPLOAD: "false"
@@ -184,7 +184,7 @@ jobs:
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: kindle-hid-passthrough-armv7.tar.gz
           generate_release_notes: true
@@ -193,7 +193,7 @@ jobs:
 
       - name: Create dev prerelease
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: dev-${{ steps.stamp.outputs.sha }}
           name: Dev build ${{ steps.stamp.outputs.sha }}


### PR DESCRIPTION
Clears the deprecation warning on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/cache@v4, docker/build-push-action@v6,
docker/login-action@v3, softprops/action-gh-release@v2
```

| Action | From | To |
|---|---|---|
| `actions/cache` (and `/restore`) | v4 | **v6** |
| `docker/build-push-action` | v6 | **v7** |
| `docker/login-action` | v3 | **v4** |
| `softprops/action-gh-release` | v2 | **v3** |

All four majors are the Node 24 runtime move plus ESM internals — I checked each release note and there are no input or behaviour changes affecting this workflow.

**One thing I did verify carefully.** build-push-action v7 removes `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS`. This workflow uses `DOCKER_BUILD_SUMMARY` and `DOCKER_BUILD_RECORD_UPLOAD` (added in 0921cf4), which are **not** among the removed ones, so summary suppression still works.

Already current and not flagged: `actions/checkout@v6`, `actions/upload-artifact@v7`, `docker/setup-buildx-action@v4`, `buildkit-cache-dance@v3`.

Requires Actions Runner v2.327.1+, which GitHub-hosted runners already exceed.