### PR TITLE
fix(install): always remount root read-only on exit

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+trap '/usr/sbin/mntroot ro 2>/dev/null' EXIT
+trap 'exit 130' INT TERM HUP
+
 INSTALL_DIR="/mnt/us/kindle_hid_passthrough"
 MAPPER_DIR="/mnt/us/kindle-button-mapper"
 APP_ID="com.lzampier.btmanager"


### PR DESCRIPTION
`installUdevRules`, `installUpstart`, `removeUpstart` and `uninstallAll` each open a `mntroot rw` window. The pairs match on the happy path, but a signal lands the script somewhere in between and leaves `/` mounted read-write. `installAll` also shells out to the bundled button-mapper installer, which runs under `set -e` and can abort inside its own window (zampierilucas/kindle-button-mapper-rs#56).

That is what turns a crash into a brick. `core_pattern` on these devices is a bare `core`, so a crashing framework process dumps into its cwd, which for the daemons is `/`. Root is a 493MB partition already sitting near full (88% on a healthy Basic 5), so a few mesquite or pillowd cores fill it and the framework stops coming up. USB mass storage only ever exports the user store, so there is nothing to delete from the host to recover. This matches #226, where the reporter saw cores land in the root, which a stock read-only root would have refused.

The trap covers the KPM entry points too, since `kpm/install.sh` and `kpm/uninstall.sh` are thin wrappers around `installAll` and `uninstallAll`.

No change to autostart. The passthrough job stays opt-in exactly as it is.

Verified with a stubbed `mntroot` that records its calls. There is no `set -e` here, so a failed command is not the risk; a signal is. `SIGTERM` mid-window exits with the last call being `rw` before, and `ro` after.

Does not fix the underlying mesquite/pillowd crashes, it stops them from being able to eat the rootfs.

Refs #226