### PR TITLE
build: shrink the release from 21.4MB to 11.5MB

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -95,6 +95,7 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --nofollow-import-to=bumble.transport.hci_socket \
     --nofollow-import-to=bumble.transport.pty \
     --nofollow-import-to=platformdirs \
+    --nofollow-import-to=cryptography \
     kindle_hid_passthrough/main.py
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.
@@ -103,7 +104,7 @@ RUN --mount=type=cache,target=/nuitka-cache \
 RUN cp /lib/ld-linux-armhf.so.3 /build/nuitka-out/main.dist/ld-linux-armhf.so.3 && \
     for lib in libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1 \
                libutil.so.1 libresolv.so.2 libnss_dns.so.2 libnss_files.so.2 \
-               libz.so.1 libstdc++.so.6; do \
+               libz.so.1; do \
         src=$(find /lib /usr/lib -name "$lib" 2>/dev/null | head -1); \
         if [ -n "$src" ]; then \
             cp -L "$src" /build/nuitka-out/main.dist/"$lib"; \

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -142,8 +142,8 @@ jobs:
 
       - name: Create tarball
         run: |
-          tar -czvf "kindle-hid-passthrough-armv7.tar.gz" -C output .
-          ls -lh *.tar.gz
+          tar -cJvf "kindle-hid-passthrough-armv7.tar.xz" -C output .
+          ls -lh *.tar.xz
 
       - name: Validate KindleForge install compatibility
         run: |
@@ -163,7 +163,7 @@ jobs:
             button-mapper/kindle-button-mapper \
             button-mapper/install.sh \
             button-mapper/config.ini; do
-            if ! tar -tzf kindle-hid-passthrough-armv7.tar.gz "./$f" >/dev/null 2>&1; then
+            if ! tar -tJf kindle-hid-passthrough-armv7.tar.xz "./$f" >/dev/null 2>&1; then
               echo "MISSING: $f"
               MISSING=1
             else
@@ -183,22 +183,22 @@ jobs:
           git diff --exit-code kpm/repo.json
           cp kpm/manifest.json kpm/install.sh kpm/uninstall.sh output/
           # KPM only finds manifest.json at the archive root, so no ./ prefix.
-          tar -czf "kindle-hid-passthrough.kpkg" -C output $(ls -A output)
-          tar -tzf kindle-hid-passthrough.kpkg | grep -qx manifest.json
+          tar -cJf "kindle-hid-passthrough.kpkg" -C output $(ls -A output)
+          tar -tJf kindle-hid-passthrough.kpkg | grep -qx manifest.json
           ls -lh kindle-hid-passthrough.kpkg
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: kindle-hid-passthrough-armv7
-          path: kindle-hid-passthrough-armv7.tar.gz
+          path: kindle-hid-passthrough-armv7.tar.xz
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            kindle-hid-passthrough-armv7.tar.gz
+            kindle-hid-passthrough-armv7.tar.xz
             kindle-hid-passthrough.kpkg
           generate_release_notes: true
         env:
@@ -211,7 +211,7 @@ jobs:
           tag_name: dev-${{ steps.stamp.outputs.sha }}
           name: Dev build ${{ steps.stamp.outputs.sha }}
           files: |
-            kindle-hid-passthrough-armv7.tar.gz
+            kindle-hid-passthrough-armv7.tar.xz
             kindle-hid-passthrough.kpkg
           prerelease: true
           make_latest: "false"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ kpm install kindle-hid-passthrough
 
 1. Download the latest release from [GitHub Releases](https://github.com/zampierilucas/kindle-hid-passthrough/releases) and unpack it somewhere other than the install directory:
    ```bash
-   curl -L -o kindle-hid-passthrough-armv7.tar.gz https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest/download/kindle-hid-passthrough-armv7.tar.gz
+   curl -L -o kindle-hid-passthrough-armv7.tar.xz https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest/download/kindle-hid-passthrough-armv7.tar.xz
    mkdir -p /mnt/us/khp-release
-   tar -xzf kindle-hid-passthrough-armv7.tar.gz -C /mnt/us/khp-release
+   tar -xJf kindle-hid-passthrough-armv7.tar.xz -C /mnt/us/khp-release
    ```
 
    The release contains a `dist/` directory with a bundled Python runtime and all dependencies — no Python installation required on the Kindle.

--- a/justfile
+++ b/justfile
@@ -193,7 +193,7 @@ remove-autostart:
 
 repo := "zampierilucas/kindle-hid-passthrough"
 artifact_name := "kindle-hid-passthrough-armv7"
-tarball_name := "kindle-hid-passthrough-armv7.tar.gz"
+tarball_name := "kindle-hid-passthrough-armv7.tar.xz"
 
 # Install onto Kindle from a GitHub release (latest, version, or local tarball path)
 install-release source="":
@@ -224,7 +224,7 @@ install-release source="":
     just host={{host}} kill
     ssh {{host}} "/usr/sbin/mntroot rw && mount -o remount,rw /mnt/base-us"
     ssh {{host}} "mkdir -p {{remote_dir}}"
-    cat "$tarball" | ssh {{host}} "tar xzf - -C {{remote_dir}}"
+    cat "$tarball" | ssh {{host}} "tar xJf - -C {{remote_dir}}"
     ssh {{host}} "cd {{remote_dir}} && sh scripts/install.sh installAll"
     ssh {{host}} "/usr/sbin/mntroot ro"
     ssh {{host}} "/sbin/initctl start hid-passthrough"


### PR DESCRIPTION
Cuts the release from 21.4MB to about 11.5MB. Draft because the Nuitka side only gets proven by CI, and pairing still needs a run on real hardware.

Three things.

bumble wraps its `cryptography` import in a try/except and falls back to `bumble.crypto.builtin`, a pure python AES and P-256. Nothing else in bumble imports it, so `--nofollow-import-to=cryptography` drops the 10MB `_rust.so` (it statically links its own OpenSSL, which is why it's that big) plus `_cffi_backend.so`. Worth 5.2MB compressed and no code change.

`libstdc++.so.6` was dead weight, 601KB. I walked the NEEDED list of every ELF in the tarball and nothing links it, it was just sitting in the Dockerfile copy loop.

The tarball and the kpkg now use xz. Busybox tar on device takes `-J` and I confirmed a stdin extract end to end on a Basic 5. Timed both on that device, gzip decompresses at 15.3MB/s and xz at 8.7MB/s, so for the new payload that's 2.3s against 4.0s, once, at install. Preset 6 wants a 9MB decoder buffer and there's 121MB free, `-9` would want 65MB for another 220KB so I left it at the tar default.

Side finding while checking this, KPM builds libarchive with `zlib=disabled, lzma=enabled, zstd=enabled`. Our gzip kpkg was only extracting through libarchive's external program fallback this whole time, xz is the format it actually decodes natively.

What I want out of CI is confirmation that `_rust.so` and `_cffi_backend.so` are gone from `dist/` and that the tarball still passes the file list check. Then a device test that pairing still works on the builtin crypto, ECDH benchmarks at 33ms on my laptop so call it a few hundred ms on the Kindle, once per pair. `AddressResolver.resolve` also does one AES block per stored key per advert, but it's gated on `address.is_resolvable` and typical gamepads don't use resolvable addresses.

Renaming the asset to `.tar.xz` touches the justfile and the readme, both updated here. KindleForge is unavailable right now anyway so nothing live breaks.
