### PR TITLE
Allow debug logging in daemon mode via KINDLE_HID_DEBUG

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,6 +19,9 @@ status hid-passthrough
 
 # View logs
 tail -f /var/log/hid_passthrough.log
+
+# Verbose logs, including a timestamped line per HID report
+KINDLE_HID_DEBUG=1 /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon &
 ```
 
 ### Pairing

--- a/kindle_hid_passthrough/logging_utils.py
+++ b/kindle_hid_passthrough/logging_utils.py
@@ -2,6 +2,7 @@
 """Logging with timestamps, delta tracking, and colored console output."""
 
 import logging
+import os
 import time
 from typing import Optional
 
@@ -129,7 +130,7 @@ def setup_daemon_logging(log_file: str):
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s')
     file_handler.setFormatter(formatter)
     root_logger.addHandler(file_handler)
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(logging.DEBUG if os.environ.get('KINDLE_HID_DEBUG') else logging.INFO)
 
     # Silence verbose Bumble library logs
     logging.getLogger('bumble').setLevel(logging.WARNING)


### PR DESCRIPTION
`setup_daemon_logging` pinned the root logger to INFO, so the per-report debug line already sitting in `_forward_report` never made it to the log file. There was no way to get a timestamp on a HID report arriving in daemon mode.

Set `KINDLE_HID_DEBUG=1` and the daemon logs at DEBUG instead. Default is unchanged.

```
KINDLE_HID_DEBUG=1 /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon &
```

For #225, to tell a report that arrives late apart from one that arrives on time and stalls somewhere downstream.