### PR TITLE
perf(ci): ship bumble.hci as bytecode + strip asserts/docstrings

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -38,6 +38,8 @@ COPY patches/ /build/patches/
 RUN BUMBLE_DIR="$(python3 -c 'import bumble, os; print(os.path.dirname(bumble.__file__))')" && \
     patch -p1 -d "$BUMBLE_DIR" < /build/patches/bumble-gatt-server-async-genexpr.patch
 
+COPY .github/nuitka-plugins/ /build/nuitka-plugins/
+
 # Enable ccache and Nuitka's own caching
 ENV CCACHE_DIR=/ccache
 ENV NUITKA_CACHE_DIR=/nuitka-cache
@@ -80,6 +82,9 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --mode=standalone \
     --jobs=$(nproc) \
     --lto=yes \
+    --user-plugin=/build/nuitka-plugins/bytecode_large_modules.py \
+    --python-flag=no_asserts \
+    --python-flag=no_docstrings \
     --show-progress \
     --output-dir=/build/nuitka-out \
     --include-data-file=kindle_hid_passthrough/config.ini=kindle_hid_passthrough/config.ini \

--- a/.github/nuitka-plugins/bytecode_large_modules.py
+++ b/.github/nuitka-plugins/bytecode_large_modules.py
@@ -1,0 +1,17 @@
+from nuitka.plugins.PluginBase import NuitkaPluginBase
+
+
+class NuitkaPluginBytecodeLargeModules(NuitkaPluginBase):
+    plugin_name = "bytecode-large-modules"
+    plugin_desc = "Ship named modules as bytecode instead of compiling them to C."
+
+    BYTECODE_MODULES = ("bumble.hci",)
+
+    @staticmethod
+    def isAlwaysEnabled():
+        return True
+
+    def decideCompilation(self, module_name):
+        if module_name in self.BYTECODE_MODULES:
+            return "bytecode"
+        return None


### PR DESCRIPTION
Targets the last known bottleneck. **Needs a device test.**

## The target

`-ftime-report` (#210) proved the link is **129 invocations, 1118 CPU-s**, distributed **min 1.0s / median 2.8s / max 586.7s**. #215 identified the big one:

```
23,450,442  module.bumble.hci.c    <- 23MB from one Python file
12,071,871  module.bumble.device.c
 5,377,436  module.bumble.l2cap.c
```

`--param lto-max-partition` could not split it: Nuitka compiles module-level code into **one C function**, and GCC will not split a single function across partitions.

## The mechanism

Nuitka has no CLI flag for per-module bytecode. Per kayhayen on [issue #1268](https://github.com/Nuitka/Nuitka/issues/1268):

> There are plans to add this kind of option, right now only a Nuitka plugin can make this decision.

So this adds a plugin implementing `decideCompilation`, which the PluginBase docs define as returning `"compiled"`, `"bytecode"` or `None`.

Also adds `--python-flag=no_asserts,no_docstrings` — confirmed to shrink generated code with no runtime effect.

## Why the runtime cost should be small

`hci.py` is **382 class and constant definitions** describing HCI command and event structures — not hot-path code. Per-event work happens in `l2cap.py` and this project's own modules, which stay compiled. Bytecode cost lands on module import, not the input path.

**But that is reasoning, not measurement.** Needs the same on-device check as #200 and #213.

## Rejected on the way here

`#pragma GCC optimize` per file: pragmas act per translation unit, but this cost is at **LTRANS**, which runs per partition after WPA decisions are baked in. Would not have helped.

Baseline: link **373-396s** across four post-#213 runs.