### PR TITLE
fix(ble): stop re-admitting a device that was just removed

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -118,6 +118,15 @@ class BLEMixin:
     def _admit_ble_connection(self, connection, matched_dev=None, match_kind=None):
         """Create a session for a new BLE connection, dropping duplicates."""
         addr = normalize_addr(str(connection.peer_address))
+
+        # A connect started before /remove still lands here; without this the
+        # session comes back and re-pairs, so the app keeps showing the device.
+        allowed = {normalize_addr(d.address) for d in self.ble_devices} | self._keystore_addresses
+        if match_kind is None and '*' not in allowed and addr not in allowed:
+            log.warning(f"[BLE] Rejecting {addr} (not allowed)")
+            self._track_task(asyncio.create_task(self._reject_connection(connection)))
+            return
+
         old = self.sessions.get(addr)
         if old is not None and old.is_alive():
             log.info(f"[BLE] Duplicate connection from {addr}, dropping")


### PR DESCRIPTION
Removing a connected BLE device from BTManager did not make it go away, it only disappeared after a daemon restart. Here is what my log shows

```
15:07:35,079 Cleared cache for 5C:2B:3E:50:4F:04     <- /remove
15:07:35,184 Devices: 1 Classic, 0 BLE               <- gone from devices.conf
15:07:35,191 Keystore has 2 entries                  <- pairing key deleted
15:07:36,122 [BLE] Device connected: 5C:2B:3E:50:4F:04
15:07:36,431 [BLE] Pairing complete                  <- key written back
15:07:37,977 receiving HID reports
```

The accept-list handler already had a create-connection in flight when the remove landed, and `_admit_ble_connection` took whatever showed up, so the session was rebuilt and re-paired itself. With no devices.conf entry left the app renders it through the "connection with no config entry" branch, which is why it sticks around. Classic has had `_is_classic_allowed` on that path for a while, BLE never got the same check.

So the admit path now drops a connection whose address is neither configured nor bonded. A rotated-address match still goes through untouched, those legitimately carry an address that is in neither list.

Verified against the log above rather than on device, since the deployed daemon is the compiled binary and reproducing means unpairing the device.