### PR TITLE
test: identify the oversized LTO partition (diagnostic)

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -53,7 +53,7 @@ COPY kindle_hid_passthrough/modules/ /build/kindle_hid_passthrough/modules/
 
 # ARM-specific compiler flags to fix branch range errors
 ENV CFLAGS="-O3 -fno-schedule-insns -mword-relocations -mlong-calls -ffunction-sections -fdata-sections"
-ENV LDFLAGS="-fno-schedule-insns -Wl,--gc-sections"
+ENV LDFLAGS="-fno-schedule-insns -flto-report-wpa -Wl,--gc-sections"
 
 # Build syscall wrapper for Kindle kernel compatibility
 # Kindle kernel 4.9.77 lacks preadv2/pwritev2 (added in 4.16)
@@ -107,6 +107,11 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --nofollow-import-to=bumble.transport.pty \
     --nofollow-import-to=platformdirs \
     kindle_hid_passthrough/main.py
+
+RUN echo "=== 20 largest generated C sources ===" && \
+    find /build/nuitka-out -name '*.c' -printf '%s %p\n' 2>/dev/null | sort -rn | head -20 && \
+    echo "=== 20 largest object files ===" && \
+    find /build/nuitka-out -name '*.o' -printf '%s %p\n' 2>/dev/null | sort -rn | head -20
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.
 # Nuitka standalone doesn't include glibc core libs (assumes they exist on target).


### PR DESCRIPTION
Diagnostic only. Not for merging.

## What we know

`-ftime-report` (#210) showed the link is **129 invocations, 1118 CPU-s**, distributed **min 1.0s / median 2.8s / max 586.7s**, the big one using 966MB. Inside it: scheduling 213.7s (36%), tree PTA 145.2s (25%).

`--param lto-max-partition=50000` failed to split it, which proves the bulk is **one function** — GCC will not split a single function across partitions.

## What we do not know

**Which function.** `bumble/hci.py` is the suspect: bumble's largest module at 8,199 lines, **1,002 top-level statements**, 382 class definitions, 125 decorated HCI command/event registrations. Nuitka compiles module-level code into one C function, so that becomes a single enormous function body. It was also the slowest compile (517s) in the clang experiment, and PTA cost scaling with variables-per-function fits.

But that is inference. This confirms or refutes it.

## What this adds

- `-flto-report-wpa` on the link — prints the WPA partition breakdown
- A step listing the 20 largest generated `.c` and `.o` files

## Why it matters

If it is `hci.py`, the module cannot be excluded — it is core to bumble. The plausible fix is compiling that one module at a lower optimisation level while keeping `-O3` everywhere else, which is only worth attempting once we know the target.