### PR TITLE
Phone media remote, volume keys turn pages

### DIFF
--- a/illusion/BTManager/index.html
+++ b/illusion/BTManager/index.html
@@ -40,6 +40,11 @@
             <button id="btnScan" class="btn btn-scan">Scan for Devices</button>
         </div>
 
+        <div class="scan-btn-wrap pair-row">
+            <button id="btnDiscoverable" class="btn btn-scan btn-pair-main">Pair Phone</button>
+            <button id="btnPairInfo" class="btn btn-scan btn-info" aria-label="About phone pairing">i</button>
+        </div>
+
         <!-- Available devices section (hidden until scan) -->
         <div id="availableSection" style="display:none;">
             <div class="section-label-row">
@@ -57,9 +62,9 @@
     </div>
 
     <!-- Start on boot toggle -->
-    <div class="toggle-row">
+    <div class="toggle-row toggle-row-secondary">
         <span class="toggle-label">Start on boot</span>
-        <button id="btnAutostart" class="toggle" aria-label="Toggle start on boot">
+        <button id="btnAutostart" class="toggle toggle-secondary" aria-label="Toggle start on boot">
             <span class="toggle-knob"></span>
         </button>
     </div>

--- a/illusion/BTManager/script.js
+++ b/illusion/BTManager/script.js
@@ -217,7 +217,8 @@ var BTManager = (function() {
 
     function setAutostartUI(on) {
         autostartOn = on;
-        getEl("btnAutostart").className = on ? "toggle on" : "toggle";
+        getEl("btnAutostart").className = on
+            ? "toggle toggle-secondary on" : "toggle toggle-secondary";
     }
 
     function toggleAutostart() {
@@ -551,6 +552,35 @@ var BTManager = (function() {
         }, 2000);
     }
 
+    var discoverableTimer = null;
+
+    function startDiscoverable() {
+        if (discoverableTimer) clearTimeout(discoverableTimer);
+        request("/discoverable?duration=60", function(data, err) {
+            if (err || !data || !data.ok) {
+                showMessage(err || (data && data.error) || "Failed", true);
+                return;
+            }
+            showMessage("Visible to phones as an audio device", false);
+            discoverableCountdown(data.duration);
+        });
+    }
+
+    function discoverableCountdown(remaining) {
+        var btn = getEl("btnDiscoverable");
+        if (remaining <= 0) {
+            discoverableTimer = null;
+            btn.innerHTML = "Pair Phone";
+            btn.className = "btn btn-scan";
+            return;
+        }
+        btn.innerHTML = "Visible (" + remaining + "s) — pair from your phone";
+        btn.className = "btn btn-scan scanning";
+        discoverableTimer = setTimeout(function() {
+            discoverableCountdown(remaining - 1);
+        }, 1000);
+    }
+
     function resetScanUI() {
         isScanning = false;
         var btn = getEl("btnScan");
@@ -752,6 +782,19 @@ var BTManager = (function() {
         confirmAction = action;
     }
 
+    function showInfo(message) {
+        getEl("dialogMessage").innerHTML = message;
+        getEl("dialogCancelBtn").style.display = "none";
+        getEl("dialogConfirmBtn").innerHTML = "OK";
+        getEl("confirmOverlay").className = "overlay visible";
+        confirmAction = null;
+    }
+
+    function resetDialogButtons() {
+        getEl("dialogCancelBtn").style.display = "";
+        getEl("dialogConfirmBtn").innerHTML = "Confirm";
+    }
+
     function confirmOk() {
         pressBtn("dialogConfirmBtn");
         getEl("confirmOverlay").className = "overlay";
@@ -759,13 +802,17 @@ var BTManager = (function() {
             removeDevice(confirmAddr);
         } else if (confirmAction === "cache") {
             clearCache();
+        } else {
+            releaseBtn("dialogConfirmBtn");
         }
+        resetDialogButtons();
         confirmAction = null;
         confirmAddr = null;
     }
 
     function confirmCancel() {
         getEl("confirmOverlay").className = "overlay";
+        resetDialogButtons();
         confirmAction = null;
         confirmAddr = null;
     }
@@ -781,6 +828,14 @@ var BTManager = (function() {
         bindBtn("btnToggle", toggleBluetooth);
         bindBtn("btnAutostart", toggleAutostart);
         bindBtn("btnScan", toggleScan);
+        bindBtn("btnDiscoverable", startDiscoverable);
+        bindBtn("btnPairInfo", function() {
+            showInfo("Pairing makes this Kindle visible to phones as a " +
+                "Bluetooth audio device. Once connected, the phone's volume " +
+                "buttons act as page-turn keys: volume up pages forward, " +
+                "volume down pages back. They can be remapped in " +
+                "Button Mapper.");
+        });
         bindBtn("footerDebug", showLogs);
         bindBtn("btnDetailClose", hideDeviceDetail);
         bindBtn("btnDetailAction", detailAction);

--- a/illusion/BTManager/style.css
+++ b/illusion/BTManager/style.css
@@ -299,6 +299,56 @@ html {
     padding: 0;
 }
 
+.pair-row {
+    overflow: hidden;
+}
+
+.btn-pair-main {
+    float: left;
+    width: 82%;
+}
+
+.btn-info {
+    float: right;
+    width: 15%;
+    font-family: Georgia, serif;
+    font-style: italic;
+}
+
+.toggle-row-secondary {
+    border-bottom: none;
+    padding: 10px 0;
+}
+
+.toggle-row-secondary .toggle-label {
+    font-size: 30px;
+    font-weight: normal;
+    line-height: 43px;
+}
+
+.toggle-secondary {
+    width: 86px;
+    height: 43px;
+    border-width: 3px;
+    padding: 3px;
+    -webkit-border-radius: 22px;
+    border-radius: 22px;
+}
+
+.toggle-secondary .toggle-knob {
+    width: 31px;
+    height: 31px;
+    -webkit-border-radius: 16px;
+    border-radius: 16px;
+    top: 3px;
+    left: 3px;
+}
+
+.toggle-secondary.on .toggle-knob {
+    left: auto;
+    right: 3px;
+}
+
 /* ---- Device Detail Overlay ---- */
 
 .device-overlay {

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -108,6 +108,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_connect(param('addr'), param('protocol'))
             case '/disconnect':
                 self._handle_disconnect(param('addr'))
+            case '/discoverable':
+                self._handle_discoverable(param('duration'))
             case '/logs':
                 self._handle_logs(param('lines'))
             case _:
@@ -244,6 +246,19 @@ class RequestHandler(BaseHTTPRequestHandler):
         controller = self._controller
         controller.request_disconnect(address=address)
         self._send_json({"ok": True, "message": "Disconnecting"})
+
+    def _handle_discoverable(self, duration_str):
+        duration = 60
+        if duration_str:
+            try:
+                duration = max(10, min(int(duration_str), 300))
+            except ValueError:
+                pass
+        if self._controller.request_discoverable(duration):
+            self._send_json({"ok": True, "duration": duration})
+        else:
+            self._send_json({"ok": False,
+                             "error": "Media remote off or Bluetooth stopped"})
 
     def _handle_logs(self, lines_str):
         log_file = config.log_file

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -3,7 +3,8 @@
 
 import asyncio
 
-from bumble.core import BT_BR_EDR_TRANSPORT, BT_HUMAN_INTERFACE_DEVICE_SERVICE, InvalidStateError, TimeoutError as BumbleTimeoutError
+from bumble.core import BT_BR_EDR_TRANSPORT, BT_HUMAN_INTERFACE_DEVICE_SERVICE, InvalidStateError
+from bumble.core import TimeoutError as BumbleTimeoutError
 from bumble.hci import (
     Address,
     HCI_Write_Scan_Enable_Command,
@@ -13,7 +14,7 @@ from bumble.hid import HID_CONTROL_PSM, HID_INTERRUPT_PSM, Message, SetProtocolM
 from bumble.l2cap import ClassicChannelSpec
 from bumble.sdp import Client as SDPClient
 
-from config import Protocol, config, normalize_addr, clean_device_name
+from config import Protocol, clean_device_name, config, normalize_addr
 from logging_utils import errstr, log
 
 FALLBACK_HID_DESCRIPTOR = bytes([
@@ -154,6 +155,9 @@ class ClassicMixin:
 
             addr_str = str(connection.peer_address)
             if not self._is_classic_allowed(addr_str):
+                if self.media_remote:
+                    self.media_remote.adopt(connection)
+                    return
                 log.warning(f"[Classic] Rejecting {addr_str} (not allowed)")
                 self._track_task(asyncio.create_task(self._reject_connection(connection)))
                 return
@@ -230,7 +234,12 @@ class ClassicMixin:
         log.success(f"[Classic] {self._format_device(session.address)} receiving HID reports")
 
     def _is_classic_allowed(self, addr_str: str) -> bool:
-        """Check if Classic address is allowed."""
+        """Check if a Classic address should get an HID session.
+
+        With the media remote on, bonded phones live in the same keystore
+        as HID devices, so only devices.conf decides what is HID; anything
+        else is handed to the media remote by the caller.
+        """
         norm_addr = normalize_addr(addr_str)
 
         for dev in self.classic_devices:
@@ -239,7 +248,7 @@ class ClassicMixin:
             if dev.address == norm_addr:
                 return True
 
-        if norm_addr in self._keystore_addresses:
+        if self.media_remote is None and norm_addr in self._keystore_addresses:
             return True
 
         return False

--- a/kindle_hid_passthrough/config.ini
+++ b/kindle_hid_passthrough/config.ini
@@ -14,12 +14,17 @@ transport_timeout = 30
 # hci_transport = file:/dev/stpbt
 
 [device]
-name = Kindle-HID
+# name defaults to the detected model (e.g. "Kindle Basic 4"); set to override
+# name = Kindle-HID
 address = F0:F0:F0:F0:F0:F0
 
 [protocol]
 # Default protocol: ble or classic
 type = classic
+
+[media_remote]
+# Phone volume keys turn pages; pair via the Pair Phone button in BTManager
+enabled = true
 
 [logging]
 log_file = /var/log/hid_passthrough.log

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -142,12 +142,17 @@ class Config:
         self.bt_settle_time = float(self._get('bluetooth', 'settle_time', '0.5'))
 
         # Device identity
-        self.device_name = self._get('device', 'name', 'Kindle-HID')
+        default_name = 'Kindle-HID'
+        if self._kindle_defaults:
+            default_name = self._kindle_defaults.model_name
+        self.device_name = self._get('device', 'name', default_name)
         self.device_address = self._get('device', 'address', 'F0:F0:F0:F0:F0:F0')
 
         # Protocol
         protocol_str = self._get('protocol', 'type', 'ble').lower()
         self.protocol = self._parse_protocol(protocol_str)
+
+        self.media_remote_enabled = self._getboolean('media_remote', 'enabled', True)
 
     def _detect_transport(self) -> str:
         """Auto-detect HCI transport from Kindle hardware.
@@ -215,6 +220,12 @@ class Config:
     def _getint(self, section: str, key: str, default: int) -> int:
         try:
             return self._parser.getint(section, key)
+        except (configparser.NoSectionError, configparser.NoOptionError, ValueError):
+            return default
+
+    def _getboolean(self, section: str, key: str, default: bool) -> bool:
+        try:
+            return self._parser.getboolean(section, key)
         except (configparser.NoSectionError, configparser.NoOptionError, ValueError):
             return default
 

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -73,6 +73,22 @@ class DaemonController:
 
         return status
 
+    def request_discoverable(self, duration: float) -> bool:
+        """From HTTP thread: open a phone-pairing window on the host."""
+        future = asyncio.run_coroutine_threadsafe(
+            self._do_discoverable(duration), self.loop)
+        try:
+            return future.result(timeout=5)
+        except Exception as e:
+            logger.error(f"Discoverable failed: {errstr(e)}")
+            return False
+
+    async def _do_discoverable(self, duration: float) -> bool:
+        host = self.daemon.host
+        if host is None or self.daemon._suspended:
+            return False
+        return await host.make_discoverable(duration)
+
     async def _resume_if_enabled(self):
         """Resume unless BT was toggled off while the op ran."""
         if self.bt_enabled:

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -154,7 +154,8 @@ class HIDDaemon:
                 if not self.running:
                     break
 
-            if not self._has_devices(log_details=True):
+            if not self._has_devices(log_details=True) \
+                    and not config.media_remote_enabled:
                 logger.info("No devices configured, waiting for pairing...")
                 self._resume_event.clear()
                 await self._resume_event.wait()

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -6,7 +6,14 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from bumble.core import InvalidStateError
-from bumble.hci import HCI_Constant, HCI_LE_SET_PRIVACY_MODE_COMMAND, HCI_LE_Set_Privacy_Mode_Command, HCI_Write_Class_Of_Device_Command, HCI_Write_Local_Name_Command
+from bumble.hci import (
+    HCI_LE_SET_PRIVACY_MODE_COMMAND,
+    HCI_Constant,
+    HCI_LE_Set_Privacy_Mode_Command,
+    HCI_Write_Class_Of_Device_Command,
+    HCI_Write_Local_Name_Command,
+    HCI_Write_Scan_Enable_Command,
+)
 
 from ble import BLEMixin
 from bt_setup import ensure_uhid
@@ -14,6 +21,7 @@ from classic import ClassicMixin
 from config import Protocol, clean_device_name, config, get_version, normalize_addr
 from device_cache import DeviceCache
 from logging_utils import log
+from media_remote import MEDIA_REMOTE_COD, MediaRemote
 from pairing import create_keystore, create_pairing_config
 from transport import create_bumble_device
 from uhid_handler import Bus, UHIDDevice, descriptor_is_pointer, sanitize_digitizer
@@ -140,6 +148,9 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         self.keystore = create_keystore(config.pairing_keys_file)
         self.device_cache = DeviceCache(config.cache_dir)
+        self.media_remote = (MediaRemote(self._notify_sessions_changed)
+                             if config.media_remote_enabled else None)
+        self._discoverable_task = None
 
         # Set by the daemon: called with True when the first pointer device
         # gets its UHID device, False when the last goes away (drives the cursor).
@@ -153,6 +164,8 @@ class HIDHost(ClassicMixin, BLEMixin):
         """Current connection state as a dict for API consumers."""
         connections = [s.state_dict() for s in list(self.sessions.values())
                        if s.is_alive()]
+        if self.media_remote:
+            connections += self.media_remote.state_list()
         return {"connected": bool(connections), "connections": connections}
 
     def _parse_devices(self):
@@ -175,15 +188,16 @@ class HIDHost(ClassicMixin, BLEMixin):
         log.info(f"HID Host v{get_version()}")
 
         def configure(device):
-            device.classic_enabled = bool(self.classic_devices)
+            device.classic_enabled = (bool(self.classic_devices)
+                                      or bool(self.media_remote))
             device.le_enabled = bool(self.ble_devices)
+            device.discoverable = False
             if pairing:
                 # No inbound links while pairing; run mode re-enables page scan.
                 device.connectable = False
-                device.discoverable = False
             device.keystore = self.keystore
             device.pairing_config_factory = create_pairing_config
-            if self.classic_devices:
+            if device.classic_enabled:
                 device.classic_ssp_enabled = True
                 device.classic_sc_enabled = True
 
@@ -195,8 +209,9 @@ class HIDHost(ClassicMixin, BLEMixin):
             log.info("Controller address resolution enabled")
 
         # Classic-specific setup
-        if self.classic_devices:
-            class_of_device = 0x000104  # Computer/Desktop
+        if self.classic_devices or self.media_remote:
+            class_of_device = (MEDIA_REMOTE_COD if self.media_remote
+                               else 0x000104)
             await self.device.host.send_command(
                 HCI_Write_Class_Of_Device_Command(class_of_device=class_of_device),
                 check_result=True
@@ -208,6 +223,9 @@ class HIDHost(ClassicMixin, BLEMixin):
                 HCI_Write_Local_Name_Command(local_name=local_name_bytes),
                 check_result=True
             )
+
+        if self.media_remote:
+            self.media_remote.setup(self.device)
 
         if self.ble_devices:
             log.info("BLE enabled")
@@ -285,7 +303,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         """Run the protocol handlers and watchdog until failure or cancel."""
         tasks = []
 
-        if self.classic_devices:
+        if self.classic_devices or self.media_remote:
             tasks.append(asyncio.create_task(
                 self._run_classic_handler(),
                 name="classic_handler"
@@ -303,8 +321,9 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         log.info(f"Serving devices (Classic: {len(self.classic_devices)}, BLE: {len(self.ble_devices)})")
 
-        tasks.append(asyncio.create_task(
-            self._session_watchdog(), name="session_watchdog"))
+        if self.classic_devices or self.ble_devices:
+            tasks.append(asyncio.create_task(
+                self._session_watchdog(), name="session_watchdog"))
 
         try:
             done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
@@ -331,7 +350,9 @@ class HIDHost(ClassicMixin, BLEMixin):
         had_session = False
         while True:
             self._sessions_changed.clear()
-            if self.sessions or had_session:
+            media_alive = bool(self.media_remote
+                               and self.media_remote.connections)
+            if self.sessions or media_alive or had_session:
                 had_session = True
                 await self._sessions_changed.wait()
                 continue
@@ -439,6 +460,44 @@ class HIDHost(ClassicMixin, BLEMixin):
             return
         for session in targets:
             await self._teardown_session(session)
+
+    async def make_discoverable(self, duration: float) -> bool:
+        """Open a pairing window: inquiry scan on for duration seconds."""
+        if not self.media_remote or not self.device:
+            return False
+        if self._discoverable_task and not self._discoverable_task.done():
+            self._discoverable_task.cancel()
+            try:
+                await self._discoverable_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._discoverable_task = self._track_task(asyncio.create_task(
+            self._discoverable_window(duration)))
+        return True
+
+    async def _discoverable_window(self, duration: float):
+        try:
+            await self.device.host.send_command(
+                HCI_Write_Scan_Enable_Command(scan_enable=0x03),
+                check_result=True)
+            log.info(f"[Media] Discoverable as {config.device_name} "
+                     f"for {duration:.0f}s")
+            await asyncio.sleep(duration)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.warning(f"[Media] Discoverable window failed: {e}")
+        finally:
+            if self.device:
+                try:
+                    await asyncio.wait_for(
+                        self.device.host.send_command(
+                            HCI_Write_Scan_Enable_Command(scan_enable=0x02),
+                            check_result=True),
+                        timeout=2.0)
+                    log.info("[Media] Discoverable window closed")
+                except Exception:
+                    pass
 
     # ==================== PAIRING ====================
 
@@ -584,6 +643,9 @@ class HIDHost(ClassicMixin, BLEMixin):
             except Exception:
                 pass
             self._pairing_session = None
+
+        if self.media_remote:
+            self.media_remote.close()
 
         if hasattr(self, '_classic_connection_listener') and self._classic_connection_listener:
             try:

--- a/kindle_hid_passthrough/media_remote.py
+++ b/kindle_hid_passthrough/media_remote.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Phone media remote — A2DP sink + AVRCP target.
+
+The Kindle shows up as a Bluetooth audio device (CoD: Audio+Rendering
+service classes, Audio/Video major, Loudspeaker minor). Once a phone
+connects, its volume keys arrive as AVRCP absolute-volume commands and
+are turned into PageUp/PageDown presses on a virtual boot keyboard,
+which the koplugin and kindle-button-mapper consume like any other
+keyboard. The received volume is re-centered to mid-range after each
+burst so both directions keep working, and the phone's initial volume
+sync after connect is ignored.
+"""
+
+import asyncio
+
+from bumble import a2dp, avc, avdtp, avrcp
+
+from bt_setup import ensure_uhid
+from config import normalize_addr
+from logging_utils import log
+from uhid_handler import Bus, UHIDDevice
+
+__all__ = ['MediaRemote', 'MEDIA_REMOTE_COD']
+
+MEDIA_REMOTE_COD = 0x240414
+
+PAGE_UP = 0x4B
+PAGE_DOWN = 0x4E
+
+BOOT_KEYBOARD_DESCRIPTOR = bytes([
+    0x05, 0x01,
+    0x09, 0x06,
+    0xA1, 0x01,
+    0x05, 0x07,
+    0x19, 0xE0, 0x29, 0xE7, 0x15, 0x00, 0x25, 0x01,
+    0x75, 0x01, 0x95, 0x08, 0x81, 0x02,
+    0x95, 0x01, 0x75, 0x08, 0x81, 0x01,
+    0x95, 0x06, 0x75, 0x08, 0x15, 0x00, 0x25, 0x65,
+    0x05, 0x07, 0x19, 0x00, 0x29, 0x65, 0x81, 0x00,
+    0xC0,
+])
+
+RECENTER_VOLUME = 0x40
+RECENTER_DELAY = 0.5
+SYNC_GRACE = 2.0
+KEY_RELEASE_DELAY = 0.05
+
+
+class _Delegate(avrcp.Delegate):
+    def __init__(self, remote):
+        super().__init__(supported_events=[avrcp.EventId.VOLUME_CHANGED])
+        self.remote = remote
+        self.volume = RECENTER_VOLUME
+
+    async def set_absolute_volume(self, volume: int) -> None:
+        previous = self.volume
+        self.volume = volume
+        self.remote.on_volume(previous, volume)
+
+    async def on_key_event(self, key, pressed, data) -> None:
+        self.remote.on_passthrough(key, pressed)
+
+
+class MediaRemote:
+    """One phone at a time; bumble's AVRCP protocol handles a single peer."""
+
+    def __init__(self, on_change=None):
+        self.connections = {}
+        self.uhid = None
+        self.delegate = _Delegate(self)
+        self.avrcp = None
+        self._on_change = on_change
+        self._recenter_handle = None
+        self._grace_until = 0.0
+
+    def setup(self, device):
+        """Register SDP records and profile listeners on the bumble device.
+
+        Must run inside the event loop: avrcp.Protocol creates futures.
+        """
+        device.sdp_service_records = {
+            0x00010001: a2dp.make_audio_sink_service_sdp_records(0x00010001),
+            0x00010002: avrcp.ControllerServiceSdpRecord(
+                0x00010002).to_service_attributes(),
+            0x00010003: avrcp.TargetServiceSdpRecord(
+                0x00010003,
+                supported_features=(avrcp.TargetFeatures.CATEGORY_1
+                                    | avrcp.TargetFeatures.CATEGORY_2),
+            ).to_service_attributes(),
+        }
+        listener = avdtp.Listener.for_device(device)
+        listener.on(listener.EVENT_CONNECTION, self._on_avdtp_connection)
+        self.avrcp = avrcp.Protocol(delegate=self.delegate)
+        self.avrcp.listen(device)
+        log.info("[Media] Remote ready (A2DP sink + AVRCP target)")
+
+    def adopt(self, connection):
+        """Track an inbound phone connection; profiles serve it via L2CAP."""
+        addr = normalize_addr(str(connection.peer_address))
+        self.connections[addr] = connection
+        self._grace_until = asyncio.get_event_loop().time() + SYNC_GRACE
+        connection.on('disconnection',
+                      lambda reason: self._on_disconnection(addr, reason))
+        log.success(f"[Media] Phone connected: {addr}")
+        self._ensure_uhid()
+        self._notify_change()
+
+    def state_list(self) -> list:
+        return [{"address": addr, "protocol": "media", "name": None,
+                 "hid_ready": self.uhid is not None}
+                for addr in self.connections]
+
+    def close(self):
+        if self._recenter_handle:
+            self._recenter_handle.cancel()
+            self._recenter_handle = None
+        if self.uhid:
+            try:
+                self.uhid.destroy()
+            except Exception:
+                pass
+            self.uhid = None
+        self.connections.clear()
+
+    def on_volume(self, previous: int, volume: int):
+        if asyncio.get_event_loop().time() < self._grace_until:
+            self._schedule_recenter()
+            return
+        if volume > previous:
+            log.info(f"[Media] Volume up ({previous} -> {volume}): page forward")
+            self._press(PAGE_DOWN)
+        elif volume < previous:
+            log.info(f"[Media] Volume down ({previous} -> {volume}): page back")
+            self._press(PAGE_UP)
+        self._schedule_recenter()
+
+    def on_passthrough(self, key, pressed: bool):
+        op = avc.PassThroughFrame.OperationId
+        usage = {op.VOLUME_UP: PAGE_DOWN, op.FORWARD: PAGE_DOWN,
+                 op.VOLUME_DOWN: PAGE_UP, op.BACKWARD: PAGE_UP}.get(key)
+        if usage is None or not pressed:
+            log.debug(f"[Media] Passthrough {key} pressed={pressed}")
+            return
+        log.info(f"[Media] Passthrough {key.name}")
+        self._press(usage)
+
+    def _on_disconnection(self, addr: str, reason):
+        self.connections.pop(addr, None)
+        log.warning(f"[Media] Phone disconnected: {addr} (reason={reason})")
+        if not self.connections:
+            self.close()
+        self._notify_change()
+
+    def _notify_change(self):
+        if self._on_change:
+            try:
+                self._on_change()
+            except Exception:
+                pass
+
+    def _on_avdtp_connection(self, server):
+        sbc = a2dp.SbcMediaCodecInformation
+        server.add_sink(avdtp.MediaCodecCapabilities(
+            media_type=avdtp.MediaType.AUDIO,
+            media_codec_type=a2dp.CodecType.SBC,
+            media_codec_information=sbc(
+                sampling_frequency=(sbc.SamplingFrequency.SF_16000
+                                    | sbc.SamplingFrequency.SF_32000
+                                    | sbc.SamplingFrequency.SF_44100
+                                    | sbc.SamplingFrequency.SF_48000),
+                channel_mode=(sbc.ChannelMode.MONO
+                              | sbc.ChannelMode.DUAL_CHANNEL
+                              | sbc.ChannelMode.STEREO
+                              | sbc.ChannelMode.JOINT_STEREO),
+                block_length=(sbc.BlockLength.BL_4
+                              | sbc.BlockLength.BL_8
+                              | sbc.BlockLength.BL_12
+                              | sbc.BlockLength.BL_16),
+                subbands=sbc.Subbands.S_4 | sbc.Subbands.S_8,
+                allocation_method=(sbc.AllocationMethod.SNR
+                                   | sbc.AllocationMethod.LOUDNESS),
+                minimum_bitpool_value=2,
+                maximum_bitpool_value=53,
+            ),
+        ))
+        log.info("[Media] AVDTP connection, sink endpoint registered "
+                 "(audio is discarded)")
+
+    def _ensure_uhid(self):
+        if self.uhid:
+            return
+        if not ensure_uhid():
+            log.error("[Media] uhid unavailable; phone keys will go nowhere")
+            return
+        try:
+            self.uhid = UHIDDevice(
+                name="Phone Media Remote",
+                report_descriptor=BOOT_KEYBOARD_DESCRIPTOR,
+                bus=Bus.BLUETOOTH,
+            )
+            log.success("[Media] Virtual keyboard created")
+            asyncio.get_event_loop().call_later(
+                0.5, lambda: self.uhid and self.uhid.discover_input_paths())
+        except Exception as e:
+            log.error(f"[Media] Failed to create virtual keyboard: {e}")
+
+    def _press(self, usage: int):
+        if not self.uhid:
+            return
+        try:
+            self.uhid.send_input(bytes([0, 0, usage, 0, 0, 0, 0, 0]))
+            asyncio.get_event_loop().call_later(
+                KEY_RELEASE_DELAY, self._release)
+        except Exception as e:
+            log.warning(f"[Media] Key send failed: {e}")
+
+    def _release(self):
+        if not self.uhid:
+            return
+        try:
+            self.uhid.send_input(bytes(8))
+        except Exception as e:
+            log.warning(f"[Media] Key release failed: {e}")
+
+    def _schedule_recenter(self):
+        if self._recenter_handle:
+            self._recenter_handle.cancel()
+        self._recenter_handle = asyncio.get_event_loop().call_later(
+            RECENTER_DELAY, self._recenter)
+
+    def _recenter(self):
+        self._recenter_handle = None
+        self.delegate.volume = RECENTER_VOLUME
+        if not self.avrcp:
+            return
+        try:
+            self.avrcp.notify_volume_changed(RECENTER_VOLUME)
+        except Exception as e:
+            log.debug(f"[Media] Recenter notify failed: {e}")


### PR DESCRIPTION
This makes the Kindle show up to phones as a Bluetooth audio device. Once a phone is connected its volume buttons turn pages, volume up forward, volume down back. It's an A2DP sink plus AVRCP target, the phone's absolute volume commands get mapped to PageUp/PageDown presses on a virtual keyboard, so the koplugin and button mapper pick them up like any other keyboard. Audio sent to it is discarded, and the reported volume re-centers after each press so both directions keep working.

Discoverability is opt-in. The new Pair Phone button in BTManager (or GET /discoverable) opens a 60s inquiry scan window with a countdown, after that the Kindle goes invisible again and bonded phones reconnect through page scan. Pairing is Just Works with no PIN, so anyone nearby can pair during the window, that's the tradeoff for phones pairing without an app.

The advertised name now defaults to the detected model, so it shows up as "Kindle Basic 4" instead of Kindle-HID. Also snuck in an info button explaining the key mapping and a smaller secondary toggle for Start on boot so it stops competing with the main Bluetooth switch.

Tested on the Basic 4 with my phone, paired through the window, both volume directions arrive and map correctly, and the window closes on its own. One phone at a time for now, and a `* classic` wildcard in devices.conf will swallow phone connections since everything inbound becomes HID.