### PR TITLE
fix(classic): leave security to the central while we are peripheral

### DIFF
--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -30,6 +30,9 @@ FALLBACK_HID_DESCRIPTOR = bytes([
 ])
 
 
+CLASSIC_PEER_CHANNEL_WAIT = 5.0
+
+
 class ClassicHIDChannels:
     """HID L2CAP channel pair (control 0x11, interrupt 0x13) for one connection."""
 
@@ -183,24 +186,41 @@ class ClassicMixin:
         if old is not None:
             await self._teardown_session(old)
 
-        if connection.role != Role.CENTRAL:
+        is_peripheral = connection.role != Role.CENTRAL
+
+        if is_peripheral:
             log.info("[Classic] Requesting role switch to central...")
             try:
                 await asyncio.wait_for(connection.switch_role(Role.CENTRAL), timeout=5.0)
                 log.success("[Classic] Role switch complete, now central")
+                is_peripheral = False
             except Exception as e:
                 log.warning(f"[Classic] Role switch failed: {errstr(e)}")
 
-        if not connection.is_encrypted:
+        if is_peripheral:
+            log.info("[Classic] Still peripheral, leaving security to the central")
+        elif not connection.is_encrypted:
             log.info("[Classic] Restoring bonding (authenticate + encrypt)...")
             try:
-                await asyncio.wait_for(connection.authenticate(), timeout=5.0)
+                if not connection.authenticated:
+                    await asyncio.wait_for(connection.authenticate(), timeout=5.0)
                 await asyncio.wait_for(connection.encrypt(enable=True), timeout=5.0)
                 log.success("[Classic] Bonding restored")
             except Exception as e:
                 log.warning(f"[Classic] Bonding restore failed: {errstr(e)}")
 
         channels = session.channels
+
+        if is_peripheral and not channels.intr_channel:
+            log.info("[Classic] Waiting for the peer to open the HID channels...")
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + CLASSIC_PEER_CHANNEL_WAIT
+            while loop.time() < deadline and not channels.intr_channel:
+                await asyncio.sleep(0.05)
+            if channels.intr_channel:
+                log.success("[Classic] Peer opened the HID channels")
+            else:
+                log.info("[Classic] Peer did not open them, paging outward")
 
         if not channels.ctrl_channel:
             log.info("[Classic] Connecting to HID control channel...")

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -6,6 +6,9 @@ import asyncio
 from bumble.core import BT_BR_EDR_TRANSPORT, BT_HUMAN_INTERFACE_DEVICE_SERVICE, InvalidStateError, TimeoutError as BumbleTimeoutError
 from bumble.hci import (
     Address,
+    HCI_DIFFERENT_TRANSACTION_COLLISION_ERROR,
+    HCI_LMP_ERROR_TRANSACTION_COLLISION_OR_LL_PROCEDURE_COLLISION_ERROR,
+    HCI_Error,
     HCI_Write_Scan_Enable_Command,
     Role,
 )
@@ -31,6 +34,15 @@ FALLBACK_HID_DESCRIPTOR = bytes([
 
 
 CLASSIC_PEER_CHANNEL_WAIT = 5.0
+
+COLLISION_ERRORS = (
+    HCI_LMP_ERROR_TRANSACTION_COLLISION_OR_LL_PROCEDURE_COLLISION_ERROR,
+    HCI_DIFFERENT_TRANSACTION_COLLISION_ERROR,
+)
+
+
+def _is_collision(e: BaseException) -> bool:
+    return isinstance(e, HCI_Error) and e.error_code in COLLISION_ERRORS
 
 
 class ClassicHIDChannels:
@@ -187,6 +199,7 @@ class ClassicMixin:
             await self._teardown_session(old)
 
         is_peripheral = connection.role != Role.CENTRAL
+        peer_driving = False
 
         if is_peripheral:
             log.info("[Classic] Requesting role switch to central...")
@@ -196,9 +209,10 @@ class ClassicMixin:
                 is_peripheral = False
             except Exception as e:
                 log.warning(f"[Classic] Role switch failed: {errstr(e)}")
+                peer_driving = _is_collision(e)
 
-        if is_peripheral:
-            log.info("[Classic] Still peripheral, leaving security to the central")
+        if is_peripheral or peer_driving:
+            log.info("[Classic] Peer is driving security, standing by")
         elif not connection.is_encrypted:
             log.info("[Classic] Restoring bonding (authenticate + encrypt)...")
             try:
@@ -208,10 +222,13 @@ class ClassicMixin:
                 log.success("[Classic] Bonding restored")
             except Exception as e:
                 log.warning(f"[Classic] Bonding restore failed: {errstr(e)}")
+                peer_driving = _is_collision(e)
+                if peer_driving:
+                    log.info("[Classic] Security collision, the peer is driving; standing by")
 
         channels = session.channels
 
-        if is_peripheral and not channels.intr_channel:
+        if (is_peripheral or peer_driving) and not channels.intr_channel:
             log.info("[Classic] Waiting for the peer to open the HID channels...")
             loop = asyncio.get_running_loop()
             deadline = loop.time() + CLASSIC_PEER_CHANNEL_WAIT


### PR DESCRIPTION
Fixes the Classic reconnect failure in #203. Two commits, the second driven by @vitorroman17's test of the first.

When the peer pages us it runs its own LMP security procedure, and anything we issue in that window collides with it. The first commit gated on role, but their PW6 run showed the role is a coin flip and the collision is the constant. When the switch happened to succeed, `encrypt()` still collided and the peer dropped the link, so roughly 4 reconnects in 10 kept failing.

The second commit keys on the error instead. `peer_driving` is set when the role switch or the bonding attempt fails with `LMP_ERROR_TRANSACTION_COLLISION` [0x23] or `DIFFERENT_TRANSACTION_COLLISION` [0x2A], and it gates the same two things as `is_peripheral`. Skip `authenticate()`/`encrypt()` and let the peer finish the procedure it already started, and wait up to 5 s for it to open the HID channels before paging outward. A collided procedure continues on the peer's side, so the link comes up encrypted anyway. The central path also skips a redundant `authenticate()` when `connection.authenticated` is already set, which was a silent 5 s stall.

### Why this does not regress #85

The switch request is unchanged, and a peer that runs no LMP procedure of its own never collides. The 8BitDo pages us, wins the switch, collides on nothing, and lands on the untouched central path where we drive security and page the channels, exactly as #117 built it. A device that collides on the switch by timing but still needs paging eats the 5 s wait and then gets paged as before, degraded, not broken.

Untested here, no peer on hand reproduces the collision. @vitorroman17 measured the peripheral half at 308 ms and has offered runs; what still needs sessions behind it is the switch-succeeded, encrypt-collided, recovered path specifically.