### PR TITLE
docs(readme): recommend usbnetlite before installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ As this project replaces the original Bluetooth stack, you can't use the default
 - Jailbroken Kindle
 - [Hotfix](https://github.com/KindleModding/Hotfix/releases/tag/v2.3.7) (only for BTManager) — it's what gives the Kindle scriptlet support, and without it the BTManager entry never shows up on the home screen. Kindles jailbroken with older methods don't have scriptlets at all.
 
+> [!IMPORTANT]
+> **Setting up [usbnetlite](https://github.com/notmarek/kindle-usbnetlite) first is highly encouraged.** This project touches Bluetooth, udev and upstart, all of which run early enough in boot that a bad state can leave a Kindle stuck on a white screen. Modern Kindles have no serial pads, so USB networking is the only way back in.
+
 Kernels without UHID support are handled automatically: the daemon loads a bundled `uhid.ko` at startup (see [Kernel Modules](#kernel-modules)).
 
 ## Installation


### PR DESCRIPTION
Adds a note under Requirements, above Installation, so it is read before anyone installs.

This project touches Bluetooth, udev and upstart, all early enough in boot that a bad state can strand a Kindle on a white screen. Modern devices have no serial pads, so USB networking is the only remaining way in.

Suggested by @mergen3107 in #226.