### PR TITLE
fix(brcm): hand the chip back to bluesleep after bring-up

### DIFF
--- a/kindle_hid_passthrough/bt_brcm.py
+++ b/kindle_hid_passthrough/bt_brcm.py
@@ -277,6 +277,23 @@ class BrcmChip(BtChip):
         # Settle after wake before the first HCI command, else HCI Reset times out.
         time.sleep(POST_WAKE_SETTLE)
 
+    def on_ready(self):
+        """Hand the chip back to bluesleep now that bring-up is done.
+
+        pre_open() turns bluesleep off so the chip is provably awake for the
+        first HCI Reset (#106), but leaving it off for the whole session tears
+        down the HOST_WAKE IRQ, so nothing pulls the SoC out of idle ahead of
+        an incoming report and the first press after an idle gap is late
+        (#225). The latency hold stays for the wake the IRQ cannot cover.
+        """
+        try:
+            with open(BT_SLEEP_PROTO_PATH, 'w') as f:
+                f.write('1')
+        except OSError as e:
+            log.warning(f"Could not re-enable bluesleep: {e}")
+            return
+        log.info(f"bluesleep re-enabled, HOST_WAKE armed ({self._sleep_state()})")
+
     def on_transport_close(self):
         self._latency.release()
 

--- a/kindle_hid_passthrough/bt_chip.py
+++ b/kindle_hid_passthrough/bt_chip.py
@@ -94,6 +94,9 @@ class BtChip:
     def on_transport_close(self):
         """Run after the transport closes, to drop anything held for it."""
 
+    def on_ready(self):
+        """Run once the controller is powered on and bring-up is done."""
+
     def on_hci_reset_timeout(self):
         """Run after HCI Reset times out, before the connect attempt is retried."""
 

--- a/kindle_hid_passthrough/transport.py
+++ b/kindle_hid_passthrough/transport.py
@@ -178,6 +178,9 @@ async def create_bumble_device(transport_spec=None, configure=None):
 
         await device.power_on()
         log.success(f"Device powered on: {device.public_address}")
+
+        # chip hook: bring-up is done, hand the chip back to its sleep protocol
+        chip().on_ready()
     except BaseException:
         try:
             await transport.close()


### PR DESCRIPTION
`pre_open()` turns bluesleep off so the chip is provably awake for the first HCI Reset (#106), but nothing ever turned it back on, so it stayed off for the entire session. `cpu_latency.py` already documents the consequence, with bluesleep off the HOST_WAKE IRQ is torn down and nothing pulls the SoC out of idle ahead of the chip's data.

On KPW4 that shows up as #225, the first press after a few seconds idle lands about 4s late. It goes away when the Kindle is attached to a computer over USB, which keeps the SoC out of deep idle anyway, and flamecho found that forcing `/proc/bluetooth/sleep/proto` back to 1 also makes it go away.

Adds an `on_ready()` chip hook that runs once the controller is powered on, and re-enables bluesleep there, after the bring-up that needed it off. The cpuidle latency hold and the resync parser are untouched, they still cover the wake the IRQ cannot.

No-op on MediaTek.

Worth noting flamecho's workaround also ran a `sleep 0.2` shell loop, which on its own keeps the SoC out of deep idle, so his test does not cleanly separate the two. This change is right regardless, but it needs confirming on a KPW4 before we call #225 fixed.