### PR TITLE
fix(host): drop sessions whose link died without a disconnection event

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -7,9 +7,15 @@ from typing import List, Optional
 
 from bumble.core import InvalidStateError
 from bumble.hci import (
+    HCI_CONNECTION_TIMEOUT_ERROR,
     HCI_LE_SET_PRIVACY_MODE_COMMAND,
+    HCI_SUCCESS,
+    HCI_UNKNOWN_CONNECTION_IDENTIFIER_ERROR,
     HCI_Constant,
+    HCI_Disconnection_Complete_Event,
+    HCI_Error,
     HCI_LE_Set_Privacy_Mode_Command,
+    HCI_Read_RSSI_Command,
     HCI_Write_Class_Of_Device_Command,
     HCI_Write_Local_Name_Command,
     HCI_Write_Scan_Enable_Command,
@@ -20,7 +26,7 @@ from bt_setup import ensure_uhid
 from classic import ClassicMixin
 from config import Protocol, clean_device_name, config, get_version, normalize_addr
 from device_cache import DeviceCache
-from logging_utils import log
+from logging_utils import errstr, log
 from media_remote import MEDIA_REMOTE_COD, MediaRemote
 from pairing import create_keystore, create_pairing_config
 from transport import create_bumble_device
@@ -140,6 +146,7 @@ class HIDHost(ClassicMixin, BLEMixin):
     ACTIVE_CONNECT_TIMEOUT = 10
     FIRST_SESSION_TIMEOUT = 60.0
     SETUP_TIMEOUT = 45.0
+    LINK_PROBE_INTERVAL = 30.0
 
     def __init__(self, transport_spec: str = None):
         self.transport_spec = transport_spec or config.transport
@@ -363,6 +370,8 @@ class HIDHost(ClassicMixin, BLEMixin):
         if self.classic_devices or self.ble_devices:
             tasks.append(asyncio.create_task(
                 self._session_watchdog(), name="session_watchdog"))
+            tasks.append(asyncio.create_task(
+                self._link_probe(), name="link_probe"))
 
         try:
             done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
@@ -402,6 +411,60 @@ class HIDHost(ClassicMixin, BLEMixin):
             except asyncio.TimeoutError:
                 log.warning("Connection timeout - no device connected")
                 raise InvalidStateError("No device connected within timeout")
+
+    async def _link_probe(self):
+        """Drop sessions whose link died without a disconnection event.
+
+        Every teardown path hangs off that event, so a session that never
+        gets one is served forever: the API keeps reporting it connected and
+        the handlers never re-initiate. On MTK the controller stays quiet
+        across a suspend we did not bracket, which is any suspend whose
+        powerd event we missed (#180). Asking the controller about the
+        handle is the only answer that does not depend on being told.
+        """
+        while True:
+            await asyncio.sleep(self.LINK_PROBE_INTERVAL)
+            for session in list(self.sessions.values()):
+                if session.closed or not session.is_alive():
+                    continue
+                if await self._handle_is_live(session.connection.handle):
+                    continue
+                proto = session.protocol.value.upper()
+                log.warning(f"[{proto}] Link is gone for "
+                            f"{self._format_device(session.address)}, "
+                            f"dropping the session")
+                self._synthesize_disconnection(session.connection.handle)
+
+    async def _handle_is_live(self, handle) -> bool:
+        """Ask the controller whether it still knows this connection handle."""
+        try:
+            await self.device.host.send_command(
+                HCI_Read_RSSI_Command(handle=handle), check_result=True)
+            return True
+        except HCI_Error as e:
+            # An unsupported command or a busy controller says nothing about
+            # the link, so only the unknown handle counts as proof.
+            return e.error_code != HCI_UNKNOWN_CONNECTION_IDENTIFIER_ERROR
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.debug(f"Link probe for handle {handle}: {errstr(e)}")
+            return True
+
+    def _synthesize_disconnection(self, handle):
+        """Hand Bumble the event the controller owed us for this handle.
+
+        Bumble drops the connection and emits it on to the listener that
+        `_register_session` already installed, so the session leaves by the
+        one path every other disconnect uses, rather than through a second
+        teardown entry point that would have to keep up with it.
+        """
+        self.device.host.on_hci_disconnection_complete_event(
+            HCI_Disconnection_Complete_Event(
+                status=HCI_SUCCESS,
+                connection_handle=handle,
+                reason=HCI_CONNECTION_TIMEOUT_ERROR,
+            ))
 
     def _notify_sessions_changed(self):
         if self._sessions_changed:


### PR DESCRIPTION
A session only ever leaves through the connection's disconnection event. If that event never arrives the session is served forever, the API keeps reporting it connected and the handlers never re-initiate, which is the half of #180 where the remote is actually gone but the device page still says connected and nothing comes back until the daemon restarts.

#186 closed the common case by watching powerd on every chip, and that is still the right thing, but the watch can miss an event. `lipc-wait-event` respawns on a 5s delay, and `_do_system_resume` returns early when the matching suspend never arrived, so one missed `readyToSuspend` and we go under holding a live session and wake up still holding it. On MTK the controller never sends the disconnection that would correct us, so it stays that way.

So stop waiting to be told. `_link_probe` runs Read RSSI against each session's handle every 30s, and an `UNKNOWN_CONNECTION_IDENTIFIER` reply is the controller saying it has no such link. That gets fed back into Bumble as the disconnection event we were owed, so the session leaves through `_on_session_disconnection` exactly like a real drop, no second teardown path to keep in sync. Any other error, an unsupported command or a busy controller, says nothing about the link, so only the unknown handle counts as proof.

Nothing changes on a healthy link beyond one HCI command every 30s per session.

Verified the logic against bumble 0.0.226 offline, a dead handle synthesizes exactly one disconnection carrying the right handle, a live one is left alone, and neither an unsupported command nor an already-dropped session touches anything. What I have not done is catch a real missed suspend on a PW6, which by its nature is not something I can force here, so this wants a run from someone who sees it.
