### PR TITLE
fix(brcm): hand btd back when we power the chip off

### DIFF
--- a/kindle_hid_passthrough/bt_brcm.py
+++ b/kindle_hid_passthrough/bt_brcm.py
@@ -66,17 +66,22 @@ def _wait_for_bsa():
     return False
 
 
+def _thaw_btd():
+    """Undo the SIGSTOP the handoff left on btd."""
+    for pid in _pgrep_x('btd'):
+        try:
+            os.kill(pid, signal.SIGCONT)
+        except OSError:
+            pass
+
+
 def _recover_btd():
     """Unfreeze and restart btd so it can respawn bsa_server.
 
     A btd left frozen by a prior handoff makes `initctl restart` hang, so
     SIGCONT it first.
     """
-    for pid in _pgrep_x('btd'):
-        try:
-            os.kill(pid, signal.SIGCONT)
-        except OSError:
-            pass
+    _thaw_btd()
     run(['initctl', 'restart', 'btd'])
     time.sleep(2.0)
     run(BTENABLE_LIPC)
@@ -275,6 +280,11 @@ class BrcmChip(BtChip):
         with self._power_lock:
             self._warm = False
             self._latency.release()
+            # Hand btd back before anything else. Frozen it can neither
+            # respawn bsa_server nor answer BTenable, so a chip powered off
+            # while btd is stopped never warms again and only a reboot
+            # clears it. The restart below hangs on a frozen btd too.
+            _thaw_btd()
             try:
                 if open(BT_ENABLE_PATH).read().strip() == '0':
                     return


### PR DESCRIPTION
The warm handoff SIGSTOPs btd so it cannot respawn bsa_server behind our back, and the only thing that has ever unfrozen it is `_recover_btd`, which only runs as a retry after a 12s warm-up timeout. Nothing on a normal path gives btd back.

So every `power_off` left it stopped. That matters because a frozen btd is exactly what the next warm-up depends on, it can neither respawn bsa_server nor answer BTenable, and `initctl restart btd` hangs on a stopped process, so the restart at the end of `power_off` burned its full 10s timeout and did nothing. The worse case is when btenable already reads 0, we return early there and never even reach the restart, so btd stays frozen with nothing left that would thaw it.

On Broadcom `survives_suspend` is False, so we power off at `goingToScreenSaver`. That means this is every screen blank, not just a real suspend.

Fix is to pull the SIGCONT out of `_recover_btd` into `_thaw_btd` and call it first thing in `power_off`, before both exits. `_recover_btd` keeps its own thaw since it can be reached without a power off.

This is aimed at the reconnect half of #225, where @flamecho reports the controller not coming back after sleep with only a reboot clearing it, and it matches that shape, a frozen btd survives everything short of a reboot. What I cannot claim from here is that it is the whole of it. The old code should still have crawled back through `_recover_btd` after roughly 25s, so if it never recovered at all there may be more going on, and this wants a run on a KPW4 across a sleep to say either way.

Checked the branches offline, an enabled chip thaws then powers down then restarts btd in that order, a chip already off still thaws and leaves btenable alone, and `_recover_btd` keeps thawing before its restart.

Separately and not fixed here, `power_off` is never called when the daemon just stops, so stopping or uninstalling also leaves btd frozen. Calling it there would power the chip down on every stop, which is a behaviour change worth its own think.
