### PR TITLE
ci: bundle the latest mapper release instead of a pinned tag

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -113,14 +113,17 @@ jobs:
           cp -r koreader-plugin/ output/
           cp kindle_hid_passthrough/config.ini output/
 
-      # Pinned rather than tracking latest, so a mapper release can't change
-      # what this tarball ships without a commit here.
+      # Tracks the latest mapper release, so a mapper fix reaches this tarball
+      # without a commit here.
       - name: Bundle kindle-button-mapper
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KBM_VERSION: v1.5.0
         run: |
           mkdir -p output/button-mapper
+          KBM_VERSION=$(gh release view \
+            --repo zampierilucas/kindle-button-mapper-rs \
+            --json tagName --jq .tagName)
+          echo "Bundling kindle-button-mapper $KBM_VERSION"
           gh release download "$KBM_VERSION" \
             --repo zampierilucas/kindle-button-mapper-rs \
             --pattern 'kindle-button-mapper-armv7.tar.gz' \

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -14,7 +14,7 @@ from kindle_detect import detect_kindle
 if TYPE_CHECKING:
     pass
 
-__version__ = "3.15.0"
+__version__ = "3.15.1"
 __build_sha__ = None  # stamped by build scripts
 
 

--- a/kpm/repo.json
+++ b/kpm/repo.json
@@ -14,7 +14,7 @@
           "version": [
             3,
             15,
-            0
+            1
           ],
           "dependencies": [],
           "supported_platforms": [


### PR DESCRIPTION
`KBM_VERSION` was pinned so a mapper release couldn't change what this tarball ships without a commit here. The cost showed up on a Basic 5 running `kpm install kindle-hid-passthrough`, where v3.15.0 bundled mapper v1.5.0 and the bundled install step died on a missing udev rules file, leaving `kindle-button-mapper` at `stop/waiting`. That was already fixed upstream in kindle-button-mapper-rs#58, but the pin meant nobody got it until someone edited this line.

The bundle step now resolves the newest non-prerelease mapper tag at build time and downloads that, so the `VERSION` file in the tarball stays accurate and the log records which one went in. Checked against the live repo, it resolves to v1.5.1.

The trade is that rebuilding an old tag no longer reproduces its original bundle, and a bad mapper release reaches users without a commit here. A pinned version is what shipped the broken installer, so tracking latest is the better side of that.

Also bumps to 3.15.1 so a release actually picks up mapper v1.5.1.
