### PR TITLE
fix(kpm): pin the artifact url to the release tag

### DIFF
--- a/kpm/repo.json
+++ b/kpm/repo.json
@@ -10,7 +10,7 @@
       "description": "Userspace Bluetooth HID host. Pairs gamepads, keyboards and remotes and passes their input straight to Linux via UHID, with a touchscreen manager app and a KOReader plugin.",
       "artifacts": [
         {
-          "url": "https://github.com/zampierilucas/kindle-hid-passthrough/releases/latest/download/kindle-hid-passthrough.kpkg",
+          "url": "https://github.com/zampierilucas/kindle-hid-passthrough/releases/download/v3.15.2/kindle-hid-passthrough.kpkg",
           "version": [
             3,
             15,

--- a/scripts/gen_kpm_manifests.py
+++ b/scripts/gen_kpm_manifests.py
@@ -10,6 +10,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 REPO = ROOT / 'kpm/repo.json'
 MANIFEST = ROOT / 'kpm/manifest.json'
+ARTIFACT_URL = ('https://github.com/zampierilucas/kindle-hid-passthrough'
+                '/releases/download/v{version}/kindle-hid-passthrough.kpkg')
 
 
 def version():
@@ -22,6 +24,7 @@ def manifests():
     pkg_id, pkg = next(iter(repo['packages'].items()))
     artifact = pkg['artifacts'][0]
     artifact['version'] = version()
+    artifact['url'] = ARTIFACT_URL.format(version='.'.join(str(n) for n in artifact['version']))
     manifest = {'manifest_version': 2, 'id': pkg_id, 'name': pkg['name'], 'author': pkg['author'],
                 'description': pkg['description'], 'version': artifact['version'],
                 'dependencies': artifact['dependencies'],


### PR DESCRIPTION
the kpm index entry pointed at releases/latest/download, so the url served whatever the newest release happened to be while the version field sitting right next to it stayed put.

kpm already computes a sha256 of every download in install.c and currently just logs it. once that hash actually gets checked against the index, a url whose contents change every release can never match. the official kindlemodding repo pins one artifact per version so this does the same, and gen_kpm_manifests.py now stamps the tag alongside the version so a version bump keeps both in sync.

one tradeoff worth knowing, a versioned url 404s in the gap between repo.json landing on main and the release actually existing, where latest never did. that only bites someone who runs kpm update inside that window, and it closes as soon as CI uploads the asset.

verified the v3.15.2 url returns 200 with the right size, and re-running the generator leaves no diff so the git diff --exit-code check in CI still passes.