### PR TITLE
feat(uhid): forward hidraw writes to the device as output reports

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -31,6 +31,7 @@ from config import Protocol, config, normalize_addr, clean_device_name
 from logging_utils import log
 
 HID_REPORT_TYPE_INPUT = 1
+HID_REPORT_TYPE_OUTPUT = 2
 
 # Re-read the battery level this often, for devices that never notify.
 BATTERY_POLL_INTERVAL = 300
@@ -475,6 +476,9 @@ class BLEMixin:
         if report_type == HID_REPORT_TYPE_INPUT:
             session.hid_reports.append((report_id, char))
             log.info(f"[BLE] Found input report {report_id}")
+        elif report_type == HID_REPORT_TYPE_OUTPUT:
+            session.output_reports[report_id] = char
+            log.info(f"[BLE] Found output report {report_id}")
 
     async def _subscribe_to_ble_reports(self, session):
         """Subscribe to BLE HID input report notifications."""

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -17,6 +17,9 @@ from bumble.sdp import Client as SDPClient
 from config import Protocol, clean_device_name, config, normalize_addr
 from logging_utils import errstr, log
 
+# HIDP DATA header, OUTPUT report type.
+HIDP_DATA_OUTPUT = 0xA2
+
 FALLBACK_HID_DESCRIPTOR = bytes([
     0x05, 0x01, 0x09, 0x05, 0xa1, 0x01, 0x85, 0x01,
     0x05, 0x01, 0x09, 0x30, 0x09, 0x31, 0x09, 0x32, 0x09, 0x35,
@@ -75,6 +78,12 @@ class ClassicHIDChannels:
         """Send HIDP SET_PROTOCOL(Report) on the control channel."""
         self.ctrl_channel.write(
             bytes(SetProtocolMessage(protocol_mode=Message.ProtocolMode.REPORT_PROTOCOL)))
+
+    def send_output_report(self, payload: bytes):
+        """Send a HIDP DATA/OUTPUT report on the interrupt channel."""
+        if self.intr_channel is None:
+            raise RuntimeError("interrupt channel is not connected")
+        self.intr_channel.write(bytes([HIDP_DATA_OUTPUT]) + payload)
 
     async def disconnect(self):
         """Close both channels, interrupt first, 1s cap each."""

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -47,9 +47,11 @@ class DeviceSession:
         self.connection = connection
         self.peer = None
         self.channels = None
+        self.uhid_loop = None
         self.name = None
         self.report_map: Optional[bytes] = None
         self.hid_reports = []
+        self.output_reports = {}
         self.uhid_device = None
         self.is_pointer = False
         self.last_report = None
@@ -98,6 +100,9 @@ class DeviceSession:
         self.closed = True
         try:
             if self.uhid_device:
+                if self.uhid_loop and self.uhid_device.fd is not None:
+                    self.uhid_loop.remove_reader(self.uhid_device.fd)
+                    self.uhid_loop = None
                 try:
                     self.uhid_device.destroy()
                 except Exception:
@@ -173,6 +178,30 @@ class HIDHost(ClassicMixin, BLEMixin):
         if self.media_remote:
             connections += self.media_remote.state_list()
         return {"connected": bool(connections), "connections": connections}
+
+    def _on_uhid_output(self, session: DeviceSession):
+        """Pass a hidraw write on to the device it was written for.
+
+        Classic takes the whole payload on the interrupt channel. BLE splits
+        it: hidraw always prefixes the report id, while HID over GATT carries
+        the id in the Report Reference descriptor and the characteristic holds
+        the body alone.
+        """
+        payload = session.uhid_device.read_output_report() if session.uhid_device else None
+        if not payload:
+            return
+        try:
+            if session.channels:
+                session.channels.send_output_report(payload)
+            elif session.peer:
+                char = session.output_reports.get(payload[0])
+                if char is None:
+                    log.debug(f"No BLE output report {payload[0]}")
+                    return
+                asyncio.ensure_future(
+                    session.peer.write_value(char, payload[1:], with_response=False))
+        except Exception as e:
+            log.debug(f"Output report not forwarded: {e}")
 
     def _parse_devices(self):
         """Parse devices from config and group by protocol."""
@@ -601,7 +630,10 @@ class HIDHost(ClassicMixin, BLEMixin):
                 uniq=session.address,
             )
             log.success(f"UHID device created: {name}")
-            asyncio.get_event_loop().call_later(
+            session.uhid_loop = asyncio.get_event_loop()
+            session.uhid_loop.add_reader(
+                session.uhid_device.fd, self._on_uhid_output, session)
+            session.uhid_loop.call_later(
                 0.5, session.uhid_device.discover_input_paths)
             session.is_pointer = descriptor_is_pointer(descriptor)
             if session.is_pointer:

--- a/kindle_hid_passthrough/uhid_handler.py
+++ b/kindle_hid_passthrough/uhid_handler.py
@@ -125,9 +125,15 @@ def descriptor_is_pointer(descriptor: bytes) -> bool:
 UHID_CREATE2 = 11
 UHID_DESTROY = 1
 UHID_INPUT2 = 12
+UHID_OUTPUT = 6
 # Maximum sizes
 HID_MAX_DESCRIPTOR_SIZE = 4096
 UHID_DATA_MAX = 4096
+# sizeof(struct uhid_event), which is packed and sized by its largest arm,
+# uhid_create2_req (4372) plus the 4-byte type.
+UHID_EVENT_MAX = 4376
+# Offset of uhid_output_req.size, which follows its data[UHID_DATA_MAX].
+UHID_OUTPUT_SIZE_OFFSET = 4 + UHID_DATA_MAX
 
 
 class Bus:
@@ -319,6 +325,33 @@ class UHIDDevice:
             logger.debug(f"Sent input: {data.hex()}")
         except OSError as e:
             raise UHIDError(f"Failed to send input: {e}")
+
+    def read_output_report(self) -> Optional[bytes]:
+        """Return the payload of a queued UHID_OUTPUT event, if that is next.
+
+        The kernel queues one per hidraw write and drops it when nothing reads,
+        which is why writes to the hidraw node succeed and do nothing. Call
+        when the fd is readable; it is a blocking fd.
+        """
+        if self._fd is None:
+            return None
+
+        try:
+            event = os.read(self._fd, UHID_EVENT_MAX)
+        except (BlockingIOError, InterruptedError):
+            return None
+        except OSError as e:
+            logger.debug(f"UHID read failed: {e}")
+            return None
+
+        if len(event) < 4:
+            return None
+        event_type, = struct.unpack_from('< L', event, 0)
+        if event_type != UHID_OUTPUT or len(event) < UHID_OUTPUT_SIZE_OFFSET + 2:
+            return None
+
+        size, = struct.unpack_from('< H', event, UHID_OUTPUT_SIZE_OFFSET)
+        return event[4:4 + min(size, UHID_DATA_MAX)] or None
 
     def destroy(self):
         """Destroy the virtual device and close the file descriptor."""


### PR DESCRIPTION
Writes to a device's hidraw node have always been a no-op. Nothing read `/dev/uhid`, so the kernel queued a `UHID_OUTPUT` event per write and dropped it, and the write still returned the byte count so it looked like it worked. Rumble, player lights and mode switches were all dead behind that.

This watches the uhid fd and passes the payload on. Classic writes it whole on the interrupt channel behind a HIDP DATA/OUTPUT header. BLE looks up the Report characteristic by id and writes the body alone, since hidraw always prefixes the report id while HID over GATT keeps it in the Report Reference descriptor.

Tested on a Basic 4 with an Xbox Wireless Controller over BLE, where output report 3 now actually rumbles the pad.

```
printf '\x03\x0f\x00\x00\x64\x64\x40\x00\x00' > /dev/hidraw0
```

The Classic path is the same idea with one L2CAP write, but I had nothing paired over Classic to try it on, so that half is unverified on hardware.

Based on @andy2mrqz's branch in #191, with two changes. `UHID_EVENT_MAX` is 4376 rather than 4380, the packed struct is 4 bytes of type plus `uhid_create2_req` at 4372, and I checked the parser against an event laid out the way `uhid.c` packs it. And the event loop is stashed on the session so `cleanup()` removes the reader when it runs off the loop thread instead of quietly leaving a watcher on a closed fd.

This is only the pipe, it sets no lights on its own. Per device init bytes and a small built in table for the controllers that need it are the next PR.

Refs #191
