### PR TITLE
chore(ci): cut dead build deps and no-op exclusions

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -11,6 +11,7 @@ FROM arm32v7/python:3.11-slim-bookworm
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    patchelf \
     ccache \
     libffi-dev \
     zlib1g-dev \

--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -5,14 +5,12 @@
 # Strategy: Nuitka standalone creates a directory with the binary + all .so deps.
 # We bundle the build container's ld-linux-armhf.so.3 and invoke it directly,
 # completely bypassing the Kindle's ancient glibc 2.20 / dynamic linker.
-# No staticx needed — just a directory with everything.
 
 FROM arm32v7/python:3.11-slim-bookworm
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    patchelf \
     ccache \
     libffi-dev \
     zlib1g-dev \
@@ -27,8 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir \
     https://github.com/Nuitka/Nuitka/archive/51f7e3703cea42263b0b8bb9029afb74dd48349d.tar.gz \
     ordered-set \
-    bumble==0.0.226 \
-    aiofiles>=23.0.0
+    bumble==0.0.226
 
 COPY .github/nuitka-plugins/ /build/nuitka-plugins/
 
@@ -82,12 +79,6 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --include-data-file=kindle_hid_passthrough/config.ini=kindle_hid_passthrough/config.ini \
     --include-data-file=kindle_hid_passthrough/BUILD_SHA=kindle_hid_passthrough/BUILD_SHA \
     --include-data-dir=kindle_hid_passthrough/modules=kindle_hid_passthrough/modules \
-    --nofollow-import-to=pytest \
-    --nofollow-import-to=unittest \
-    --nofollow-import-to=setuptools \
-    --nofollow-import-to=grpc \
-    --nofollow-import-to=google \
-    --nofollow-import-to=usb \
     --nofollow-import-to=bumble.transport.usb \
     --nofollow-import-to=bumble.transport.pyusb \
     --nofollow-import-to=bumble.transport.android_emulator \


### PR DESCRIPTION
Deletion only, **+1 / -9**. Skeletons from earlier experiments.

| Cut | Why it is dead |
|---|---|
| `aiofiles>=23.0.0` (pip) | Imported by nothing in `kindle_hid_passthrough/`, and not a bumble 0.0.226 dependency |
| `--nofollow-import-to=pytest` / `unittest` / `setuptools` | No-ops. Nuitka anti-bloat is always on and prunes these; stdlib ships as bytecode so `unittest` never reaches gcc |
| `--nofollow-import-to=grpc` / `google` / `usb` | Pre-emptive guesses. Nothing imports them directly — they only arrived via `bumble.transport.grpc_protobuf`, `.usb`, `.pyusb`, all excluded explicitly since #200 |
| `# No staticx needed` comment | Explains a tool this build does not use |

21 nofollow flags down to 15.

## patchelf was NOT dead — caught by the first build

The first push also removed `patchelf`, on the grounds that nothing in this repo references it. That failed:

```
FATAL: Error, standalone mode on Linux requires patchelf to be installed.
```

**Nuitka calls it directly** to rewrite RPATHs on bundled shared libraries. Grepping this repo was the wrong check — the caller is Nuitka. Restored.

## Verification

- **C file count must stay 109.** If a removed exclusion was suppressing a module, it returns and the count rises.
- **Link time must stay sub-reportable** (no `took N seconds` line).

Left alone deliberately: `rustc`/`cargo` build `cryptography` (no armv7 wheels), `libx11-dev` builds mousecursor, `ordered-set` is a Nuitka dependency.