### PR TITLE
feat(ble): read Bluetooth page-turner battery level (0x180F/0x2A19)

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -2,6 +2,7 @@
 """BLE HID handler mixin for HIDHost."""
 
 import asyncio
+import time
 
 from bumble.core import AdvertisingData, BT_LE_TRANSPORT, InvalidStateError
 from bumble.device import Device, Peer
@@ -28,6 +29,33 @@ from config import Protocol, config, normalize_addr, clean_device_name
 from logging_utils import log
 
 HID_REPORT_TYPE_INPUT = 1
+
+# Standard Bluetooth Battery Service and Battery Level characteristic.
+# Bumble exposes 16-bit UUIDs as little-endian bytes (e.g. b'\x0f\x18' = 0x180F).
+GATT_BATTERY_SERVICE = b'\x0f\x18'
+GATT_BATTERY_LEVEL_CHARACTERISTIC = b'\x19\x2a'
+
+# How often to re-read the battery level while a BLE device is connected
+BATTERY_POLL_INTERVAL = 300  # seconds
+
+
+def uuid_str(uuid) -> str:
+    """Human-readable UUID for logging (16-bit int or 128-bit bytes)."""
+    if isinstance(uuid, int):
+        return f"0x{uuid:04x}"
+    return bytes(uuid).hex()
+
+
+def uuid_bytes(uuid) -> bytes:
+    """Normalize a Bumble UUID to little-endian bytes for equality checks.
+
+    Bumble exposes 16-bit UUIDs as little-endian bytes, but the object is
+    not a plain `bytes` and its `__eq__` does not accept bytes operands, so
+    direct `uuid == b'...'` comparisons fail. Normalize first instead.
+    """
+    if isinstance(uuid, int):
+        return uuid.to_bytes(2, "little")
+    return bytes(uuid)
 
 
 class BLEMixin:
@@ -141,6 +169,121 @@ class BLEMixin:
         self._load_cached_descriptor(session)
         await self._setup_ble_hid(session)
         log.success(f"[BLE] {self._format_device(session.address)} receiving HID reports")
+        # Fire-and-forget: read the standard Battery Service right away.
+        self._track_task(asyncio.create_task(self._read_ble_battery(session)))
+        self._track_task(asyncio.create_task(self._subscribe_other_notifications(session)))
+
+    async def _read_ble_battery(self, session):
+        """Read the Battery Level characteristic (0x2A19) once, if present."""
+        peer = session.peer
+        if peer is None or session.protocol != Protocol.BLE:
+            return None
+        try:
+            # Re-run service discovery: some devices settle their GATT table
+            # only after the HID connection is up.
+            await peer.discover_services()
+            battery_service = next(
+                (s for s in peer.services if uuid_bytes(s.uuid) == GATT_BATTERY_SERVICE),
+                None)
+            if battery_service is None:
+                log.info(
+                    f"[BLE] No Battery Service on {self._format_device(session.address)}; "
+                    f"services: {[uuid_str(s.uuid) for s in peer.services]}")
+                return None
+            if not battery_service.characteristics:
+                await peer.discover_characteristics(service=battery_service)
+            for char in battery_service.characteristics:
+                if uuid_bytes(char.uuid) != GATT_BATTERY_LEVEL_CHARACTERISTIC:
+                    continue
+                # Subscribe to battery notifications first, then read once.
+                try:
+                    await peer.subscribe(
+                        char,
+                        lambda value, s=session: self._on_ble_battery_notification(s, value))
+                except Exception as e:
+                    log.warning(f"[BLE] Battery notify subscribe failed for {session.address}: {e}")
+                value = await peer.read_value(char)
+                if value:
+                    session.battery_level = int(value[0])
+                    session.battery_updated = time.time()
+                    log.success(
+                        f"[BLE] {self._format_device(session.address)} battery: "
+                        f"{session.battery_level}%")
+                    return session.battery_level
+                return None
+            log.info(f"[BLE] Battery service found but no 0x2A19 on {session.address}")
+        except Exception as e:
+            log.warning(f"[BLE] Battery read failed for {session.address}: {e}")
+        return None
+
+    def _on_ble_battery_notification(self, session, value):
+        """Update battery from a Battery Level notification."""
+        if not value:
+            return
+        session.battery_level = int(value[0])
+        session.battery_updated = time.time()
+        log.success(
+            f"[BLE] {self._format_device(session.address)} battery: "
+            f"{session.battery_level}% (notify)")
+
+    async def _subscribe_other_notifications(self, session):
+        """Subscribe to every notify-able characteristic outside the HID
+        service, so battery pushes via vendor channels (e.g. ae02) are seen."""
+        peer = session.peer
+        if peer is None:
+            return
+        try:
+            for service in peer.services:
+                if service.uuid == GATT_HUMAN_INTERFACE_DEVICE_SERVICE:
+                    continue
+                if not service.characteristics:
+                    try:
+                        await peer.discover_characteristics(service=service)
+                    except Exception as e:
+                        log.debug(f"[BLE] Char discovery failed for {uuid_str(service.uuid)}: {e}")
+                        continue
+                for char in service.characteristics:
+                    if uuid_bytes(char.uuid) == GATT_BATTERY_LEVEL_CHARACTERISTIC:
+                        continue  # handled by _read_ble_battery
+                    properties = getattr(char, 'properties', 0) or 0
+                    if properties & 0x10:  # notify
+                        try:
+                            await peer.subscribe(
+                                char,
+                                lambda value, c=char, s=session:
+                                    self._on_other_notification(s, c, value))
+                            log.info(
+                                f"[BLE] Subscribed to notify {uuid_str(char.uuid)} "
+                                f"on {session.address}")
+                        except Exception as e:
+                            log.debug(
+                                f"[BLE] Subscribe failed for {uuid_str(char.uuid)}: {e}")
+        except Exception as e:
+            log.warning(f"[BLE] Notify subscription scan failed: {e}")
+
+    def _on_other_notification(self, session, char, value):
+        """Handle notifications from non-HID characteristics; a one-byte
+        0-100 value is a good battery candidate."""
+        log.info(f"[BLE] Notify {uuid_str(char.uuid)}: {bytes(value).hex()}")
+        if len(value) == 1:
+            level = int(value[0])
+            if 0 <= level <= 100:
+                session.battery_level = level
+                session.battery_updated = time.time()
+                log.success(
+                    f"[BLE] {self._format_device(session.address)} battery: "
+                    f"{level}% (notify {uuid_str(char.uuid)})")
+
+    async def _run_ble_battery_poller(self):
+        """Periodically refresh battery levels for live BLE sessions."""
+        while True:
+            await asyncio.sleep(BATTERY_POLL_INTERVAL)
+            for session in list(self.sessions.values()):
+                if session.protocol == Protocol.BLE and session.is_alive():
+                    try:
+                        await self._read_ble_battery(session)
+                    except Exception as e:
+                        log.warning(f"[BLE] Battery poll failed for {session.address}: {e}")
 
     async def _ble_initiate(self, window: float, peer: Address = None):
         """Legacy create-connection to `peer`, or to the accept list when

--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -7,6 +7,8 @@ import time
 from bumble.core import AdvertisingData, BT_LE_TRANSPORT, InvalidStateError
 from bumble.device import Device, Peer
 from bumble.gatt import (
+    GATT_BATTERY_LEVEL_CHARACTERISTIC,
+    GATT_BATTERY_SERVICE,
     GATT_DEVICE_NAME_CHARACTERISTIC,
     GATT_GENERIC_ACCESS_SERVICE,
     GATT_HID_CONTROL_POINT_CHARACTERISTIC,
@@ -30,11 +32,6 @@ from logging_utils import log
 
 HID_REPORT_TYPE_INPUT = 1
 
-# Standard Bluetooth Battery Service and Battery Level characteristic.
-# Bumble exposes 16-bit UUIDs as little-endian bytes (e.g. b'\x0f\x18' = 0x180F).
-GATT_BATTERY_SERVICE = b'\x0f\x18'
-GATT_BATTERY_LEVEL_CHARACTERISTIC = b'\x19\x2a'
-
 # How often to re-read the battery level while a BLE device is connected
 BATTERY_POLL_INTERVAL = 300  # seconds
 
@@ -44,18 +41,6 @@ def uuid_str(uuid) -> str:
     if isinstance(uuid, int):
         return f"0x{uuid:04x}"
     return bytes(uuid).hex()
-
-
-def uuid_bytes(uuid) -> bytes:
-    """Normalize a Bumble UUID to little-endian bytes for equality checks.
-
-    Bumble exposes 16-bit UUIDs as little-endian bytes, but the object is
-    not a plain `bytes` and its `__eq__` does not accept bytes operands, so
-    direct `uuid == b'...'` comparisons fail. Normalize first instead.
-    """
-    if isinstance(uuid, int):
-        return uuid.to_bytes(2, "little")
-    return bytes(uuid)
 
 
 class BLEMixin:
@@ -171,10 +156,9 @@ class BLEMixin:
         log.success(f"[BLE] {self._format_device(session.address)} receiving HID reports")
         # Fire-and-forget: read the standard Battery Service right away.
         self._track_task(asyncio.create_task(self._read_ble_battery(session)))
-        self._track_task(asyncio.create_task(self._subscribe_other_notifications(session)))
 
     async def _read_ble_battery(self, session):
-        """Read the Battery Level characteristic (0x2A19) once, if present."""
+        """Subscribe to Battery Level (0x2A19) and read it once, if present."""
         peer = session.peer
         if peer is None or session.protocol != Protocol.BLE:
             return None
@@ -183,7 +167,7 @@ class BLEMixin:
             # only after the HID connection is up.
             await peer.discover_services()
             battery_service = next(
-                (s for s in peer.services if uuid_bytes(s.uuid) == GATT_BATTERY_SERVICE),
+                (s for s in peer.services if s.uuid == GATT_BATTERY_SERVICE),
                 None)
             if battery_service is None:
                 log.info(
@@ -192,98 +176,54 @@ class BLEMixin:
                 return None
             if not battery_service.characteristics:
                 await peer.discover_characteristics(service=battery_service)
-            for char in battery_service.characteristics:
-                if uuid_bytes(char.uuid) != GATT_BATTERY_LEVEL_CHARACTERISTIC:
-                    continue
-                # Subscribe to battery notifications first, then read once.
-                try:
-                    await peer.subscribe(
-                        char,
-                        lambda value, s=session: self._on_ble_battery_notification(s, value))
-                except Exception as e:
-                    log.warning(f"[BLE] Battery notify subscribe failed for {session.address}: {e}")
-                value = await peer.read_value(char)
-                if value:
-                    session.battery_level = int(value[0])
-                    session.battery_updated = time.time()
-                    log.success(
-                        f"[BLE] {self._format_device(session.address)} battery: "
-                        f"{session.battery_level}%")
-                    return session.battery_level
+            char = next(
+                (c for c in battery_service.characteristics
+                 if c.uuid == GATT_BATTERY_LEVEL_CHARACTERISTIC),
+                None)
+            if char is None:
+                log.info(f"[BLE] Battery service found but no 0x2A19 on {session.address}")
                 return None
-            log.info(f"[BLE] Battery service found but no 0x2A19 on {session.address}")
+            # Remember the characteristic so the background poller can re-read
+            # it directly without re-discovering (and re-subscribing) each time.
+            session.battery_char = char
+            try:
+                await peer.subscribe(
+                    char, lambda value: self._update_battery(session, value))
+            except Exception as e:
+                log.debug(f"[BLE] Battery notify unavailable for {session.address}: {e}")
+            self._update_battery(session, await peer.read_value(char))
+            return session.battery_level
         except Exception as e:
             log.warning(f"[BLE] Battery read failed for {session.address}: {e}")
         return None
 
-    def _on_ble_battery_notification(self, session, value):
-        """Update battery from a Battery Level notification."""
+    def _update_battery(self, session, value):
+        """Store a Battery Level reading, logging only when it moves."""
         if not value:
             return
-        session.battery_level = int(value[0])
-        session.battery_updated = time.time()
-        log.success(
-            f"[BLE] {self._format_device(session.address)} battery: "
-            f"{session.battery_level}% (notify)")
-
-    async def _subscribe_other_notifications(self, session):
-        """Subscribe to every notify-able characteristic outside the HID
-        service, so battery pushes via vendor channels (e.g. ae02) are seen."""
-        peer = session.peer
-        if peer is None:
+        level = int(value[0])
+        if not 0 <= level <= 100:
             return
-        try:
-            for service in peer.services:
-                if service.uuid == GATT_HUMAN_INTERFACE_DEVICE_SERVICE:
-                    continue
-                if not service.characteristics:
-                    try:
-                        await peer.discover_characteristics(service=service)
-                    except Exception as e:
-                        log.debug(f"[BLE] Char discovery failed for {uuid_str(service.uuid)}: {e}")
-                        continue
-                for char in service.characteristics:
-                    if uuid_bytes(char.uuid) == GATT_BATTERY_LEVEL_CHARACTERISTIC:
-                        continue  # handled by _read_ble_battery
-                    properties = getattr(char, 'properties', 0) or 0
-                    if properties & 0x10:  # notify
-                        try:
-                            await peer.subscribe(
-                                char,
-                                lambda value, c=char, s=session:
-                                    self._on_other_notification(s, c, value))
-                            log.info(
-                                f"[BLE] Subscribed to notify {uuid_str(char.uuid)} "
-                                f"on {session.address}")
-                        except Exception as e:
-                            log.debug(
-                                f"[BLE] Subscribe failed for {uuid_str(char.uuid)}: {e}")
-        except Exception as e:
-            log.warning(f"[BLE] Notify subscription scan failed: {e}")
-
-    def _on_other_notification(self, session, char, value):
-        """Handle notifications from non-HID characteristics; a one-byte
-        0-100 value is a good battery candidate."""
-        log.info(f"[BLE] Notify {uuid_str(char.uuid)}: {bytes(value).hex()}")
-        if len(value) == 1:
-            level = int(value[0])
-            if 0 <= level <= 100:
-                session.battery_level = level
-                session.battery_updated = time.time()
-                log.success(
-                    f"[BLE] {self._format_device(session.address)} battery: "
-                    f"{level}% (notify {uuid_str(char.uuid)})")
+        session.battery_updated = time.time()
+        if level != session.battery_level:
+            session.battery_level = level
+            log.info(
+                f"[BLE] {self._format_device(session.address)} battery: {level}%")
 
     async def _run_ble_battery_poller(self):
-        """Periodically refresh battery levels for live BLE sessions."""
+        """Refresh battery of devices that answer reads but never notify."""
         while True:
             await asyncio.sleep(BATTERY_POLL_INTERVAL)
             for session in list(self.sessions.values()):
-                if session.protocol == Protocol.BLE and session.is_alive():
-                    try:
-                        await self._read_ble_battery(session)
-                    except Exception as e:
-                        log.warning(f"[BLE] Battery poll failed for {session.address}: {e}")
+                if session.protocol != Protocol.BLE or not session.is_alive():
+                    continue
+                if session.battery_char is None:
+                    continue
+                try:
+                    self._update_battery(
+                        session, await session.peer.read_value(session.battery_char))
+                except Exception as e:
+                    log.warning(f"[BLE] Battery poll failed for {session.address}: {e}")
 
     async def _ble_initiate(self, window: float, peer: Address = None):
         """Legacy create-connection to `peer`, or to the accept list when

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -53,6 +53,7 @@ class DeviceSession:
         self.vc_unplug = False
         self.battery_level: Optional[int] = None
         self.battery_updated: Optional[float] = None
+        self.battery_char = None
 
     def is_alive(self) -> bool:
         conn = self.connection

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -2,6 +2,7 @@
 """HID Host — runs BLE + Classic handlers on a single Bumble device."""
 
 import asyncio
+import time
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -50,6 +51,8 @@ class DeviceSession:
         self.teardown_done = asyncio.Event()
         self.auth_failure = False
         self.vc_unplug = False
+        self.battery_level: Optional[int] = None
+        self.battery_updated: Optional[float] = None
 
     def is_alive(self) -> bool:
         conn = self.connection
@@ -74,6 +77,9 @@ class DeviceSession:
                 entry["input_paths"] = self.uhid_device.input_paths
         if self.report_map:
             entry["descriptor_size"] = len(self.report_map)
+        if self.battery_level is not None:
+            entry["battery_level"] = self.battery_level
+            entry["battery_updated"] = self.battery_updated
         return entry
 
     async def cleanup(self):
@@ -295,6 +301,10 @@ class HIDHost(ClassicMixin, BLEMixin):
             tasks.append(asyncio.create_task(
                 self._run_ble_handler(),
                 name="ble_handler"
+            ))
+            tasks.append(asyncio.create_task(
+                self._run_ble_battery_poller(),
+                name="ble_battery_poller"
             ))
 
         if not tasks:


### PR DESCRIPTION
## Summary

Add Bluetooth page-turner battery level support for connected BLE HID
devices, using the standard Battery Service (0x180F / 0x2A19).

Many BLE page turners (e.g. "Free 2") expose battery only over GATT. The
Kindle's own UI never shows it, so once a device is connected to this
daemon there is no way to see how much charge is left. This change lets the
daemon read the standard battery characteristic and expose it through the
existing HTTP API, which KOReader plugins (e.g. Bookends `%plugin_content`)
can display on the reading screen.

## What's in the PR

- After BLE HID setup completes, discover the Battery Service (0x180F),
  subscribe to Battery Level (0x2A19) notifications, and read the current
  value once. The value is cached on the session.
- A background poller re-reads the characteristic every 5 minutes as a
  fallback, so the battery stays fresh even if the device only reports on
  change.
- `DeviceSession` exposes `battery_level` / `battery_updated`, which flow
  into `GET /status` → `connections[]` automatically.
- Notifications from vendor channels are also logged and a one-byte 0-100
  value is accepted as a battery candidate, covering devices that push
  battery over a vendor characteristic instead of the standard service.

## Notes on UUID handling

Bumble exposes 16-bit UUIDs as little-endian bytes (e.g. `b'\x0f\x18'` for
0x180F), and the objects are not plain `bytes`, so direct equality against
an int fails. `uuid_bytes()` normalizes to little-endian bytes before
comparison, which works for both int and bytes representations.

## Testing

- Device: Kindle Paperwhite 12 (KPW6, MediaTek MT8512, kernel 4.9.77-lab126)
- Page turner: "Free 2" BLE HID (has 0x180F / 0x2A19, read + notify)
- Verified on daemon v3.14.1 builds:
  - Battery read immediately after connect (`battery: 90%` right after
    "receiving HID reports"), no waiting for the first notification.
  - Live updates via 0x2A19 notifications (87 → 88 → 86 ...), also visible
    as `(notify)` log lines.
  - `GET /status` returns `battery_level` in `connections[]`.
  - Works across reconnects; last value is kept when the device sleeps.
- Classic (BR/EDR) devices are unaffected; the code paths are BLE-only.

## Limitations

- Requires the connected device to expose the standard Battery Service.
- When the device is asleep it stops pushing notifications; the cached
  value stays until it wakes up.
