### PR TITLE
Compute downloads badge in CI, prune old dev prereleases

### DIFF
--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -1,0 +1,78 @@
+name: Downloads badge
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: downloads-badge
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout badges branch
+        uses: actions/checkout@v5
+        with:
+          ref: badges
+          path: badges
+
+      - name: Prune dev prereleases and recount downloads
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          R: ${{ github.repository }}
+          KEEP: '5'
+        run: |
+          set -euo pipefail
+
+          pruned=$(jq -r '.pruned // 0' badges/downloads.json)
+          prev=$(jq -r '.downloads // 0' badges/downloads.json)
+
+          mapfile -t old < <(gh api "repos/$R/releases" --paginate \
+            --jq '.[] | select(.tag_name | startswith("dev-"))
+                  | [.created_at, .tag_name, ([.assets[].download_count] | add // 0)] | @tsv' \
+            | sort -r | tail -n "+$((KEEP + 1))")
+
+          # ponytail: bank after the delete lands, so a crash mid-loop undercounts by one
+          # release rather than double-counting it. Swap for a durable per-tag ledger if that
+          # single release ever matters.
+          for row in ${old[@]+"${old[@]}"}; do
+            tag=$(cut -f2 <<<"$row")
+            gh release delete "$tag" --repo "$R" --yes --cleanup-tag
+            pruned=$((pruned + $(cut -f3 <<<"$row")))
+          done
+
+          live=$(gh api "repos/$R/releases" --paginate \
+            --jq '[.[].assets[].download_count] | add // 0' | awk '{s+=$1} END{print s+0}')
+          total=$((live + pruned))
+
+          # download counters only ever climb, so a drop means we read a truncated page
+          if [ "$total" -lt "$prev" ]; then
+            echo "::warning::computed $total below stored $prev, keeping stored"
+            total=$prev
+          fi
+
+          message=$(awk -v n="$total" 'BEGIN{
+            if (n >= 1000) { s = sprintf("%.1fk", n / 1000); sub(/\.0k$/, "k", s) } else { s = n }
+            print s
+          }')
+
+          jq -n --arg m "$message" --argjson d "$total" --argjson p "$pruned" \
+            '{schemaVersion: 1, label: "downloads", message: $m, color: "blue", downloads: $d, pruned: $p}' \
+            > badges/downloads.json
+
+          echo "live=$live pruned=$pruned total=$total"
+
+      - name: Commit
+        working-directory: badges
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add downloads.json
+          git diff --staged --quiet || git commit -m "downloads: $(jq -r .downloads downloads.json)"
+          git push

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://img.shields.io/github/actions/workflow/status/zampierilucas/kindle-hid-passthrough/build-arm.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white)](https://github.com/zampierilucas/kindle-hid-passthrough/actions/workflows/build-arm.yml)
 [![Release](https://img.shields.io/github/v/release/zampierilucas/kindle-hid-passthrough?style=flat-square&logo=github)](https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/zampierilucas/kindle-hid-passthrough/total?style=flat-square&color=blue)](https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest)
+[![Downloads](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zampierilucas/kindle-hid-passthrough/badges/downloads.json&style=flat-square)](https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest)
 [![License](https://img.shields.io/github/license/zampierilucas/kindle-hid-passthrough?style=flat-square)](LICENSE)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support%20me-FF5E5B?style=flat-square&logo=kofi&logoColor=white)](https://ko-fi.com/lzampier)
 


### PR DESCRIPTION
shields only sums the first 100 releases and we have 121, so the older stable releases that hold most of the downloads were falling off page one and the badge drifted between 3k and 5k depending on how many dev builds had landed that day.

this adds a scheduled job that paginates the whole release list, prunes dev prereleases past the newest five while carrying their download counts forward in a stored offset, and writes the total to downloads.json on the badges branch. readme badge reads that through the shields endpoint route.

first run deletes 85 stale dev releases and banks their 290 downloads so the number stays whole. verified locally, and the endpoint badge already renders 5.3k off the seed commit.