### PR TITLE
chore: bump version to 3.15.2

### DIFF
--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -14,7 +14,7 @@ from kindle_detect import detect_kindle
 if TYPE_CHECKING:
     pass
 
-__version__ = "3.15.1"
+__version__ = "3.15.2"
 __build_sha__ = None  # stamped by build scripts
 
 

--- a/kpm/repo.json
+++ b/kpm/repo.json
@@ -14,7 +14,7 @@
           "version": [
             3,
             15,
-            1
+            2
           ],
           "dependencies": [],
           "supported_platforms": [


### PR DESCRIPTION
Patch bump to release the size work from #237. The release is 6965120 bytes now against 21414210 before all this, so 67% off.

kpm/repo.json regenerated with scripts/gen_kpm_manifests.py, the CI step that checks it is in sync would fail otherwise.