### PR TITLE
build: shrink main.bin and prune the remaining dead weight

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -99,12 +99,16 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --nofollow-import-to=cryptography \
     --nofollow-import-to=ssl \
     --nofollow-import-to=_hashlib \
-    --nofollow-import-to=_codecs_cn \
-    --nofollow-import-to=_codecs_hk \
-    --nofollow-import-to=_codecs_iso2022 \
-    --nofollow-import-to=_codecs_jp \
-    --nofollow-import-to=_codecs_kr \
-    --nofollow-import-to=_codecs_tw \
+    --nofollow-import-to=encodings.euc_* \
+    --nofollow-import-to=encodings.shift_jis* \
+    --nofollow-import-to=encodings.iso2022_* \
+    --nofollow-import-to=encodings.big5* \
+    --nofollow-import-to=encodings.gb* \
+    --nofollow-import-to=encodings.cp932 \
+    --nofollow-import-to=encodings.cp949 \
+    --nofollow-import-to=encodings.cp950 \
+    --nofollow-import-to=encodings.johab \
+    --nofollow-import-to=encodings.hz \
     kindle_hid_passthrough/main.py
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.

--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -99,6 +99,8 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --nofollow-import-to=cryptography \
     --nofollow-import-to=ssl \
     --nofollow-import-to=_hashlib \
+    --nofollow-import-to=multiprocessing \
+    --nofollow-import-to=concurrent.futures.process \
     kindle_hid_passthrough/main.py
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.
@@ -134,7 +136,8 @@ RUN rm -f /build/nuitka-out/main.dist/_codecs_cn.so \
           /build/nuitka-out/main.dist/_codecs_jp.so \
           /build/nuitka-out/main.dist/_codecs_kr.so \
           /build/nuitka-out/main.dist/_codecs_tw.so \
-          /build/nuitka-out/main.dist/_multibytecodec.so
+          /build/nuitka-out/main.dist/_multibytecodec.so \
+          /build/nuitka-out/main.dist/unicodedata.so
 
 # Build C wrapper that invokes the bundled ld-linux directly
 # This bypasses the system dynamic linker entirely

--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -99,16 +99,6 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --nofollow-import-to=cryptography \
     --nofollow-import-to=ssl \
     --nofollow-import-to=_hashlib \
-    --nofollow-import-to=encodings.euc_* \
-    --nofollow-import-to=encodings.shift_jis* \
-    --nofollow-import-to=encodings.iso2022_* \
-    --nofollow-import-to=encodings.big5* \
-    --nofollow-import-to=encodings.gb* \
-    --nofollow-import-to=encodings.cp932 \
-    --nofollow-import-to=encodings.cp949 \
-    --nofollow-import-to=encodings.cp950 \
-    --nofollow-import-to=encodings.johab \
-    --nofollow-import-to=encodings.hz \
     kindle_hid_passthrough/main.py
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.
@@ -134,6 +124,17 @@ RUN gcc -O2 /build/mousecursor.c -o /build/nuitka-out/main.dist/mousecursor.bin 
         while read -r lib; do cp -Ln "$lib" /build/nuitka-out/main.dist/ 2>/dev/null || true; done && \
     echo "Cursor deps:" && ls -la /build/nuitka-out/main.dist/mousecursor.bin \
         /build/nuitka-out/main.dist/libX11* /build/nuitka-out/main.dist/libxcb*
+
+# Nuitka force-includes the whole encodings package in standalone mode and
+# copies these with it, so --nofollow-import-to can't reach them. Nothing asks
+# for a CJK encoding, and the codec registry only loads them on lookup.
+RUN rm -f /build/nuitka-out/main.dist/_codecs_cn.so \
+          /build/nuitka-out/main.dist/_codecs_hk.so \
+          /build/nuitka-out/main.dist/_codecs_iso2022.so \
+          /build/nuitka-out/main.dist/_codecs_jp.so \
+          /build/nuitka-out/main.dist/_codecs_kr.so \
+          /build/nuitka-out/main.dist/_codecs_tw.so \
+          /build/nuitka-out/main.dist/_multibytecodec.so
 
 # Build C wrapper that invokes the bundled ld-linux directly
 # This bypasses the system dynamic linker entirely

--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libx11-dev \
     rustc \
     cargo \
+    musl-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python build tools
@@ -96,6 +97,14 @@ RUN --mount=type=cache,target=/nuitka-cache \
     --nofollow-import-to=bumble.transport.pty \
     --nofollow-import-to=platformdirs \
     --nofollow-import-to=cryptography \
+    --nofollow-import-to=ssl \
+    --nofollow-import-to=_hashlib \
+    --nofollow-import-to=_codecs_cn \
+    --nofollow-import-to=_codecs_hk \
+    --nofollow-import-to=_codecs_iso2022 \
+    --nofollow-import-to=_codecs_jp \
+    --nofollow-import-to=_codecs_kr \
+    --nofollow-import-to=_codecs_tw \
     kindle_hid_passthrough/main.py
 
 # Copy the build container's dynamic linker and core glibc libs into the dist.
@@ -184,7 +193,7 @@ RUN printf '%s\n' \
     '    return 1;' \
     '}' \
     > /build/wrapper.c && \
-    gcc -static -o /build/kindle-hid-passthrough /build/wrapper.c && \
+    musl-gcc -Os -static -o /build/kindle-hid-passthrough /build/wrapper.c && \
     strip /build/kindle-hid-passthrough
 
 # Same wrapper trick for the cursor overlay. It ships in scripts/, so dist/ is
@@ -240,7 +249,7 @@ RUN printf '%s\n' \
     '    return 1;' \
     '}' \
     > /build/mousecursor_wrapper.c && \
-    gcc -static -o /build/mousecursor /build/mousecursor_wrapper.c && \
+    musl-gcc -Os -static -o /build/mousecursor /build/mousecursor_wrapper.c && \
     strip /build/mousecursor
 
 # Prepare the output directory structure:

--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -140,7 +140,7 @@ RUN printf '%s\n' \
     '#include <string.h>' \
     '#include <unistd.h>' \
     '#include <libgen.h>' \
-    '#include <linux/limits.h>' \
+    '#include <limits.h>' \
     '' \
     'int main(int argc, char *argv[]) {' \
     '    char exe_path[PATH_MAX];' \
@@ -206,7 +206,7 @@ RUN printf '%s\n' \
     '#include <unistd.h>' \
     '#include <string.h>' \
     '#include <libgen.h>' \
-    '#include <linux/limits.h>' \
+    '#include <limits.h>' \
     '' \
     'int main(int argc, char *argv[]) {' \
     '    char exe_path[PATH_MAX];' \

--- a/.github/nuitka-plugins/bytecode_large_modules.py
+++ b/.github/nuitka-plugins/bytecode_large_modules.py
@@ -3,15 +3,21 @@ from nuitka.plugins.PluginBase import NuitkaPluginBase
 
 class NuitkaPluginBytecodeLargeModules(NuitkaPluginBase):
     plugin_name = "bytecode-large-modules"
-    plugin_desc = "Ship named modules as bytecode instead of compiling them to C."
+    plugin_desc = "Ship bumble as bytecode instead of compiling it to C."
 
-    BYTECODE_MODULES = ("bumble.hci", "bumble.gatt_server")
+    # Compiled, not bytecode. Pairing runs ECDH P-256 in pure python here since
+    # cryptography was dropped, and interpreting it makes pairing measurably slower.
+    COMPILED_PREFIXES = ("bumble.crypto",)
 
     @staticmethod
     def isAlwaysEnabled():
         return True
 
     def decideCompilation(self, module_name):
-        if module_name in self.BYTECODE_MODULES:
-            return "bytecode"
-        return None
+        name = str(module_name)
+        if name != "bumble" and not name.startswith("bumble."):
+            return None
+        for prefix in self.COMPILED_PREFIXES:
+            if name == prefix or name.startswith(prefix + "."):
+                return None
+        return "bytecode"


### PR DESCRIPTION
main.bin is 5.3MB of the 11.3MB release, so it's the only thing left that really moves the number. Draft until CI tells us what the bytecode change is actually worth, and it needs a device run before merging.

The plugin already shipped `bumble.hci` and `bumble.gatt_server` as bytecode. This widens it to the whole package, which should pull a lot out of the 11MB of `.text`. It should shorten the LTO link too, since there's less C to compile.

`bumble.crypto` deliberately stays compiled. Pairing does ECDH P-256 in pure python there now that cryptography is gone, and it lands at about 300ms on device. Interpreting that would be a regression you'd feel every time you pair.

The rest is the low risk pruning, measured by deleting each thing from the real tarball and re-compressing.

Dropping ssl and _hashlib is worth 1.38MB, because it takes libcrypto and libssl with them. Nothing imports either directly. `ssl` comes in through `http.server` to `http.client`, which wraps the import in try/except, and `hashlib` falls back to the bundled `_md5`, `_sha1`, `_sha256`, `_sha512`, `_blake2` and `_sha3` when `_hashlib` is missing. The CJK multibyte codecs are another 273KB. And the two exec wrappers are forty lines of C each that were costing 363KB apiece as static glibc, so they build with musl now.

Left alone on purpose. `unicodedata.so` is 272KB but `encodings.idna` imports it and I didn't want to chase that. The X11 stack plus mousecursor is 581KB but that's deleting the cursor overlay, not shrinking it. `bz2`, `lzma`, `pyexpat` and `_decimal` are 225KB together but I couldn't pin down what pulls `decimal`, so it isn't low risk.

Worth checking on device after CI, whether pairing is still around 300ms, and that the API server still serves over plain HTTP with ssl gone.
