### PR TITLE
fix(uhid): hold reports until the input node can be read

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -2,6 +2,8 @@
 """HID Host — runs BLE + Classic handlers on a single Bumble device."""
 
 import asyncio
+import time
+from collections import deque
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -24,7 +26,14 @@ from logging_utils import log
 from media_remote import MEDIA_REMOTE_COD, MediaRemote
 from pairing import create_keystore, create_pairing_config
 from transport import create_bumble_device
-from uhid_handler import Bus, UHIDDevice, descriptor_is_pointer, sanitize_digitizer
+from uhid_handler import (
+    PENDING_REPORTS,
+    REPLAY_WINDOW,
+    Bus,
+    UHIDDevice,
+    descriptor_is_pointer,
+    sanitize_digitizer,
+)
 
 __all__ = ['HIDHost']
 
@@ -53,6 +62,7 @@ class DeviceSession:
         self.uhid_device = None
         self.is_pointer = False
         self.last_report = None
+        self.pending_reports = deque(maxlen=PENDING_REPORTS)
         self.setup_task = None
         self.closed = False
         self.teardown_done = asyncio.Event()
@@ -567,6 +577,22 @@ class HIDHost(ClassicMixin, BLEMixin):
                 session.uhid_device.send_input(data)
             except Exception as e:
                 log.warning(f"UHID send failed: {e}")
+        else:
+            session.pending_reports.append((time.monotonic(), data))
+
+    def _replay_pending(self, session: DeviceSession):
+        """Write the reports the peer sent before the input node existed."""
+        cutoff = time.monotonic() - REPLAY_WINDOW
+        held = [data for stamp, data in session.pending_reports if stamp >= cutoff]
+        session.pending_reports.clear()
+        if not held or not session.uhid_device:
+            return
+        log.info(f"Replaying {len(held)} report(s) sent before the input node existed")
+        for data in held:
+            try:
+                session.uhid_device.send_input(data)
+            except Exception as e:
+                log.warning(f"UHID send failed: {e}")
 
     def _load_cached_descriptor(self, session: DeviceSession) -> bool:
         """Load report descriptor and device name from cache. Returns True if found."""
@@ -601,6 +627,7 @@ class HIDHost(ClassicMixin, BLEMixin):
                 uniq=session.address,
             )
             log.success(f"UHID device created: {name}")
+            self._replay_pending(session)
             asyncio.get_event_loop().call_later(
                 0.5, session.uhid_device.discover_input_paths)
             session.is_pointer = descriptor_is_pointer(descriptor)

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Virtual HID devices via Linux UHID (/dev/uhid)."""
 
+import asyncio
 import logging
 import os
 import struct
+import time
+from collections import deque
 from typing import Optional
 
 __all__ = ['UHIDDevice', 'UHIDError', 'Bus', 'sanitize_digitizer']
@@ -129,6 +132,13 @@ UHID_INPUT2 = 12
 HID_MAX_DESCRIPTOR_SIZE = 4096
 UHID_DATA_MAX = 4096
 
+# Nothing has a freshly created input node open yet, and evdev only buffers for
+# readers that are already attached, so a report written in that gap is lost.
+# Hold reports for this long instead, then write them: X takes about half a
+# second to open a new node on a Kindle Basic 4.
+REPLAY_WINDOW = 1.0
+PENDING_REPORTS = 16
+
 
 class Bus:
     """Bus types for HID devices."""
@@ -202,10 +212,14 @@ class UHIDDevice:
 
         self._fd: Optional[int] = None
         self._created = False
+        self._created_at = 0.0
+        self._pending = deque(maxlen=PENDING_REPORTS)
+        self._flush_handle = None
         self.input_paths: list = []
 
         self._open_uhid()
         self._create_device()
+        self._schedule_flush()
 
     def _open_uhid(self):
         """Open /dev/uhid file descriptor."""
@@ -251,12 +265,39 @@ class UHIDDevice:
             if written != len(event):
                 raise UHIDError(f"Incomplete write: {written} != {len(event)}")
             self._created = True
+            self._created_at = time.monotonic()
             logger.info(f"Created UHID device: {self.name} "
                        f"(vendor=0x{self.vendor:04x}, product=0x{self.product:04x}, "
                        f"rd_size={len(self.report_descriptor)})")
 
         except OSError as e:
             raise UHIDError(f"Failed to create device: {e}")
+
+    def _schedule_flush(self):
+        """Write the held reports once a reader has had time to attach."""
+        try:
+            self._flush_handle = asyncio.get_event_loop().call_later(
+                REPLAY_WINDOW, self._flush_pending)
+        except RuntimeError:
+            logger.debug("No event loop, reports will flush on the next write")
+
+    @property
+    def is_holding(self) -> bool:
+        """Whether the node is still too new for a report to reach a reader."""
+        return time.monotonic() - self._created_at < REPLAY_WINDOW
+
+    def _flush_pending(self):
+        """Write the reports held while nothing could read them."""
+        if not self._pending:
+            return
+        held = list(self._pending)
+        self._pending.clear()
+        logger.info(f"Writing {len(held)} report(s) held while the node was new")
+        for data in held:
+            try:
+                self._write_input(data)
+            except UHIDError as e:
+                logger.warning(f"Held report dropped: {e}")
 
     def discover_input_paths(self):
         """Find /dev/input/eventX paths for this UHID device.
@@ -305,6 +346,15 @@ class UHIDDevice:
         if len(data) > UHID_DATA_MAX:
             raise UHIDError(f"Input data too large: {len(data)} > {UHID_DATA_MAX}")
 
+        if self.is_holding:
+            self._pending.append(data)
+            logger.debug("Held report, the input node is too new to be read")
+            return
+
+        self._flush_pending()
+        self._write_input(data)
+
+    def _write_input(self, data: bytes):
         # Pack UHID_INPUT2 event
         # Format: type(L) size(H) data(4096s)
         event = struct.pack(
@@ -324,6 +374,10 @@ class UHIDDevice:
         """Destroy the virtual device and close the file descriptor."""
         if self._fd is None:
             return
+
+        if self._flush_handle:
+            self._flush_handle.cancel()
+            self._flush_handle = None
 
         if self._created:
             try:


### PR DESCRIPTION
Fixes #185.

The peer sends reports before we create its UHID node and those get dropped. Chasing it on a Basic 4 turned up the other half, a report written after the node exists is lost too while nothing has opened the evdev node yet, since evdev only starts buffering for a reader once it attaches.

Flushing on UHID_OPEN was my first idea and it does not work on this kernel. The in-kernel keyboard handler claims anything with EV_KEY bits, so the event fires at creation with no reader attached and never fires again when a real one shows up. Measured what actually happens instead and X opens a fresh node about half a second after it appears, so reports are held for a second and written when that window closes.

Two places hold them. `host.py` keeps what arrives before the node exists and hands it over at creation, and `UHIDDevice` holds everything until the window is up. The media remote creates its own node through the same class so it gets this for free.

Checked with a synthetic peer driving the real code paths and reading the evdev node, both a press before the node exists and one right after creation reach it now, both were lost before. A reader that attaches later than a second still misses the first press, which is deliberate, replaying stale input is worse than dropping it.