### PR TITLE
Feat/A2DP Audio Passthrough

### DIFF
--- a/.github/Dockerfile.arm
+++ b/.github/Dockerfile.arm
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-libc-dev \
     libssl-dev \
     libx11-dev \
+    libsbc-dev \
     rustc \
     cargo \
     && rm -rf /var/lib/apt/lists/*
@@ -103,7 +104,7 @@ RUN --mount=type=cache,target=/nuitka-cache \
 RUN cp /lib/ld-linux-armhf.so.3 /build/nuitka-out/main.dist/ld-linux-armhf.so.3 && \
     for lib in libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1 \
                libutil.so.1 libresolv.so.2 libnss_dns.so.2 libnss_files.so.2 \
-               libz.so.1 libstdc++.so.6; do \
+               libz.so.1 libstdc++.so.6 libsbc.so.1; do \
         src=$(find /lib /usr/lib -name "$lib" 2>/dev/null | head -1); \
         if [ -n "$src" ]; then \
             cp -L "$src" /build/nuitka-out/main.dist/"$lib"; \

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -153,6 +153,10 @@ jobs:
             kindle-hid-passthrough \
             assets/hid-passthrough.upstart \
             assets/99-hid-keyboard.rules \
+            assets/audio-hack/start_audio_hack.sh \
+            assets/audio-hack/stop_audio_hack.sh \
+            assets/audio-hack/gst-launch-wrapper.sh \
+            assets/audio-hack/lipc_audio_mock.lua \
             scripts/dev_is_keyboard.sh \
             illusion/BTManager.sh \
             koreader-plugin/hidpassthrough.koplugin/main.lua \

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -160,6 +160,7 @@ jobs:
             assets/audio-hack/stop_audio_hack.sh \
             assets/audio-hack/gst-launch-wrapper.sh \
             assets/audio-hack/lipc_audio_mock.lua \
+            assets/audio-hack/media.sh \
             scripts/dev_is_keyboard.sh \
             illusion/BTManager.sh \
             koreader-plugin/hidpassthrough.koplugin/main.lua \

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -168,6 +168,7 @@ jobs:
             koreader-plugin/hidpassthrough.koplugin/event_map_extra.lua \
             config.ini \
             dist/main.bin \
+            dist/libsbc.so.1 \
             button-mapper/kindle-button-mapper \
             button-mapper/install.sh \
             button-mapper/config.ini; do

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -2,7 +2,7 @@ name: Build ARM Binary
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'feat/*']
     tags: ['v*']
   pull_request:
     branches: [main]
@@ -205,7 +205,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create dev prerelease
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/feat/'))
         uses: softprops/action-gh-release@v3
         with:
           tag_name: dev-${{ steps.stamp.outputs.sha }}

--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -2,7 +2,7 @@ name: Build ARM Binary
 
 on:
   push:
-    branches: [main, 'feat/*']
+    branches: [main]
     tags: ['v*']
   pull_request:
     branches: [main]
@@ -214,7 +214,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create dev prerelease
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/feat/'))
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: dev-${{ steps.stamp.outputs.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ evsieve-kindle/
 future-work.md
 pr-24-*.md
 .worktrees/
-venv/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ evsieve-kindle/
 future-work.md
 pr-24-*.md
 .worktrees/
+venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,15 +102,3 @@ The `just deploy` command installs the dev version. Binary releases include the 
 ```bash
 just remove-autostart  # Disable autostart (removes upstart config)
 ```
-
-## A2DP Audio Passthrough (ALSA -> SBC)
-
-### O que foi feito
-Implementamos um hack agressivo no sistema de áudio nativo do Kindle para capturar qualquer som tocado no aparelho e redirecioná-lo para os fones de ouvido Bluetooth conectados pelo nosso daemon (já que tomamos controle exclusivo da interface `hci0`, cegando o sistema original da Amazon).
-
-### Como foi feito
-1. **ALSA Hijack (`/etc/asound.conf`)**: Sobrescrevemos os dispositivos `pcm.!default` e `pcm.dmix0` no Kindle usando os plugins `plug` e `file` do ALSA. Qualquer áudio tocado no sistema (ex: via `aplay`) é forçadamente reamostrado para **44100 Hz, Stereo, S16_LE** e despejado continuamente em um arquivo FIFO (pipe) em `/tmp/kindle_audio.fifo`.
-2. **Leitura Assíncrona (`audio_pipe.py`)**: O nosso daemon lê esse pipe continuamente (buffering instantâneo do tipo *bit-bucket* do ALSA nulo) sem bloquear o clock do sistema, armazenando o PCM bruto em memória.
-3. **Encoding SBC (`libsbc.so.1`)**: Usamos `ctypes` para invocar a biblioteca de compressão C nativa. Corrigimos um bug crítico de áudio metálico/sintetizador alterando diretamente a memória da `sbc_struct` no Python para forçar o modo **Joint Stereo (0x03)** e **44.1kHz (0x02)**, batendo perfeitamente com a negociação AVDTP que o Bumble faz com os fones de ouvido.
-4. **Streaming AVDTP (`host.py`)**: O PCM é fatiado (5 frames por pacote), comprimido para SBC, envelopado como payload RTP, e injetado na conexão A2DP de forma assíncrona. Se não houver áudio tocando, o daemon envia frames de silêncio sintéticos pré-calculados para manter os fones acordados.
-5. **KOReader Audiobook Plugin (Fork)**: Como o plugin original tentava usar a infraestrutura da Amazon (`gst-launch` -> `mixersink` -> `audiomgrd`), ele travava por timeout pois a antena BT nativa estava morta. Modificamos o plugin para simplesmente usar o `aplay` padrão do Linux, que cai perfeitamente no nosso cano do ALSA.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,15 @@ The `just deploy` command installs the dev version. Binary releases include the 
 ```bash
 just remove-autostart  # Disable autostart (removes upstart config)
 ```
+
+## A2DP Audio Passthrough (ALSA -> SBC)
+
+### O que foi feito
+Implementamos um hack agressivo no sistema de áudio nativo do Kindle para capturar qualquer som tocado no aparelho e redirecioná-lo para os fones de ouvido Bluetooth conectados pelo nosso daemon (já que tomamos controle exclusivo da interface `hci0`, cegando o sistema original da Amazon).
+
+### Como foi feito
+1. **ALSA Hijack (`/etc/asound.conf`)**: Sobrescrevemos os dispositivos `pcm.!default` e `pcm.dmix0` no Kindle usando os plugins `plug` e `file` do ALSA. Qualquer áudio tocado no sistema (ex: via `aplay`) é forçadamente reamostrado para **44100 Hz, Stereo, S16_LE** e despejado continuamente em um arquivo FIFO (pipe) em `/tmp/kindle_audio.fifo`.
+2. **Leitura Assíncrona (`audio_pipe.py`)**: O nosso daemon lê esse pipe continuamente (buffering instantâneo do tipo *bit-bucket* do ALSA nulo) sem bloquear o clock do sistema, armazenando o PCM bruto em memória.
+3. **Encoding SBC (`libsbc.so.1`)**: Usamos `ctypes` para invocar a biblioteca de compressão C nativa. Corrigimos um bug crítico de áudio metálico/sintetizador alterando diretamente a memória da `sbc_struct` no Python para forçar o modo **Joint Stereo (0x03)** e **44.1kHz (0x02)**, batendo perfeitamente com a negociação AVDTP que o Bumble faz com os fones de ouvido.
+4. **Streaming AVDTP (`host.py`)**: O PCM é fatiado (5 frames por pacote), comprimido para SBC, envelopado como payload RTP, e injetado na conexão A2DP de forma assíncrona. Se não houver áudio tocando, o daemon envia frames de silêncio sintéticos pré-calculados para manter os fones acordados.
+5. **KOReader Audiobook Plugin (Fork)**: Como o plugin original tentava usar a infraestrutura da Amazon (`gst-launch` -> `mixersink` -> `audiomgrd`), ele travava por timeout pois a antena BT nativa estava morta. Modificamos o plugin para simplesmente usar o `aplay` padrão do Linux, que cai perfeitamente no nosso cano do ALSA.

--- a/assets/audio-hack/gst-launch-wrapper.sh
+++ b/assets/audio-hack/gst-launch-wrapper.sh
@@ -58,7 +58,7 @@ fmt_channels=""
 
 for a in "$@"; do
     case "$a" in
-        *rate=*)
+        rate=*|*,rate=*)
             r="${a#*rate=}"
             case "$r" in
                 \(int\)*) r="${r#\(int\)}" ;;
@@ -75,7 +75,7 @@ for a in "$@"; do
             ;;
     esac
     case "$a" in
-        *channels=*)
+        channels=*|*,channels=*)
             c="${a#*channels=}"
             case "$c" in
                 \(int\)*) c="${c#\(int\)}" ;;
@@ -93,10 +93,13 @@ for a in "$@"; do
     esac
 done
 
-if [ -n "$fmt_rate" ] || [ -n "$fmt_channels" ]; then
-    r="${fmt_rate:-44100}"
-    c="${fmt_channels:-2}"
-    echo "rate=$r channels=$c" > "${FMT_FILE}.tmp" 2>/dev/null && mv -f "${FMT_FILE}.tmp" "$FMT_FILE" 2>/dev/null || true
+# Both or neither: publishing a guessed rate next to a real channel count made
+# the daemon resample against a rate the pipeline never had. With nothing
+# written the daemon keeps the format it is already using, which is no worse
+# than the guess and is at least honest about not knowing.
+if [ -n "$fmt_rate" ] && [ -n "$fmt_channels" ]; then
+    echo "rate=$fmt_rate channels=$fmt_channels" > "${FMT_FILE}.tmp" 2>/dev/null &&
+        mv -f "${FMT_FILE}.tmp" "$FMT_FILE" 2>/dev/null || true
 fi
 
 # Transform argument vector: replace mixersink with filesink and drop incompatible sink properties

--- a/assets/audio-hack/gst-launch-wrapper.sh
+++ b/assets/audio-hack/gst-launch-wrapper.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# ==============================================================================
+# Amazon Kindle GStreamer 0.10 Interception & Redirection Wrapper
+# Part of the kindle-hid-passthrough audio bypass
+#
+# Intercepts GStreamer 0.10 audio pipelines specifying 'mixersink' (which block
+# when stock btmanagerd/audiomgrd are inactive) and transparently redirects
+# PCM audio to /tmp/kindle_audio.fifo using 'filesink'.
+#
+# Emits audio format (rate and channels) dynamically to /tmp/kindle_audio.fmt.
+# Injects --gst-debug="mixersink stream-type=Music:0" for process visibility.
+#
+# KOReader source code remains 100% untouched.
+# Compatible with BusyBox ash and POSIX /bin/sh.
+# ==============================================================================
+
+# Destination FIFO for userspace audio streaming
+FIFO="${KINDLE_AUDIO_FIFO:-/tmp/kindle_audio.fifo}"
+FMT_FILE="/tmp/kindle_audio.fmt"
+
+# Real binary resolution
+REAL_BIN="${GST_REAL_BIN:-/usr/bin/gst-launch-0.10.real}"
+if [ ! -x "$REAL_BIN" ]; then
+    if [ -x "/usr/bin/gst-launch-0.10" ] && [ "$(readlink -f /usr/bin/gst-launch-0.10 2>/dev/null)" != "$(readlink -f "$0" 2>/dev/null)" ]; then
+        REAL_BIN="/usr/bin/gst-launch-0.10"
+    else
+        echo "gst-launch-0.10 wrapper error: cannot locate executable binary $REAL_BIN" >&2
+        exit 127
+    fi
+fi
+
+# Fast Path: Check if 'mixersink' is targeted
+has_mixersink=0
+for arg in "$@"; do
+    if [ "$arg" = "mixersink" ]; then
+        has_mixersink=1
+        break
+    fi
+done
+
+# If mixersink is not in argument list, pass through directly
+if [ "$has_mixersink" -eq 0 ]; then
+    exec "$REAL_BIN" "$@"
+fi
+
+# Ensure FIFO exists with 0666 permissions (do not recreate if already a named pipe)
+if [ ! -p "$FIFO" ]; then
+    if [ -e "$FIFO" ] || [ -L "$FIFO" ]; then
+        rm -f "$FIFO" 2>/dev/null
+    fi
+    mkfifo -m 666 "$FIFO" 2>/dev/null || mkfifo "$FIFO" 2>/dev/null
+    chmod 666 "$FIFO" 2>/dev/null || true
+fi
+
+# Extract audio format parameters (rate and channels) from caps if present
+fmt_rate=""
+fmt_channels=""
+
+for a in "$@"; do
+    case "$a" in
+        *rate=*)
+            r="${a#*rate=}"
+            case "$r" in
+                \(int\)*) r="${r#\(int\)}" ;;
+            esac
+            while [ "${r# }" != "$r" ]; do r="${r# }"; done
+            r="${r%%,*}"
+            r="${r%% *}"
+            r="${r%%\'*}"
+            r="${r%%\"*}"
+            case "$r" in
+                ''|*[!0-9]*) ;;
+                *) fmt_rate="$r" ;;
+            esac
+            ;;
+    esac
+    case "$a" in
+        *channels=*)
+            c="${a#*channels=}"
+            case "$c" in
+                \(int\)*) c="${c#\(int\)}" ;;
+            esac
+            while [ "${c# }" != "$c" ]; do c="${c# }"; done
+            c="${c%%,*}"
+            c="${c%% *}"
+            c="${c%%\'*}"
+            c="${c%%\"*}"
+            case "$c" in
+                ''|*[!0-9]*) ;;
+                *) fmt_channels="$c" ;;
+            esac
+            ;;
+    esac
+done
+
+if [ -n "$fmt_rate" ] || [ -n "$fmt_channels" ]; then
+    r="${fmt_rate:-44100}"
+    c="${fmt_channels:-2}"
+    echo "rate=$r channels=$c" > "${FMT_FILE}.tmp" 2>/dev/null && mv -f "${FMT_FILE}.tmp" "$FMT_FILE" 2>/dev/null || true
+fi
+
+# Transform argument vector: replace mixersink with filesink and drop incompatible sink properties
+ORIG_COUNT=$#
+i=0
+in_mixersink=0
+
+while [ $i -lt "$ORIG_COUNT" ]; do
+    arg="$1"
+    shift
+    i=$((i + 1))
+
+    if [ "$arg" = "mixersink" ]; then
+        in_mixersink=1
+        set -- "$@" "filesink" "location=$FIFO" "sync=true"
+    elif [ "$in_mixersink" -eq 1 ]; then
+        case "$arg" in
+            "!"|--*|-*)
+                in_mixersink=0
+                set -- "$@" "$arg"
+                ;;
+            *=*)
+                # Drop property tokens targeted at mixersink (stream-type=*, sync=*, buffer-time=*, etc.)
+                ;;
+            *)
+                in_mixersink=0
+                set -- "$@" "$arg"
+                ;;
+        esac
+    else
+        set -- "$@" "$arg"
+    fi
+done
+
+# Prepend debug flag to ensure 'mixersink stream-type=Music' remains in /proc/$PID/cmdline
+# This guarantees that KOReader's `pkill -9 -f 'mixersink stream-type=Music'` cleanly terminates playback.
+set -- "--gst-debug=mixersink stream-type=Music:0" "$@"
+
+# Replace current process with real GStreamer binary
+exec "$REAL_BIN" "$@"

--- a/assets/audio-hack/lipc_audio_mock.lua
+++ b/assets/audio-hack/lipc_audio_mock.lua
@@ -1,0 +1,160 @@
+#!/mnt/us/koreader/luajit
+-- ============================================================================
+-- LIPC Audio Manager Spoofing Daemon (Milestone M2)
+-- Target: /mnt/us/kindle_hid_passthrough/teamwork_audio_hack/lipc_audio_mock.lua
+-- Service: com.lab126.audiomgrd
+--
+-- Exposes spoofed LIPC properties to satisfy KOReader audio checks without
+-- modifying any KOReader source code.
+-- ============================================================================
+
+local ffi = require("ffi")
+
+ffi.cdef[[
+typedef void* LipcHandle;
+typedef int LipcErr;
+
+typedef LipcErr (*LipcGetIntCb)(LipcHandle h, const char* name, int* val, void* user_data);
+typedef LipcErr (*LipcSetIntCb)(LipcHandle h, const char* name, int val, void* user_data);
+typedef LipcErr (*LipcGetStrCb)(LipcHandle h, const char* name, char* val, size_t* len, void* user_data);
+typedef LipcErr (*LipcSetStrCb)(LipcHandle h, const char* name, const char* val, void* user_data);
+
+LipcHandle LipcOpen(const char* service_name);
+LipcErr LipcClose(LipcHandle h);
+LipcErr LipcRegisterIntProperty(LipcHandle h, const char* name, LipcGetIntCb get_cb, LipcSetIntCb set_cb, void* user_data);
+LipcErr LipcRegisterStringProperty(LipcHandle h, const char* name, LipcGetStrCb get_cb, LipcSetStrCb set_cb, void* user_data);
+LipcErr LipcStartListener(LipcHandle h);
+LipcErr LipcStopListener(LipcHandle h);
+
+typedef void (*sighandler_t)(int);
+sighandler_t signal(int signum, sighandler_t handler);
+unsigned int sleep(unsigned int seconds);
+int usleep(unsigned int usec);
+]]
+
+local liblipc = ffi.load("/usr/lib/liblipc.so.1")
+
+-- Internal property state table
+local int_props = {
+    audioOutputConnected = 1,
+    audioCurrentOutput   = 1,
+    speakerVolume        = 100,
+    headphoneVolume      = 100,
+    isStarted            = 1,
+}
+
+local str_props = {
+    setFocus = "tts",
+    getFocus = "tts",
+    logLevel = "info",
+    logMask  = "0x0fff0000",
+}
+
+-- Hold references to C callbacks to prevent LuaJIT garbage collection
+local callbacks = {}
+
+callbacks.get_int = ffi.cast("LipcGetIntCb", function(h, name, val_ptr, user_data)
+    if name == nil or val_ptr == nil then return 1 end
+    local prop = ffi.string(name)
+    val_ptr[0] = int_props[prop] or 0
+    return 0
+end)
+
+callbacks.set_int = ffi.cast("LipcSetIntCb", function(h, name, val, user_data)
+    if name == nil then return 1 end
+    local prop = ffi.string(name)
+    int_props[prop] = val
+    return 0
+end)
+
+callbacks.get_str = ffi.cast("LipcGetStrCb", function(h, name, val_buf, len_ptr, user_data)
+    if name == nil or val_buf == nil or len_ptr == nil then return 1 end
+    local prop = ffi.string(name)
+    local str_val = str_props[prop] or ""
+    local max_len = tonumber(len_ptr[0])
+    local needed = #str_val + 1
+    if max_len < needed then
+        len_ptr[0] = needed
+        return 10 -- LIPC_ERR_BUF_TOO_SMALL
+    end
+    ffi.copy(val_buf, str_val)
+    return 0
+end)
+
+callbacks.set_str = ffi.cast("LipcSetStrCb", function(h, name, val, user_data)
+    if name == nil then return 1 end
+    local prop = ffi.string(name)
+    if val ~= nil then
+        local s = ffi.string(val)
+        str_props[prop] = s
+        if prop == "setFocus" then
+            str_props["getFocus"] = s
+        end
+    end
+    return 0
+end)
+
+-- Signal handling for graceful shutdown
+local running = true
+callbacks.sig_handler = ffi.cast("sighandler_t", function(signum)
+    running = false
+end)
+
+-- Register signals: SIGTERM(15), SIGINT(2), SIGHUP(1), SIGQUIT(3)
+ffi.C.signal(15, callbacks.sig_handler)
+ffi.C.signal(2, callbacks.sig_handler)
+ffi.C.signal(1, callbacks.sig_handler)
+ffi.C.signal(3, callbacks.sig_handler)
+
+local SERVICE_NAME = "com.lab126.audiomgrd"
+
+local h = liblipc.LipcOpen(SERVICE_NAME)
+if h == nil then
+    io.stderr:write(string.format("[lipc_audio_mock] ERROR: LipcOpen('%s') failed (is stock audiomgrd still running?)\n", SERVICE_NAME))
+    io.stderr:flush()
+    os.exit(1)
+end
+
+-- Register integer properties
+-- Read-only: audioOutputConnected, audioCurrentOutput, isStarted
+-- Read-write: speakerVolume, headphoneVolume
+liblipc.LipcRegisterIntProperty(h, "audioOutputConnected", callbacks.get_int, nil, nil)
+liblipc.LipcRegisterIntProperty(h, "audioCurrentOutput",   callbacks.get_int, nil, nil)
+liblipc.LipcRegisterIntProperty(h, "speakerVolume",        callbacks.get_int, callbacks.set_int, nil)
+liblipc.LipcRegisterIntProperty(h, "headphoneVolume",      callbacks.get_int, callbacks.set_int, nil)
+liblipc.LipcRegisterIntProperty(h, "isStarted",            callbacks.get_int, nil, nil)
+
+-- Register string properties
+-- Write-only: setFocus
+-- Read-only: getFocus
+-- Read-write: logLevel, logMask
+liblipc.LipcRegisterStringProperty(h, "setFocus", nil, callbacks.set_str, nil)
+liblipc.LipcRegisterStringProperty(h, "getFocus", callbacks.get_str, nil, nil)
+liblipc.LipcRegisterStringProperty(h, "logLevel", callbacks.get_str, callbacks.set_str, nil)
+liblipc.LipcRegisterStringProperty(h, "logMask",  callbacks.get_str, callbacks.set_str, nil)
+
+local start_err = liblipc.LipcStartListener(h)
+if start_err ~= 0 then
+    io.stderr:write(string.format("[lipc_audio_mock] ERROR: LipcStartListener failed with code %d\n", start_err))
+    io.stderr:flush()
+    liblipc.LipcClose(h)
+    os.exit(1)
+end
+
+print(string.format("[lipc_audio_mock] Service '%s' successfully registered and listening.", SERVICE_NAME))
+io.stdout:flush()
+
+-- Main loop: sleep until signal received
+while running do
+    ffi.C.sleep(1)
+end
+
+print("[lipc_audio_mock] Termination signal caught, shutting down cleanly...")
+io.stdout:flush()
+
+liblipc.LipcStopListener(h)
+liblipc.LipcClose(h)
+
+print("[lipc_audio_mock] Clean shutdown complete.")
+io.stdout:flush()
+os.exit(0)

--- a/assets/audio-hack/media.sh
+++ b/assets/audio-hack/media.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# ==============================================================================
+# Media control for the daemon's audio path.
+#
+# Pauses whatever is playing, whoever is playing it: the daemon stops draining
+# /tmp/kindle_audio.fifo, the writer blocks and freezes in place, and resuming
+# picks up at the same sample. No cooperation from the playing application.
+#
+# Map a button to this from the button mapper, for example:
+#   [device.headset.buttons]
+#   play_pause = /mnt/us/kindle_hid_passthrough/assets/audio-hack/media.sh toggle
+# ==============================================================================
+
+API="http://127.0.0.1:8321"
+
+usage() {
+    echo "usage: $(basename "$0") {toggle|play|pause|status}" >&2
+    exit 2
+}
+
+[ $# -eq 1 ] || usage
+
+case "$1" in
+    toggle|play|pause) path="/media/$1" ;;
+    status)            path="/status" ;;
+    *)                 usage ;;
+esac
+
+if command -v wget >/dev/null 2>&1; then
+    wget -qO- "$API$path"
+elif command -v curl >/dev/null 2>&1; then
+    curl -s "$API$path"
+else
+    echo "media.sh: neither wget nor curl available" >&2
+    exit 1
+fi

--- a/assets/audio-hack/start_audio_hack.sh
+++ b/assets/audio-hack/start_audio_hack.sh
@@ -27,6 +27,16 @@ log_error() {
     echo "[start_audio_hack] ERROR: $1" >&2
 }
 
+# 0. The mock runs under KOReader's LuaJIT. Check the interpreter before
+#    touching anything: stopping the stock audiomgrd and then failing to
+#    start a replacement leaves the device with no audio at all.
+LUAJIT="/mnt/us/koreader/luajit"
+if [ ! -x "$LUAJIT" ]; then
+    log_error "LuaJIT not found at $LUAJIT (KOReader not installed?)."
+    log_error "Leaving the stock audio daemon running."
+    exit 1
+fi
+
 # 1. Ensure FIFO exists with mode 0666
 if [ ! -p "$FIFO" ]; then
     rm -f "$FIFO" 2>/dev/null || true
@@ -36,9 +46,9 @@ if [ ! -p "$FIFO" ]; then
 fi
 
 # 2. Ensure symlink to luajit exists with name 'audiomgrd'
-if [ ! -L "$SYMLINK_BIN" ] || [ "$(readlink "$SYMLINK_BIN" 2>/dev/null)" != "/mnt/us/koreader/luajit" ]; then
-    log_info "Creating audiomgrd symlink -> /mnt/us/koreader/luajit"
-    ln -sf /mnt/us/koreader/luajit "$SYMLINK_BIN"
+if [ ! -L "$SYMLINK_BIN" ] || [ "$(readlink "$SYMLINK_BIN" 2>/dev/null)" != "$LUAJIT" ]; then
+    log_info "Creating audiomgrd symlink -> $LUAJIT"
+    ln -sf "$LUAJIT" "$SYMLINK_BIN"
 fi
 
 # 3. Check if mock daemon is already running and responsive
@@ -105,5 +115,7 @@ if [ "$READY" -eq 1 ]; then
 else
     log_error "Mock daemon failed to register com.lab126.audiomgrd within timeout."
     cat "$LOG_FILE" >&2 2>/dev/null || true
+    log_warn "Restoring the stock audio daemon."
+    initctl start audiomgrd 2>/dev/null || true
     exit 1
 fi

--- a/assets/audio-hack/start_audio_hack.sh
+++ b/assets/audio-hack/start_audio_hack.sh
@@ -11,7 +11,7 @@ set -e
 
 WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
 MOCK_SCRIPT="$WORK_DIR/lipc_audio_mock.lua"
-SYMLINK_BIN="$WORK_DIR/audiomgrd"
+SYMLINK_BIN="/tmp/audiomgrd"
 FIFO="/tmp/kindle_audio.fifo"
 LOG_FILE="/tmp/audiomgrd_mock.log"
 

--- a/assets/audio-hack/start_audio_hack.sh
+++ b/assets/audio-hack/start_audio_hack.sh
@@ -3,8 +3,9 @@
 # Amazon Kindle Audio Bypass - Service Startup Script
 # Part of the kindle-hid-passthrough audio bypass
 #
-# Ensures audio FIFO exists, stops stock audiomgrd, launches the mock LIPC
-# daemon under the process name 'audiomgrd', and confirms service readiness.
+# Installs the gst-launch wrapper, ensures the audio FIFO exists, stops stock
+# audiomgrd, launches the mock LIPC daemon under the process name 'audiomgrd',
+# and confirms service readiness.
 # ==============================================================================
 
 set -e
@@ -37,7 +38,49 @@ if [ ! -x "$LUAJIT" ]; then
     exit 1
 fi
 
-# 1. Ensure FIFO exists with mode 0666
+# 1. Put the gst-launch wrapper in place. It is what rewrites the pipeline's
+#    sink into the FIFO; without it nothing ever writes there, the reader
+#    drains an empty pipe and the sink receives silence -- which from the
+#    outside is indistinguishable from a working bypass. Do this before
+#    stopping the stock daemon, so a failure here leaves audio untouched.
+WRAPPER="$WORK_DIR/gst-launch-wrapper.sh"
+GST="/usr/bin/gst-launch-0.10"
+GST_REAL="$GST.real"
+
+if [ ! -f "$WRAPPER" ]; then
+    log_error "Wrapper missing at $WRAPPER."
+    log_error "Leaving the stock audio daemon running."
+    exit 1
+fi
+
+/usr/sbin/mntroot rw >/dev/null 2>&1 || true
+# Only wrap a stock binary we could actually set aside: a wrapper with no
+# .real to delegate to makes every gst call exit 127, and overwriting the
+# stock binary without saving it is unrecoverable.
+if [ ! -f "$GST_REAL" ]; then
+    if [ ! -f "$GST" ]; then
+        log_error "No stock gst-launch-0.10 on this firmware."
+        /usr/sbin/mntroot ro >/dev/null 2>&1 || true
+        exit 1
+    fi
+    if ! mv "$GST" "$GST_REAL"; then
+        log_error "Could not set the stock gst-launch-0.10 aside."
+        /usr/sbin/mntroot ro >/dev/null 2>&1 || true
+        exit 1
+    fi
+fi
+# Copied every time, not only when .real is created: this is also the repair
+# path after an update or an uninstall put the stock binary back.
+if cp "$WRAPPER" "$GST" && chmod +x "$GST"; then
+    /usr/sbin/mntroot ro >/dev/null 2>&1 || true
+    log_info "gst-launch wrapper in place (stock kept at $GST_REAL)"
+else
+    /usr/sbin/mntroot ro >/dev/null 2>&1 || true
+    log_error "Could not install the gst-launch wrapper."
+    exit 1
+fi
+
+# 2. Ensure FIFO exists with mode 0666
 if [ ! -p "$FIFO" ]; then
     rm -f "$FIFO" 2>/dev/null || true
     mkfifo -m 666 "$FIFO" 2>/dev/null || mkfifo "$FIFO" 2>/dev/null
@@ -45,13 +88,13 @@ if [ ! -p "$FIFO" ]; then
     log_info "Audio FIFO verified at $FIFO"
 fi
 
-# 2. Ensure symlink to luajit exists with name 'audiomgrd'
+# 3. Ensure symlink to luajit exists with name 'audiomgrd'
 if [ ! -L "$SYMLINK_BIN" ] || [ "$(readlink "$SYMLINK_BIN" 2>/dev/null)" != "$LUAJIT" ]; then
     log_info "Creating audiomgrd symlink -> $LUAJIT"
     ln -sf "$LUAJIT" "$SYMLINK_BIN"
 fi
 
-# 3. Check if mock daemon is already running and responsive
+# 4. Check if mock daemon is already running and responsive
 if pidof audiomgrd >/dev/null 2>&1; then
     for pid in $(pidof audiomgrd); do
         cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ')
@@ -68,7 +111,7 @@ if pidof audiomgrd >/dev/null 2>&1; then
     done
 fi
 
-# 4. Stop stock audiomgrd service
+# 5. Stop stock audiomgrd service
 if initctl status audiomgrd 2>/dev/null | grep -q "start/running"; then
     log_info "Stopping stock audiomgrd via Upstart..."
     initctl stop audiomgrd 2>/dev/null || true
@@ -87,7 +130,7 @@ if pidof audiomgrd >/dev/null 2>&1; then
     sleep 1
 fi
 
-# 5. Launch mock daemon in background under symlinked name with setsid/nohup
+# 6. Launch mock daemon in background under symlinked name with setsid/nohup
 log_info "Launching mock audiomgrd daemon..."
 if [ -x /usr/bin/setsid ]; then
     /usr/bin/setsid "$SYMLINK_BIN" "$MOCK_SCRIPT" >"$LOG_FILE" 2>&1 &
@@ -98,7 +141,7 @@ else
 fi
 MOCK_PID=$!
 
-# 6. Wait and verify that the daemon registered the LIPC service
+# 7. Wait and verify that the daemon registered the LIPC service
 READY=0
 for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
     val=$(lipc-get-prop com.lab126.audiomgrd audioOutputConnected 2>/dev/null || true)

--- a/assets/audio-hack/start_audio_hack.sh
+++ b/assets/audio-hack/start_audio_hack.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# ==============================================================================
+# Amazon Kindle Audio Bypass - Service Startup Script
+# Part of the kindle-hid-passthrough audio bypass
+#
+# Ensures audio FIFO exists, stops stock audiomgrd, launches the mock LIPC
+# daemon under the process name 'audiomgrd', and confirms service readiness.
+# ==============================================================================
+
+set -e
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+MOCK_SCRIPT="$WORK_DIR/lipc_audio_mock.lua"
+SYMLINK_BIN="$WORK_DIR/audiomgrd"
+FIFO="/tmp/kindle_audio.fifo"
+LOG_FILE="/tmp/audiomgrd_mock.log"
+
+log_info() {
+    echo "[start_audio_hack] INFO: $1"
+}
+
+log_warn() {
+    echo "[start_audio_hack] WARN: $1" >&2
+}
+
+log_error() {
+    echo "[start_audio_hack] ERROR: $1" >&2
+}
+
+# 1. Ensure FIFO exists with mode 0666
+if [ ! -p "$FIFO" ]; then
+    rm -f "$FIFO" 2>/dev/null || true
+    mkfifo -m 666 "$FIFO" 2>/dev/null || mkfifo "$FIFO" 2>/dev/null
+    chmod 666 "$FIFO" 2>/dev/null || true
+    log_info "Audio FIFO verified at $FIFO"
+fi
+
+# 2. Ensure symlink to luajit exists with name 'audiomgrd'
+if [ ! -L "$SYMLINK_BIN" ] || [ "$(readlink "$SYMLINK_BIN" 2>/dev/null)" != "/mnt/us/koreader/luajit" ]; then
+    log_info "Creating audiomgrd symlink -> /mnt/us/koreader/luajit"
+    ln -sf /mnt/us/koreader/luajit "$SYMLINK_BIN"
+fi
+
+# 3. Check if mock daemon is already running and responsive
+if pidof audiomgrd >/dev/null 2>&1; then
+    for pid in $(pidof audiomgrd); do
+        cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ')
+        if echo "$cmdline" | grep -q "lipc_audio_mock.lua"; then
+            val=$(lipc-get-prop com.lab126.audiomgrd audioOutputConnected 2>/dev/null || true)
+            if [ "$val" = "1" ]; then
+                log_info "Mock audiomgrd is already running (PID $pid) and responsive."
+                exit 0
+            fi
+            # Stale mock daemon, terminate it
+            log_warn "Mock audiomgrd (PID $pid) is unresponsive. Terminating..."
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    done
+fi
+
+# 4. Stop stock audiomgrd service
+if initctl status audiomgrd 2>/dev/null | grep -q "start/running"; then
+    log_info "Stopping stock audiomgrd via Upstart..."
+    initctl stop audiomgrd 2>/dev/null || true
+    sleep 1
+fi
+
+# Kill any remaining stock audiomgrd processes
+if pidof audiomgrd >/dev/null 2>&1; then
+    for pid in $(pidof audiomgrd); do
+        cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ')
+        if echo "$cmdline" | grep -qv "lipc_audio_mock.lua"; then
+            log_info "Terminating dangling stock audiomgrd (PID $pid)..."
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    done
+    sleep 1
+fi
+
+# 5. Launch mock daemon in background under symlinked name with setsid/nohup
+log_info "Launching mock audiomgrd daemon..."
+if [ -x /usr/bin/setsid ]; then
+    /usr/bin/setsid "$SYMLINK_BIN" "$MOCK_SCRIPT" >"$LOG_FILE" 2>&1 &
+elif [ -x /usr/bin/nohup ]; then
+    /usr/bin/nohup "$SYMLINK_BIN" "$MOCK_SCRIPT" >"$LOG_FILE" 2>&1 &
+else
+    "$SYMLINK_BIN" "$MOCK_SCRIPT" >"$LOG_FILE" 2>&1 &
+fi
+MOCK_PID=$!
+
+# 6. Wait and verify that the daemon registered the LIPC service
+READY=0
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    val=$(lipc-get-prop com.lab126.audiomgrd audioOutputConnected 2>/dev/null || true)
+    if [ "$val" = "1" ]; then
+        READY=1
+        break
+    fi
+    usleep 200000 2>/dev/null || sleep 1
+done
+
+if [ "$READY" -eq 1 ]; then
+    log_info "Audio hack daemon started successfully (audioOutputConnected=1)."
+    exit 0
+else
+    log_error "Mock daemon failed to register com.lab126.audiomgrd within timeout."
+    cat "$LOG_FILE" >&2 2>/dev/null || true
+    exit 1
+fi

--- a/assets/audio-hack/stop_audio_hack.sh
+++ b/assets/audio-hack/stop_audio_hack.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# ==============================================================================
+# Amazon Kindle Audio Bypass - Service Teardown Script
+# Part of the kindle-hid-passthrough audio bypass
+#
+# Terminates the mock LIPC daemon and restores the stock audiomgrd service.
+# ==============================================================================
+
+set -e
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+log_info() {
+    echo "[stop_audio_hack] INFO: $1"
+}
+
+log_warn() {
+    echo "[stop_audio_hack] WARN: $1" >&2
+}
+
+log_error() {
+    echo "[stop_audio_hack] ERROR: $1" >&2
+}
+
+main() {
+    log_info "Stopping Kindle Audio Bypass services..."
+
+    # Step 1: Find and terminate mock daemon
+    if pidof audiomgrd >/dev/null 2>&1; then
+        for pid in $(pidof audiomgrd); do
+            cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ')
+            if echo "$cmdline" | grep -q "lipc_audio_mock.lua"; then
+                log_info "Sending SIGTERM to mock daemon (PID $pid)..."
+                kill -TERM "$pid" 2>/dev/null || true
+            fi
+        done
+        sleep 1
+
+        # Check if mock daemon is still alive and force kill
+        for pid in $(pidof audiomgrd 2>/dev/null || true); do
+            cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ')
+            if echo "$cmdline" | grep -q "lipc_audio_mock.lua"; then
+                log_info "Force killing mock daemon (PID $pid)..."
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        done
+    fi
+
+    # Step 2: Restart stock audiomgrd
+    log_info "Starting stock audiomgrd via Upstart..."
+    initctl start audiomgrd 2>/dev/null || true
+    sleep 1
+
+    # Step 3: Verify stock audiomgrd status
+    RUNNING=0
+    for i in 1 2 3 4 5; do
+        if initctl status audiomgrd 2>/dev/null | grep -q "start/running"; then
+            RUNNING=1
+            break
+        fi
+        sleep 1
+    done
+
+    if [ "$RUNNING" -eq 1 ]; then
+        log_info "Stock audiomgrd successfully restored."
+        return 0
+    else
+        log_warn "Stock audiomgrd did not report start/running state."
+        return 1
+    fi
+}
+
+main "$@"

--- a/assets/audio-hack/stop_audio_hack.sh
+++ b/assets/audio-hack/stop_audio_hack.sh
@@ -3,7 +3,8 @@
 # Amazon Kindle Audio Bypass - Service Teardown Script
 # Part of the kindle-hid-passthrough audio bypass
 #
-# Terminates the mock LIPC daemon and restores the stock audiomgrd service.
+# Terminates the mock LIPC daemon and restores the stock gst-launch binary
+# and audiomgrd service.
 # ==============================================================================
 
 set -e
@@ -46,12 +47,25 @@ main() {
         done
     fi
 
-    # Step 2: Restart stock audiomgrd
+    # Step 2: Restore the stock gst-launch. The wrapper rewrites any
+    # mixersink pipeline into the FIFO whether or not anything is draining
+    # it, so leaving it behind once the reader is gone makes the next
+    # playback block on the FIFO instead of playing.
+    GST="/usr/bin/gst-launch-0.10"
+    GST_REAL="$GST.real"
+    if [ -f "$GST_REAL" ]; then
+        log_info "Restoring the stock gst-launch-0.10..."
+        /usr/sbin/mntroot rw >/dev/null 2>&1 || true
+        mv -f "$GST_REAL" "$GST" || log_warn "Could not restore $GST."
+        /usr/sbin/mntroot ro >/dev/null 2>&1 || true
+    fi
+
+    # Step 3: Restart stock audiomgrd
     log_info "Starting stock audiomgrd via Upstart..."
     initctl start audiomgrd 2>/dev/null || true
     sleep 1
 
-    # Step 3: Verify stock audiomgrd status
+    # Step 4: Verify stock audiomgrd status
     RUNNING=0
     for i in 1 2 3 4 5; do
         if initctl status audiomgrd 2>/dev/null | grep -q "start/running"; then

--- a/assets/audio-hack/uninstall.sh
+++ b/assets/audio-hack/uninstall.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# ==============================================================================
+# Amazon Kindle Audio Bypass - Uninstallation Script
+# Part of the kindle-hid-passthrough audio bypass
+#
+# Restores genuine /usr/bin/gst-launch-0.10 binary, stops mock LIPC daemon,
+# cleans up Upstart pre-start persistence hooks, and restores rootfs to read-only.
+# ==============================================================================
+
+set -e
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="/usr/bin/gst-launch-0.10"
+TARGET_REAL="/usr/bin/gst-launch-0.10.real"
+BACKUP_DIR="$WORK_DIR/backup"
+BACKUP_COPY="$BACKUP_DIR/gst-launch-0.10.orig"
+UPSTART_CONF="/etc/upstart/hid-passthrough.conf"
+UPSTART_ASSET="/mnt/us/kindle_hid_passthrough/assets/hid-passthrough.upstart"
+
+# Logging helpers
+log_info() {
+    echo "[uninstall.sh] INFO: $1"
+}
+
+log_warn() {
+    echo "[uninstall.sh] WARN: $1" >&2
+}
+
+log_error() {
+    echo "[uninstall.sh] ERROR: $1" >&2
+}
+
+# Root filesystem remount helpers
+remount_rw() {
+    if [ -x /usr/sbin/mntroot ]; then
+        /usr/sbin/mntroot rw >/dev/null 2>&1 || mount -o remount,rw /
+    else
+        mount -o remount,rw /
+    fi
+}
+
+remount_ro() {
+    sync
+    if [ -x /usr/sbin/mntroot ]; then
+        /usr/sbin/mntroot ro >/dev/null 2>&1 || mount -o remount,ro /
+    else
+        mount -o remount,ro /
+    fi
+}
+
+# Trap to guarantee rootfs is never left rw on exit, error, or interrupt
+trap 'remount_ro' EXIT INT TERM HUP
+
+remove_upstart_hook() {
+    conf="$1"
+    [ -f "$conf" ] || return 0
+    if ! grep -q "start_audio_hack.sh" "$conf"; then
+        log_info "No Upstart hook found in $conf."
+        return 0
+    fi
+    log_info "Removing start_audio_hack.sh hook from $conf..."
+    if [ -x /mnt/us/python3/usr/bin/python3.11 ]; then
+        /mnt/us/python3/usr/bin/python3.11 - "$conf" << 'PYEOF'
+import sys
+conf_path = sys.argv[1]
+with open(conf_path, 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+for line in lines:
+    if "start_audio_hack.sh" in line or "Auto-start Kindle audio bypass hack" in line:
+        continue
+    new_lines.append(line)
+
+with open(conf_path, 'w') as f:
+    f.writelines(new_lines)
+PYEOF
+    else
+        sed -i '/start_audio_hack\.sh/d' "$conf"
+        sed -i '/Auto-start Kindle audio bypass hack/d' "$conf"
+    fi
+}
+
+main() {
+    log_info "Starting Kindle GStreamer Audio Bypass Uninstallation..."
+
+    # Pre-flight check: Root privileges
+    if [ "$(id -u)" -ne 0 ]; then
+        log_error "Must run as root."
+        exit 1
+    fi
+
+    # Step 1: Stop mock daemon if running
+    if [ -x "$WORK_DIR/stop_audio_hack.sh" ]; then
+        log_info "Stopping audio hack services via stop_audio_hack.sh..."
+        "$WORK_DIR/stop_audio_hack.sh" || true
+    else
+        log_info "Stopping any running mock daemon processes..."
+        if pidof audiomgrd >/dev/null 2>&1; then
+            for pid in $(pidof audiomgrd); do
+                cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr '\0' ' ')
+                if echo "$cmdline" | grep -q "lipc_audio_mock.lua"; then
+                    log_info "Terminating mock daemon PID $pid..."
+                    kill -TERM "$pid" 2>/dev/null || true
+                fi
+            done
+        fi
+        # Start stock audiomgrd if not running
+        if ! initctl status audiomgrd 2>/dev/null | grep -q "start/running"; then
+            log_info "Starting stock audiomgrd..."
+            initctl start audiomgrd 2>/dev/null || true
+        fi
+    fi
+
+    # Step 2: Remount rootfs as RW to restore genuine binary and Upstart config
+    log_info "Remounting root filesystem read-write..."
+    remount_rw
+
+    # Step 3: Restore genuine binary
+    if [ -f "$TARGET_REAL" ]; then
+        log_info "Restoring genuine binary $TARGET_REAL -> $TARGET..."
+        mv -f "$TARGET_REAL" "$TARGET"
+        chmod 0755 "$TARGET"
+        chown root:root "$TARGET" 2>/dev/null || true
+    elif [ -f "$BACKUP_COPY" ]; then
+        log_info "Restoring genuine binary from backup $BACKUP_COPY -> $TARGET..."
+        cp -f "$BACKUP_COPY" "$TARGET"
+        chmod 0755 "$TARGET"
+        chown root:root "$TARGET" 2>/dev/null || true
+    else
+        if [ -f "$TARGET" ] && head -c 4 "$TARGET" | grep -q 'ELF'; then
+            log_info "$TARGET is already the genuine ELF binary. No restore needed."
+        else
+            log_error "No genuine backup binary found at $TARGET_REAL or $BACKUP_COPY."
+            exit 1
+        fi
+    fi
+
+    sync
+
+    # Step 4: Remove Upstart pre-start hooks
+    remove_upstart_hook "$UPSTART_CONF"
+    remove_upstart_hook "$UPSTART_ASSET"
+
+    # Reload Upstart configuration
+    /sbin/initctl reload-configuration 2>/dev/null || true
+
+    # Step 5: Verification of restored binary
+    if [ ! -p "$TARGET" ] && [ ! -x "$TARGET" ]; then
+        log_error "Restoration verification failed: $TARGET is not executable."
+        exit 1
+    fi
+
+    VERSION_OUT=$("$TARGET" --version 2>&1 || true)
+    if echo "$VERSION_OUT" | grep -q "gst-launch-0.10"; then
+        log_info "Restored GStreamer binary verified: $VERSION_OUT"
+    else
+        log_warn "Restored binary --version returned unexpected output: $VERSION_OUT"
+    fi
+
+    # Step 6: Verify stock audiomgrd status
+    if initctl status audiomgrd 2>/dev/null | grep -q "start/running"; then
+        log_info "Stock audiomgrd is running."
+    else
+        log_warn "Stock audiomgrd is not running; attempting to start..."
+        initctl start audiomgrd 2>/dev/null || true
+    fi
+
+    log_info "Uninstallation completed successfully."
+    return 0
+}
+
+main "$@"

--- a/assets/hid-passthrough.upstart
+++ b/assets/hid-passthrough.upstart
@@ -27,3 +27,10 @@ end script
 script
     exec /mnt/us/kindle_hid_passthrough/kindle-hid-passthrough --daemon >>/var/log/hid_passthrough.log 2>&1
 end script
+
+post-stop script
+    # Safety net: the controller already ties the audio LIPC mock to the HID
+    # on/off state, this covers a hard service stop or shutdown.
+    # Bracketed pattern so pkill never matches the shell running this block.
+    pkill -f 'lipc_audio_moc[k].lua' 2>/dev/null || true
+end script

--- a/justfile
+++ b/justfile
@@ -23,6 +23,7 @@ deploy:
     @echo "Remounting filesystems as writable..."
     ssh {{host}} "/usr/sbin/mntroot rw && mount -o remount,rw /mnt/base-us"
     @echo "Copying all files via tar pipe..."
+    # libsbc.so.1 is not in the repo, so it is globbed away when absent.
     (cd {{src_dir}} && tar cf - \
         --transform='s|^kindle_hid_passthrough/hid-passthrough-dev.upstart|etc/upstart/hid-passthrough.conf|' \
         --transform='s|^kindle_hid_passthrough/|mnt/us/kindle_hid_passthrough/|' \
@@ -33,7 +34,7 @@ deploy:
         --transform='s|^illusion/BTManager.sh|mnt/us/kindle_hid_passthrough/illusion/BTManager.sh|' \
         kindle_hid_passthrough/*.py \
         kindle_hid_passthrough/config.ini \
-        kindle_hid_passthrough/libsbc.so.1 \
+        $(ls kindle_hid_passthrough/libsbc.so.1 2>/dev/null) \
         kindle_hid_passthrough/BUILD_SHA \
         kindle_hid_passthrough/hid-passthrough-dev.upstart \
         kindle_hid_passthrough/modules/*.ko \

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ deploy:
         --transform='s|^illusion/BTManager.sh|mnt/us/kindle_hid_passthrough/illusion/BTManager.sh|' \
         kindle_hid_passthrough/*.py \
         kindle_hid_passthrough/config.ini \
+        kindle_hid_passthrough/libsbc.so.1 \
         kindle_hid_passthrough/BUILD_SHA \
         kindle_hid_passthrough/hid-passthrough-dev.upstart \
         kindle_hid_passthrough/modules/*.ko \

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -214,7 +214,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._send_json({"ok": False, "error": "No address provided"})
             return
 
-        protocol = Protocol.CLASSIC if protocol_str == 'classic' else Protocol.BLE
+        try:
+            protocol = Protocol(protocol_str or 'ble')
+        except ValueError:
+            protocol = Protocol.CLASSIC if protocol_str == 'classic' else Protocol.BLE
 
         if controller.is_pairing:
             self._send_json({"ok": True, "message": "Pairing already in progress"})

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -325,33 +325,30 @@ class RequestHandler(BaseHTTPRequestHandler):
         except OSError as e:
             self._send_json({"ok": False, "error": str(e)})
 
+    def _audio_streamer(self):
+        """The live session's audio streamer, None when nothing is playing.
+
+        host is None while the daemon is suspended, and _audio_session only
+        exists once AVDTP is streaming.
+        """
+        host = self._controller.daemon.host
+        session = getattr(host, '_audio_session', None) if host else None
+        return session[1] if session else None
+
+    def _handle_media(self, action):
+        streamer = self._audio_streamer()
+        if streamer is None:
+            self._send_json({"ok": False, "error": "No active audio session"})
+            return
+        getattr(streamer, action)()
+        self._send_json({"ok": True, "paused": streamer.paused})
+
     def _handle_media_toggle(self):
-        controller = self._controller
-        if hasattr(controller, 'daemon') and hasattr(controller.daemon, 'host') and hasattr(controller.daemon.host, '_audio_session') and controller.daemon.host._audio_session:
-            audio_streamer = controller.daemon.host._audio_session[1]
-            if audio_streamer:
-                audio_streamer.toggle_pause()
-                self._send_json({"ok": True, "paused": audio_streamer.paused})
-                return
-        self._send_json({"ok": False, "error": "No active audio session"})
+        self._handle_media('toggle_pause')
 
     def _handle_media_play(self):
-        controller = self._controller
-        if hasattr(controller, 'daemon') and hasattr(controller.daemon, 'host') and hasattr(controller.daemon.host, '_audio_session') and controller.daemon.host._audio_session:
-            audio_streamer = controller.daemon.host._audio_session[1]
-            if audio_streamer:
-                audio_streamer.play()
-                self._send_json({"ok": True, "paused": False})
-                return
-        self._send_json({"ok": False, "error": "No active audio session"})
+        self._handle_media('play')
 
     def _handle_media_pause(self):
-        controller = self._controller
-        if hasattr(controller, 'daemon') and hasattr(controller.daemon, 'host') and hasattr(controller.daemon.host, '_audio_session') and controller.daemon.host._audio_session:
-            audio_streamer = controller.daemon.host._audio_session[1]
-            if audio_streamer:
-                audio_streamer.pause()
-                self._send_json({"ok": True, "paused": True})
-                return
-        self._send_json({"ok": False, "error": "No active audio session"})
+        self._handle_media('pause')
 

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -96,6 +96,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_clear_cache()
             case '/autostart':
                 self._handle_autostart(param('enable'))
+            case '/audio':
+                self._handle_audio(param('enable'))
             case '/scan':
                 self._handle_scan()
             case '/scan-status':
@@ -154,6 +156,17 @@ class RequestHandler(BaseHTTPRequestHandler):
         else:
             err = (result.stderr or result.stdout or 'failed').strip()
             self._send_json({"ok": False, "enabled": enabled, "error": err[-200:]})
+
+    def _handle_audio(self, enable):
+        """Read or set the audio bypass. Separate from HID on purpose: it
+        replaces the stock audio daemon, so a device it does not work on can
+        run the HID host with its own audio left alone."""
+        controller = self._controller
+        if enable is None:
+            self._send_json({"ok": True, "enabled": controller.audio_enabled})
+            return
+        controller.audio_enabled = enable not in ('0', 'false', 'off')
+        self._send_json({"ok": True, "enabled": controller.audio_enabled})
 
     def _handle_start(self):
         controller = self._controller

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -163,7 +163,10 @@ class RequestHandler(BaseHTTPRequestHandler):
         run the HID host with its own audio left alone."""
         controller = self._controller
         if enable is None:
-            self._send_json({"ok": True, "enabled": controller.audio_enabled})
+            # running is what is actually up, enabled is what was asked for.
+            self._send_json({"ok": True,
+                             "enabled": controller.audio_enabled,
+                             "running": controller._audio_mock_running()})
             return
         controller.audio_enabled = enable not in ('0', 'false', 'off')
         self._send_json({"ok": True, "enabled": controller.audio_enabled})

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -166,7 +166,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             # running is what is actually up, enabled is what was asked for.
             self._send_json({"ok": True,
                              "enabled": controller.audio_enabled,
-                             "running": controller._audio_mock_running()})
+                             "running": controller.audio_running})
             return
         controller.audio_enabled = enable not in ('0', 'false', 'off')
         self._send_json({"ok": True, "enabled": controller.audio_enabled})

--- a/kindle_hid_passthrough/api_server.py
+++ b/kindle_hid_passthrough/api_server.py
@@ -112,6 +112,12 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self._handle_discoverable(param('duration'))
             case '/logs':
                 self._handle_logs(param('lines'))
+            case '/media/toggle':
+                self._handle_media_toggle()
+            case '/media/play':
+                self._handle_media_play()
+            case '/media/pause':
+                self._handle_media_pause()
             case _:
                 self._send_json({"ok": False, "error": "Not found"})
 
@@ -305,4 +311,34 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._send_json({"ok": True, "lines": short})
         except OSError as e:
             self._send_json({"ok": False, "error": str(e)})
+
+    def _handle_media_toggle(self):
+        controller = self._controller
+        if hasattr(controller, 'daemon') and hasattr(controller.daemon, 'host') and hasattr(controller.daemon.host, '_audio_session') and controller.daemon.host._audio_session:
+            audio_streamer = controller.daemon.host._audio_session[1]
+            if audio_streamer:
+                audio_streamer.toggle_pause()
+                self._send_json({"ok": True, "paused": audio_streamer.paused})
+                return
+        self._send_json({"ok": False, "error": "No active audio session"})
+
+    def _handle_media_play(self):
+        controller = self._controller
+        if hasattr(controller, 'daemon') and hasattr(controller.daemon, 'host') and hasattr(controller.daemon.host, '_audio_session') and controller.daemon.host._audio_session:
+            audio_streamer = controller.daemon.host._audio_session[1]
+            if audio_streamer:
+                audio_streamer.play()
+                self._send_json({"ok": True, "paused": False})
+                return
+        self._send_json({"ok": False, "error": "No active audio session"})
+
+    def _handle_media_pause(self):
+        controller = self._controller
+        if hasattr(controller, 'daemon') and hasattr(controller.daemon, 'host') and hasattr(controller.daemon.host, '_audio_session') and controller.daemon.host._audio_session:
+            audio_streamer = controller.daemon.host._audio_session[1]
+            if audio_streamer:
+                audio_streamer.pause()
+                self._send_json({"ok": True, "paused": True})
+                return
+        self._send_json({"ok": False, "error": "No active audio session"})
 

--- a/kindle_hid_passthrough/audio_pipe.py
+++ b/kindle_hid_passthrough/audio_pipe.py
@@ -11,9 +11,10 @@ import ctypes
 import fcntl
 import logging
 import os
+import threading
 from collections import deque
 
-log = logging.getLogger("kindle-hid-passthrough")
+log = logging.getLogger(__name__)
 
 SBC_BITPOOL_DEFAULT = 35
 PCM_BYTES_PER_SAMPLE = 4
@@ -31,6 +32,14 @@ READ_CHUNK_MAX = 8192
 F_SETPIPE_SZ = 1031
 FIFO_PIPE_SIZE = 16384
 
+# Shared with assets/audio-hack/gst-launch-wrapper.sh, which writes to the FIFO
+# and publishes the caps it saw to the sidecar. Keep the two in step.
+MIN_INPUT_RATE = 4000
+MAX_INPUT_RATE = 192000
+
+FIFO_PATH = "/tmp/kindle_audio.fifo"
+FMT_PATH = "/tmp/kindle_audio.fmt"
+
 
 class AudioResampler:
     """Dynamic PCM Resampler supporting 16kHz, 22.05kHz, 44.1kHz, 48kHz mono/stereo
@@ -43,7 +52,7 @@ class AudioResampler:
         in_channels: int = 1,
         out_rate: int = 44100,
         out_channels: int = 2,
-        fmt_path: str = "/tmp/kindle_audio.fmt",
+        fmt_path: str = FMT_PATH,
     ):
         self.in_rate = in_rate
         self.in_channels = in_channels
@@ -55,36 +64,60 @@ class AudioResampler:
         self._fmt_mtime = 0
 
     def check_format_update(self):
-        """Check if format specification file was updated and apply new parameters."""
+        """Adopt the format the wrapper published, if it published a new one.
+
+        A rewritten sidecar means a new pipeline, which is the only stream
+        boundary visible from here: the FIFO is held open read-write, so a
+        writer going away never surfaces as end-of-file. Treat it as one and
+        drop the carried state, or a partial sample left by a pipeline that
+        was killed mid-write shifts every following sample by a byte.
+        """
         try:
             st = os.stat(self.fmt_path)
-            if st.st_mtime != self._fmt_mtime:
-                self._fmt_mtime = st.st_mtime
-                with open(self.fmt_path, "r") as f:
-                    content = f.read()
-                new_rate = None
-                new_channels = None
-                for token in content.split():
-                    if token.startswith("rate="):
-                        new_rate = int(token.split("=")[1])
-                    elif token.startswith("channels="):
-                        new_channels = int(token.split("=")[1])
-                self.set_format(new_rate, new_channels)
-        except Exception:
-            pass
+        except OSError:
+            return  # No sidecar yet; keep the format we are already using.
+        if st.st_mtime == self._fmt_mtime:
+            return
+
+        try:
+            with open(self.fmt_path, "r") as f:
+                content = f.read()
+            new_rate = None
+            new_channels = None
+            for token in content.split():
+                if token.startswith("rate="):
+                    new_rate = int(token.split("=")[1])
+                elif token.startswith("channels="):
+                    new_channels = int(token.split("=")[1])
+        except (OSError, ValueError) as e:
+            # Leave _fmt_mtime alone so a readable rewrite is picked up later.
+            log.warning(f"[AudioResampler] Ignoring unreadable {self.fmt_path}: {e}")
+            return
+
+        self._fmt_mtime = st.st_mtime
+        self.new_stream()
+        self.set_format(new_rate, new_channels)
+
+    def new_stream(self):
+        """Forget state carried from the previous writer."""
+        self._rate_state = None
+        self._odd_byte = b""
 
     def set_format(self, in_rate: int = None, in_channels: int = None):
         """Update input audio sample rate and channel configuration."""
         changed = False
-        if in_rate and in_rate > 0 and in_rate != self.in_rate:
+        if in_rate and MIN_INPUT_RATE <= in_rate <= MAX_INPUT_RATE and in_rate != self.in_rate:
             self.in_rate = in_rate
             changed = True
+        elif in_rate and not (MIN_INPUT_RATE <= in_rate <= MAX_INPUT_RATE):
+            # A rate outside audio range is a parse artefact, not a stream.
+            # Resampling from it allocates in proportion to in_rate/out_rate.
+            log.warning(f"[AudioResampler] Ignoring out-of-range rate {in_rate}Hz")
         if in_channels and in_channels in (1, 2) and in_channels != self.in_channels:
             self.in_channels = in_channels
             changed = True
         if changed:
-            self._rate_state = None
-            self._odd_byte = b""
+            self.new_stream()
             log.info(
                 f"[AudioResampler] Format set: {self.in_rate}Hz {self.in_channels}ch -> "
                 f"{self.out_rate}Hz {self.out_channels}ch"
@@ -237,10 +270,17 @@ class SbcEncoder:
         return None
 
     def close(self):
+        # sbc_finish frees the private state, so the encoder must be marked
+        # unusable in the same breath: a later encode_frame would dereference
+        # a freed pointer inside libsbc and take the process with it. close()
+        # is reached twice on teardown (explicitly, then from the generator's
+        # finally at GC), so it has to be idempotent.
         if self._available and self._sbc_lib:
+            self._available = False
             try:
                 self._sbc_lib.sbc_finish(self._sbc_struct)
             except Exception:
+                # Teardown only; a failure here has nothing left to affect.
                 pass
 
 
@@ -253,7 +293,7 @@ class FifoAudioStreamer:
     to the FIFO writer when full.
     """
 
-    def __init__(self, fifo_path: str = "/tmp/kindle_audio.fifo"):
+    def __init__(self, fifo_path: str = FIFO_PATH):
         self.fifo_path = fifo_path
         self.fifo_fd = None
         self._chunks = deque()
@@ -261,18 +301,27 @@ class FifoAudioStreamer:
         self.resampler = AudioResampler()
         self.encoder = SbcEncoder()
 
+        # An encoder that initialised but cannot produce a frame is unusable:
+        # without a silence frame there is nothing to substitute when a later
+        # encode fails, and joining None into the payload would kill the pump.
         self.silence_sbc_frame = self.encoder.encode_frame(b"\x00" * PCM_FRAME_SIZE)
         if self.silence_sbc_frame:
             self.silence_rtp_payload = (
                 bytes([FRAMES_PER_PACKET]) + self.silence_sbc_frame * FRAMES_PER_PACKET
             )
         else:
+            log.warning("[Audio] encoder produced no silence frame; streaming silence only")
+            self.encoder.close()
             self.silence_rtp_payload = bytes([0])
         self._ensure_fifo()
         self.paused = False
+        # toggle_pause is called from the API server's thread while the pump
+        # reads self.paused on the event loop; the read-modify-write needs it.
+        self._pause_lock = threading.Lock()
 
     def toggle_pause(self):
-        self.paused = not self.paused
+        with self._pause_lock:
+            self.paused = not self.paused
 
     def play(self):
         self.paused = False
@@ -286,18 +335,23 @@ class FifoAudioStreamer:
         try:
             if not os.path.exists(self.fifo_path):
                 os.mkfifo(self.fifo_path, 0o666)
-        except Exception:
+        except OSError:
+            # Someone else may have created it between the check and the call.
+            # If it is really unusable the open below reports it.
             pass
 
         try:
             self.fifo_fd = os.open(self.fifo_path, os.O_RDWR | os.O_NONBLOCK)
-        except Exception:
+        except OSError as e:
+            log.warning(f"[Audio] cannot open {self.fifo_path}: {e}")
             self.fifo_fd = None
             return
 
         try:
             fcntl.fcntl(self.fifo_fd, F_SETPIPE_SZ, FIFO_PIPE_SIZE)
-        except Exception:
+        except OSError:
+            # Tuning, not a requirement: the default pipe size still works,
+            # it just holds less before the writer blocks.
             pass
 
     # ---------- buffer O(1) ----------
@@ -357,6 +411,11 @@ class FifoAudioStreamer:
             resampled = self.resampler.resample_chunk(chunk)
             if resampled:
                 self._push(resampled)
+            elif chunk:
+                # Nothing came back from a non-empty read: the format is wrong
+                # or the resampler is failing. Looping would drain the whole
+                # FIFO into the void, one warning per iteration.
+                break
             if len(chunk) < want:
                 break
 
@@ -366,7 +425,8 @@ class FifoAudioStreamer:
 
         self.read_pcm_available()
 
-        if self._avail >= PCM_PACKET_SIZE and self.encoder.is_available:
+        if (self._avail >= PCM_PACKET_SIZE and self.encoder.is_available
+                and self.silence_sbc_frame):
             raw_packet_pcm = self._pull(PCM_PACKET_SIZE)
             sbc_frames = []
             for i in range(FRAMES_PER_PACKET):
@@ -381,7 +441,8 @@ class FifoAudioStreamer:
         if self.fifo_fd is not None:
             try:
                 os.close(self.fifo_fd)
-            except Exception:
+            except OSError:
+                # Closing an already-dead fd is not worth reporting.
                 pass
             self.fifo_fd = None
         self._chunks.clear()

--- a/kindle_hid_passthrough/audio_pipe.py
+++ b/kindle_hid_passthrough/audio_pipe.py
@@ -1,0 +1,162 @@
+import os
+import errno
+import ctypes
+import ctypes.util
+import logging
+
+log = logging.getLogger("kindle-hid-passthrough")
+
+SBC_BITPOOL_DEFAULT = 53
+PCM_BYTES_PER_SAMPLE = 4
+SAMPLES_PER_FRAME = 16 * 8
+FRAMES_PER_PACKET = 5
+PCM_FRAME_SIZE = SAMPLES_PER_FRAME * PCM_BYTES_PER_SAMPLE
+PCM_PACKET_SIZE = PCM_FRAME_SIZE * FRAMES_PER_PACKET
+
+class SbcStruct(__import__('ctypes').Structure):
+    _fields_ = [
+        ("flags", __import__('ctypes').c_ulong),
+        ("frequency", __import__('ctypes').c_uint8),
+        ("blocks", __import__('ctypes').c_uint8),
+        ("subbands", __import__('ctypes').c_uint8),
+        ("mode", __import__('ctypes').c_uint8),
+        ("allocation", __import__('ctypes').c_uint8),
+        ("bitpool", __import__('ctypes').c_uint8),
+        ("endian", __import__('ctypes').c_uint8),
+    ]
+
+class SbcEncoder:
+    def __init__(self, bitpool: int = SBC_BITPOOL_DEFAULT):
+        self.bitpool = bitpool
+        self._sbc_lib = None
+        self._sbc_struct = None
+        self._available = False
+        self._init_libsbc()
+
+    def _init_libsbc(self):
+        try:
+            lib_name = os.path.join(os.path.dirname(__file__), "libsbc.so.1")
+            if not os.path.exists(lib_name):
+                lib_name = "/mnt/us/kindle_hid_passthrough/libsbc.so.1"
+            
+            self._sbc_lib = ctypes.CDLL(lib_name)
+            self._sbc_struct = ctypes.create_string_buffer(1024)
+            self._sbc_lib.sbc_init.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+            self._sbc_lib.sbc_init.restype = ctypes.c_int
+            
+            self._sbc_lib.sbc_encode.argtypes = [
+                ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+                ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_ssize_t)
+            ]
+            self._sbc_lib.sbc_encode.restype = ctypes.c_ssize_t
+            
+            ret = self._sbc_lib.sbc_init(self._sbc_struct, 0)
+            if ret == 0:
+                # FIX A2DP MISMATCH (Synthesizer voice)
+                sbc_cfg = ctypes.cast(self._sbc_struct, ctypes.POINTER(SbcStruct)).contents
+                sbc_cfg.frequency = 0x02 # 44100
+                sbc_cfg.blocks = 0x03 # 16 blocks
+                sbc_cfg.subbands = 0x01 # 8 subbands
+                sbc_cfg.mode = 0x03 # JOINT_STEREO (default was STEREO 0x02, causing metal synth)
+                sbc_cfg.allocation = 0x00 # LOUDNESS
+                sbc_cfg.bitpool = self.bitpool # 53
+                self._available = True
+                log.info("[Audio] libsbc carregada com sucesso!")
+        except Exception as e:
+            log.warning(f"[Audio] libsbc não encontrada ({e}). Fallback de silêncio será usado.")
+            self._available = False
+
+    @property
+    def is_available(self) -> bool:
+        return self._available
+
+    def encode_frame(self, pcm_chunk: bytes) -> bytes:
+        if not self._available or len(pcm_chunk) < PCM_FRAME_SIZE:
+            return None
+        out_buf = ctypes.create_string_buffer(256)
+        written = ctypes.c_ssize_t(0)
+        res = self._sbc_lib.sbc_encode(
+            self._sbc_struct, pcm_chunk, PCM_FRAME_SIZE, out_buf, 256, ctypes.byref(written)
+        )
+        if res > 0 and written.value > 0:
+            return out_buf.raw[:written.value]
+        return None
+
+    def close(self):
+        if self._available and self._sbc_lib:
+            try:
+                self._sbc_lib.sbc_finish(self._sbc_struct)
+            except Exception:
+                pass
+
+class FifoAudioStreamer:
+    def __init__(self, fifo_path: str = "/tmp/kindle_audio.fifo"):
+        self.fifo_path = fifo_path
+        self.fifo_fd = None
+        self.pcm_buffer = bytearray()
+        self.encoder = SbcEncoder()
+        
+        self.silence_sbc_frame = bytes([0x9C, 0xBD, 0x35, 0x00]) + bytes(115)
+        self.silence_rtp_payload = bytes([FRAMES_PER_PACKET]) + (self.silence_sbc_frame * FRAMES_PER_PACKET)
+        self._ensure_fifo()
+
+    def _ensure_fifo(self):
+        try:
+            if not os.path.exists(self.fifo_path):
+                os.mkfifo(self.fifo_path, 0o666)
+        except Exception as e:
+            log.error(f"[Audio] Erro ao criar FIFO {self.fifo_path}: {e}")
+
+        try:
+            self.fifo_fd = os.open(self.fifo_path, os.O_RDWR | os.O_NONBLOCK)
+            log.info(f"[Audio] FIFO {self.fifo_path} aberta (FD={self.fifo_fd})")
+        except Exception as e:
+            log.error(f"[Audio] Falha ao abrir FIFO: {e}")
+
+    def read_pcm_available(self):
+        if self.fifo_fd is None:
+            return
+        
+        try:
+            while True:
+                chunk = os.read(self.fifo_fd, 8192)
+                if not chunk:
+                    break
+                self.pcm_buffer.extend(chunk)
+                
+                # Controle de latência e lag (máximo de 3 pacotes, ~43ms em buffer)
+                if len(self.pcm_buffer) > PCM_PACKET_SIZE * 3:
+                    pass # del self.pcm_buffer[:-PCM_PACKET_SIZE * 3]
+        except (BlockingIOError, InterruptedError):
+            pass
+        except OSError as e:
+            if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                log.warning(f"[Audio] Erro lendo FIFO: {e}")
+
+    def get_next_payload(self) -> bytes:
+        self.read_pcm_available()
+        
+        if len(self.pcm_buffer) >= PCM_PACKET_SIZE and self.encoder.is_available:
+            raw_packet_pcm = bytes(self.pcm_buffer[:PCM_PACKET_SIZE])
+            del self.pcm_buffer[:PCM_PACKET_SIZE]
+            
+            sbc_frames = []
+            for i in range(FRAMES_PER_PACKET):
+                pcm_chunk = raw_packet_pcm[i * PCM_FRAME_SIZE : (i + 1) * PCM_FRAME_SIZE]
+                encoded = self.encoder.encode_frame(pcm_chunk)
+                if encoded:
+                    sbc_frames.append(encoded)
+                else:
+                    sbc_frames.append(self.silence_sbc_frame)
+            return bytes([FRAMES_PER_PACKET]) + b"".join(sbc_frames)
+        
+        return self.silence_rtp_payload
+
+    def close(self):
+        if self.fifo_fd is not None:
+            try:
+                os.close(self.fifo_fd)
+            except Exception:
+                pass
+            self.fifo_fd = None
+        self.encoder.close()

--- a/kindle_hid_passthrough/audio_pipe.py
+++ b/kindle_hid_passthrough/audio_pipe.py
@@ -267,6 +267,16 @@ class FifoAudioStreamer:
         else:
             self.silence_rtp_payload = bytes([0])
         self._ensure_fifo()
+        self.paused = False
+
+    def toggle_pause(self):
+        self.paused = not self.paused
+
+    def play(self):
+        self.paused = False
+
+    def pause(self):
+        self.paused = True
 
     # ---------- FIFO ----------
 
@@ -349,6 +359,9 @@ class FifoAudioStreamer:
                 break
 
     def get_next_payload(self) -> bytes:
+        if self.paused:
+            return self.silence_rtp_payload
+
         self.read_pcm_available()
 
         if self._avail >= PCM_PACKET_SIZE and self.encoder.is_available:

--- a/kindle_hid_passthrough/audio_pipe.py
+++ b/kindle_hid_passthrough/audio_pipe.py
@@ -184,11 +184,13 @@ class SbcEncoder:
 
     def _init_libsbc(self):
         try:
-            lib_name = os.path.join(os.path.dirname(__file__), "libsbc.so.1")
-            if not os.path.exists(lib_name):
-                lib_name = "/mnt/us/kindle_hid_passthrough/libsbc.so.1"
-
-            self._sbc_lib = ctypes.CDLL(lib_name)
+            try:
+                self._sbc_lib = ctypes.CDLL("libsbc.so.1")
+            except OSError:
+                lib_name = os.path.join(os.path.dirname(__file__), "libsbc.so.1")
+                if not os.path.exists(lib_name):
+                    lib_name = "/mnt/us/kindle_hid_passthrough/libsbc.so.1"
+                self._sbc_lib = ctypes.CDLL(lib_name)
             self._sbc_struct = ctypes.create_string_buffer(1024)
             self._sbc_lib.sbc_init.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
             self._sbc_lib.sbc_init.restype = ctypes.c_int

--- a/kindle_hid_passthrough/audio_pipe.py
+++ b/kindle_hid_passthrough/audio_pipe.py
@@ -1,29 +1,178 @@
-import os
-import errno
+"""Kindle Bluetooth Audio Pipeline & Dynamic Resampling Engine.
+
+Provides real-time PCM resampling (supporting 16kHz Piper TTS, 22.05kHz KOReader,
+44.1kHz, 48kHz mono/stereo -> 44.1kHz stereo S16_LE) and SBC RTP frame generation
+for A2DP Bluetooth streaming on Kindle ARMv7 hardware.
+"""
+
+import array
+import audioop
 import ctypes
-import ctypes.util
+import fcntl
 import logging
+import os
+from collections import deque
 
 log = logging.getLogger("kindle-hid-passthrough")
 
-SBC_BITPOOL_DEFAULT = 53
+SBC_BITPOOL_DEFAULT = 35
 PCM_BYTES_PER_SAMPLE = 4
 SAMPLES_PER_FRAME = 16 * 8
 FRAMES_PER_PACKET = 5
 PCM_FRAME_SIZE = SAMPLES_PER_FRAME * PCM_BYTES_PER_SAMPLE
 PCM_PACKET_SIZE = PCM_FRAME_SIZE * FRAMES_PER_PACKET
 
-class SbcStruct(__import__('ctypes').Structure):
+# Buffer target: 8 packets (~116 ms of audio) to absorb jitter without latency lag
+MAX_BUFFERED_PACKETS = 8
+BUFFER_TARGET = PCM_PACKET_SIZE * MAX_BUFFERED_PACKETS
+READ_CHUNK_MAX = 8192
+
+# F_SETPIPE_SZ: limit kernel pipe size to reduce accumulated latency
+F_SETPIPE_SZ = 1031
+FIFO_PIPE_SIZE = 16384
+
+
+class AudioResampler:
+    """Dynamic PCM Resampler supporting 16kHz, 22.05kHz, 44.1kHz, 48kHz mono/stereo
+    resampling to 44.1kHz stereo S16_LE with minimal CPU overhead (<1%) on ARMv7.
+    """
+
+    def __init__(
+        self,
+        in_rate: int = 22050,
+        in_channels: int = 1,
+        out_rate: int = 44100,
+        out_channels: int = 2,
+        fmt_path: str = "/tmp/kindle_audio.fmt",
+    ):
+        self.in_rate = in_rate
+        self.in_channels = in_channels
+        self.out_rate = out_rate
+        self.out_channels = out_channels
+        self.fmt_path = fmt_path
+        self._rate_state = None
+        self._odd_byte = b""
+        self._fmt_mtime = 0
+
+    def check_format_update(self):
+        """Check if format specification file was updated and apply new parameters."""
+        try:
+            st = os.stat(self.fmt_path)
+            if st.st_mtime != self._fmt_mtime:
+                self._fmt_mtime = st.st_mtime
+                with open(self.fmt_path, "r") as f:
+                    content = f.read()
+                new_rate = None
+                new_channels = None
+                for token in content.split():
+                    if token.startswith("rate="):
+                        new_rate = int(token.split("=")[1])
+                    elif token.startswith("channels="):
+                        new_channels = int(token.split("=")[1])
+                self.set_format(new_rate, new_channels)
+        except Exception:
+            pass
+
+    def set_format(self, in_rate: int = None, in_channels: int = None):
+        """Update input audio sample rate and channel configuration."""
+        changed = False
+        if in_rate and in_rate > 0 and in_rate != self.in_rate:
+            self.in_rate = in_rate
+            changed = True
+        if in_channels and in_channels in (1, 2) and in_channels != self.in_channels:
+            self.in_channels = in_channels
+            changed = True
+        if changed:
+            self._rate_state = None
+            self._odd_byte = b""
+            log.info(
+                f"[AudioResampler] Format set: {self.in_rate}Hz {self.in_channels}ch -> "
+                f"{self.out_rate}Hz {self.out_channels}ch"
+            )
+
+    def resample_chunk(self, chunk: bytes) -> bytes:
+        """Resample a chunk of raw S16_LE PCM from (in_rate, in_channels) to (out_rate, out_channels)."""
+        if not chunk and not self._odd_byte:
+            return b""
+
+        if self._odd_byte:
+            chunk = self._odd_byte + chunk
+            self._odd_byte = b""
+
+        # Preserve sample frame alignment (2 bytes per sample * in_channels)
+        frame_align = 2 * self.in_channels
+        rem = len(chunk) % frame_align
+        if rem:
+            self._odd_byte = chunk[-rem:]
+            chunk = chunk[:-rem]
+
+        if not chunk:
+            return b""
+
+        # Fast path 1: 22050 Hz mono -> 44100 Hz stereo (KOReader Audiobook fast path)
+        if self.in_rate == 22050 and self.in_channels == 1 and self.out_rate == 44100 and self.out_channels == 2:
+            try:
+                in_arr = array.array("h", chunk)
+                out_arr = array.array("h", bytes(len(chunk) * 4))
+                out_arr[0::4] = in_arr
+                out_arr[1::4] = in_arr
+                out_arr[2::4] = in_arr
+                out_arr[3::4] = in_arr
+                return out_arr.tobytes()
+            except Exception as e:
+                log.warning(f"[AudioResampler] Fast-path 22k mono error: {e}")
+
+        # Fast path 2: 44100 Hz stereo -> 44100 Hz stereo (Identity)
+        if self.in_rate == 44100 and self.in_channels == 2 and self.out_rate == 44100 and self.out_channels == 2:
+            return chunk
+
+        # Fast path 3: 44100 Hz mono -> 44100 Hz stereo
+        if self.in_rate == 44100 and self.in_channels == 1 and self.out_rate == 44100 and self.out_channels == 2:
+            try:
+                return audioop.tostereo(chunk, 2, 1, 1)
+            except Exception as e:
+                log.warning(f"[AudioResampler] Fast-path 44k mono error: {e}")
+
+        # General resampling path using audioop.ratecv
+        try:
+            if self.in_rate != self.out_rate:
+                converted, self._rate_state = audioop.ratecv(
+                    chunk, 2, self.in_channels, self.in_rate, self.out_rate, self._rate_state
+                )
+            else:
+                converted = chunk
+
+            if self.in_channels == 1 and self.out_channels == 2:
+                converted = audioop.tostereo(converted, 2, 1, 1)
+            elif self.in_channels == 2 and self.out_channels == 1:
+                converted = audioop.tomono(converted, 2, 0.5, 0.5)
+
+            return converted
+        except Exception as e:
+            log.warning(
+                f"[AudioResampler] General resample error ({self.in_rate}Hz {self.in_channels}ch -> "
+                f"{self.out_rate}Hz {self.out_channels}ch): {e}"
+            )
+            return b""
+
+    def reset(self):
+        """Reset internal filter states and buffers."""
+        self._rate_state = None
+        self._odd_byte = b""
+
+
+class SbcStruct(ctypes.Structure):
     _fields_ = [
-        ("flags", __import__('ctypes').c_ulong),
-        ("frequency", __import__('ctypes').c_uint8),
-        ("blocks", __import__('ctypes').c_uint8),
-        ("subbands", __import__('ctypes').c_uint8),
-        ("mode", __import__('ctypes').c_uint8),
-        ("allocation", __import__('ctypes').c_uint8),
-        ("bitpool", __import__('ctypes').c_uint8),
-        ("endian", __import__('ctypes').c_uint8),
+        ("flags", ctypes.c_ulong),
+        ("frequency", ctypes.c_uint8),
+        ("blocks", ctypes.c_uint8),
+        ("subbands", ctypes.c_uint8),
+        ("mode", ctypes.c_uint8),
+        ("allocation", ctypes.c_uint8),
+        ("bitpool", ctypes.c_uint8),
+        ("endian", ctypes.c_uint8),
     ]
+
 
 class SbcEncoder:
     def __init__(self, bitpool: int = SBC_BITPOOL_DEFAULT):
@@ -38,32 +187,35 @@ class SbcEncoder:
             lib_name = os.path.join(os.path.dirname(__file__), "libsbc.so.1")
             if not os.path.exists(lib_name):
                 lib_name = "/mnt/us/kindle_hid_passthrough/libsbc.so.1"
-            
+
             self._sbc_lib = ctypes.CDLL(lib_name)
             self._sbc_struct = ctypes.create_string_buffer(1024)
             self._sbc_lib.sbc_init.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
             self._sbc_lib.sbc_init.restype = ctypes.c_int
-            
+
             self._sbc_lib.sbc_encode.argtypes = [
-                ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
-                ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_ssize_t)
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_size_t,
+                ctypes.c_void_p,
+                ctypes.c_size_t,
+                ctypes.POINTER(ctypes.c_ssize_t),
             ]
             self._sbc_lib.sbc_encode.restype = ctypes.c_ssize_t
-            
+
             ret = self._sbc_lib.sbc_init(self._sbc_struct, 0)
             if ret == 0:
-                # FIX A2DP MISMATCH (Synthesizer voice)
                 sbc_cfg = ctypes.cast(self._sbc_struct, ctypes.POINTER(SbcStruct)).contents
-                sbc_cfg.frequency = 0x02 # 44100
-                sbc_cfg.blocks = 0x03 # 16 blocks
-                sbc_cfg.subbands = 0x01 # 8 subbands
-                sbc_cfg.mode = 0x03 # JOINT_STEREO (default was STEREO 0x02, causing metal synth)
-                sbc_cfg.allocation = 0x00 # LOUDNESS
-                sbc_cfg.bitpool = self.bitpool # 53
+                sbc_cfg.frequency = 0x02  # 44.1 kHz
+                sbc_cfg.blocks = 0x03     # 16 blocks
+                sbc_cfg.subbands = 0x01   # 8 subbands
+                sbc_cfg.mode = 0x03       # Joint Stereo
+                sbc_cfg.allocation = 0x00 # Loudness
+                sbc_cfg.bitpool = self.bitpool
                 self._available = True
-                log.info("[Audio] libsbc carregada com sucesso!")
+                log.info("[Audio] libsbc loaded successfully")
         except Exception as e:
-            log.warning(f"[Audio] libsbc não encontrada ({e}). Fallback de silêncio será usado.")
+            log.warning(f"[Audio] libsbc initialization failed: {e}")
             self._available = False
 
     @property
@@ -89,67 +241,125 @@ class SbcEncoder:
             except Exception:
                 pass
 
+
 class FifoAudioStreamer:
+    """Reads raw PCM of arbitrary rate/channel from FIFO, resamples to 44.1kHz stereo,
+    and delivers ready RTP/SBC payloads for AVDTP streaming pump.
+
+    Flow control: Consumer pulls in real-time (~14.5 ms per packet). This streamer
+    maintains up to BUFFER_TARGET output bytes in memory and applies backpressure
+    to the FIFO writer when full.
+    """
+
     def __init__(self, fifo_path: str = "/tmp/kindle_audio.fifo"):
         self.fifo_path = fifo_path
         self.fifo_fd = None
-        self.pcm_buffer = bytearray()
+        self._chunks = deque()
+        self._avail = 0
+        self.resampler = AudioResampler()
         self.encoder = SbcEncoder()
-        
-        self.silence_sbc_frame = bytes([0x9C, 0xBD, 0x35, 0x00]) + bytes(115)
-        self.silence_rtp_payload = bytes([FRAMES_PER_PACKET]) + (self.silence_sbc_frame * FRAMES_PER_PACKET)
+
+        self.silence_sbc_frame = self.encoder.encode_frame(b"\x00" * PCM_FRAME_SIZE)
+        if self.silence_sbc_frame:
+            self.silence_rtp_payload = (
+                bytes([FRAMES_PER_PACKET]) + self.silence_sbc_frame * FRAMES_PER_PACKET
+            )
+        else:
+            self.silence_rtp_payload = bytes([0])
         self._ensure_fifo()
+
+    # ---------- FIFO ----------
 
     def _ensure_fifo(self):
         try:
             if not os.path.exists(self.fifo_path):
                 os.mkfifo(self.fifo_path, 0o666)
-        except Exception as e:
-            log.error(f"[Audio] Erro ao criar FIFO {self.fifo_path}: {e}")
+        except Exception:
+            pass
 
         try:
             self.fifo_fd = os.open(self.fifo_path, os.O_RDWR | os.O_NONBLOCK)
-            log.info(f"[Audio] FIFO {self.fifo_path} aberta (FD={self.fifo_fd})")
-        except Exception as e:
-            log.error(f"[Audio] Falha ao abrir FIFO: {e}")
+        except Exception:
+            self.fifo_fd = None
+            return
+
+        try:
+            fcntl.fcntl(self.fifo_fd, F_SETPIPE_SZ, FIFO_PIPE_SIZE)
+        except Exception:
+            pass
+
+    # ---------- buffer O(1) ----------
+
+    def _push(self, data: bytes):
+        if data:
+            self._chunks.append(data)
+            self._avail += len(data)
+
+    def _pull(self, n: int) -> bytes:
+        if self._avail < n:
+            return None
+        out = bytearray(n)
+        pos = 0
+        while pos < n:
+            head = self._chunks[0]
+            need = n - pos
+            if len(head) <= need:
+                out[pos : pos + len(head)] = head
+                pos += len(head)
+                self._chunks.popleft()
+            else:
+                out[pos:n] = head[:need]
+                self._chunks[0] = head[need:]
+                pos = n
+        self._avail -= n
+        return bytes(out)
+
+    # ---------- reading & dynamic resampling ----------
 
     def read_pcm_available(self):
         if self.fifo_fd is None:
             return
-        
-        try:
-            while True:
-                chunk = os.read(self.fifo_fd, 8192)
-                if not chunk:
-                    break
-                self.pcm_buffer.extend(chunk)
-                
-                # Controle de latência e lag (máximo de 3 pacotes, ~43ms em buffer)
-                if len(self.pcm_buffer) > PCM_PACKET_SIZE * 3:
-                    pass # del self.pcm_buffer[:-PCM_PACKET_SIZE * 3]
-        except (BlockingIOError, InterruptedError):
-            pass
-        except OSError as e:
-            if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
-                log.warning(f"[Audio] Erro lendo FIFO: {e}")
+        self.resampler.check_format_update()
+        while self._avail < BUFFER_TARGET:
+            bytes_needed = BUFFER_TARGET - self._avail
+            in_bps = self.resampler.in_rate * self.resampler.in_channels * 2
+            out_bps = self.resampler.out_rate * self.resampler.out_channels * 2
+            if out_bps > 0:
+                approx_want = max(512, int(bytes_needed * in_bps / out_bps))
+            else:
+                approx_want = 1024
+            want = min(READ_CHUNK_MAX, max(512, approx_want))
+            frame_align = 2 * self.resampler.in_channels
+            want = (want // frame_align) * frame_align
+            if want < frame_align:
+                want = frame_align
+
+            try:
+                chunk = os.read(self.fifo_fd, want)
+            except (BlockingIOError, InterruptedError):
+                break
+            except OSError:
+                break
+            if not chunk:
+                break
+            resampled = self.resampler.resample_chunk(chunk)
+            if resampled:
+                self._push(resampled)
+            if len(chunk) < want:
+                break
 
     def get_next_payload(self) -> bytes:
         self.read_pcm_available()
-        
-        if len(self.pcm_buffer) >= PCM_PACKET_SIZE and self.encoder.is_available:
-            raw_packet_pcm = bytes(self.pcm_buffer[:PCM_PACKET_SIZE])
-            del self.pcm_buffer[:PCM_PACKET_SIZE]
-            
+
+        if self._avail >= PCM_PACKET_SIZE and self.encoder.is_available:
+            raw_packet_pcm = self._pull(PCM_PACKET_SIZE)
             sbc_frames = []
             for i in range(FRAMES_PER_PACKET):
                 pcm_chunk = raw_packet_pcm[i * PCM_FRAME_SIZE : (i + 1) * PCM_FRAME_SIZE]
                 encoded = self.encoder.encode_frame(pcm_chunk)
-                if encoded:
-                    sbc_frames.append(encoded)
-                else:
-                    sbc_frames.append(self.silence_sbc_frame)
+                sbc_frames.append(encoded if encoded else self.silence_sbc_frame)
             return bytes([FRAMES_PER_PACKET]) + b"".join(sbc_frames)
-        
+
         return self.silence_rtp_payload
 
     def close(self):
@@ -159,4 +369,7 @@ class FifoAudioStreamer:
             except Exception:
                 pass
             self.fifo_fd = None
+        self._chunks.clear()
+        self._avail = 0
+        self.resampler.reset()
         self.encoder.close()

--- a/kindle_hid_passthrough/button_mapper.py
+++ b/kindle_hid_passthrough/button_mapper.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 MAPPER_CONFIG = "/mnt/us/kindle-button-mapper/config.ini"
 
 
+def _is_audio(protocol) -> bool:
+    return str(getattr(protocol, 'value', protocol)) == 'classic_audio'
+
+
 def _bare_addr(value: str) -> str:
     return value.split('/')[0].strip().upper()
 
@@ -43,7 +47,8 @@ def _slug(name: str, address: str, text: str) -> str:
     return slug
 
 
-def register_device(address: str, name: str = None, reload: bool = True) -> bool:
+def register_device(address: str, name: str = None, reload: bool = True,
+                    audio: bool = False) -> bool:
     """Add a device block to the mapper config. True if one was added."""
     try:
         with open(MAPPER_CONFIG) as f:
@@ -60,6 +65,14 @@ def register_device(address: str, name: str = None, reload: bool = True) -> bool
     if name:
         block += f'name = {name}\n'
     block += f'uniq = {address}\n'
+    if audio:
+        # An audio device reaches us through the injected Consumer Control
+        # descriptor, so its node carries media keys and nothing else --
+        # keys KOReader has no binding for. Leaving the node to KOReader by
+        # default meant the mapper never saw a press and the button did
+        # nothing until the user found the mode setting by hand. Passthrough
+        # keeps whatever is unmapped flowing on.
+        block += 'grab = true\npassthrough = true\n'
 
     try:
         with open(MAPPER_CONFIG, 'a') as f:
@@ -142,10 +155,11 @@ def _block_uniq(block) -> str:
 def register_all(devices) -> None:
     """Register every (address, protocol, name) tuple, skipping wildcards."""
     added = False
-    for address, _proto, name in devices:
+    for address, proto, name in devices:
         if address == '*':
             continue
-        added |= register_device(address, name, reload=False)
+        added |= register_device(address, name, reload=False,
+                                 audio=_is_audio(proto))
     if added:
         _reload_mapper()
 

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -7,6 +7,7 @@ from bumble.core import BT_BR_EDR_TRANSPORT, BT_HUMAN_INTERFACE_DEVICE_SERVICE, 
 from bumble.core import TimeoutError as BumbleTimeoutError
 from bumble.hci import (
     Address,
+    HCI_Error,
     HCI_Write_Scan_Enable_Command,
     Role,
 )
@@ -16,19 +17,32 @@ from bumble.sdp import Client as SDPClient
 
 from config import Protocol, clean_device_name, config, normalize_addr
 from logging_utils import errstr, log
-from bumble.hci import HCI_Error
 
 CLASSIC_COLLISION_ERRORS = (0x23, 0x2A)
+# The only failures that mean the stored link key is the problem:
+# AUTHENTICATION_FAILURE and PIN_OR_KEY_MISSING. Anything else -- a timeout
+# above all -- says nothing about the key, and dropping it there costs the
+# user a re-pairing of a device that was working.
+CLASSIC_STALE_KEY_ERRORS = (0x05, 0x06)
+# A bonded device waking from deep sleep has to wake its own radio before it
+# can answer, and 5 s was not enough for that: the restore timed out on a
+# perfectly good key. Give it room before concluding anything.
+CLASSIC_AUTH_TIMEOUT = 15.0
 
 # HIDP DATA header, OUTPUT report type.
 HIDP_DATA_OUTPUT = 0xA2
 
 FALLBACK_HID_DESCRIPTOR = bytes([
-    0x05, 0x01, 0x09, 0x06, 0xA1, 0x01, 0x85, 0x01, 0x05, 0x07, 0x19, 0xE0, 0x29, 0xE7, 0x15, 0x00,
-    0x25, 0x01, 0x75, 0x01, 0x95, 0x08, 0x81, 0x02, 0x95, 0x01, 0x75, 0x08, 0x81, 0x01, 0x95, 0x05,
-    0x75, 0x01, 0x05, 0x08, 0x19, 0x01, 0x29, 0x05, 0x91, 0x02, 0x95, 0x01, 0x75, 0x03, 0x91, 0x01,
-    0x95, 0x06, 0x75, 0x08, 0x15, 0x00, 0x25, 0x65, 0x05, 0x07, 0x19, 0x00, 0x29, 0x65, 0x81, 0x00,
-    0xC0
+    0x05, 0x01, 0x09, 0x05, 0xa1, 0x01, 0x85, 0x01,
+    0x05, 0x01, 0x09, 0x30, 0x09, 0x31, 0x09, 0x32, 0x09, 0x35,
+    0x16, 0x00, 0x00, 0x26, 0xff, 0xff, 0x75, 0x10, 0x95, 0x04, 0x81, 0x02,
+    0x05, 0x02, 0x09, 0xc5, 0x09, 0xc4,
+    0x16, 0x00, 0x00, 0x26, 0xff, 0x03, 0x75, 0x10, 0x95, 0x02, 0x81, 0x02,
+    0x05, 0x01, 0x09, 0x39, 0x15, 0x01, 0x25, 0x08,
+    0x35, 0x00, 0x46, 0x3b, 0x01, 0x65, 0x14, 0x75, 0x08, 0x95, 0x01, 0x81, 0x42,
+    0x05, 0x09, 0x19, 0x01, 0x29, 0x10,
+    0x15, 0x00, 0x25, 0x01, 0x75, 0x01, 0x95, 0x10, 0x81, 0x02,
+    0xc0,
 ])
 
 
@@ -174,11 +188,20 @@ class ClassicMixin:
 
             addr = normalize_addr(addr_str)
             old = self.sessions.get(addr)
+            # Specific address first: a '*' entry earlier in devices.conf used
+            # to win over the exact match below it and hand every device the
+            # wildcard's protocol -- audio for keyboards, or the reverse.
             proto = Protocol.CLASSIC
+            wildcard = None
             for dev in self.classic_devices:
-                if dev.address == addr or dev.address == '*':
+                if dev.address == addr:
                     proto = dev.protocol
                     break
+                if dev.address == '*' and wildcard is None:
+                    wildcard = dev.protocol
+            else:
+                if wildcard is not None:
+                    proto = wildcard
 
             session = self._new_session(addr, proto, connection)
             if proto != Protocol.CLASSIC_AUDIO:
@@ -214,7 +237,7 @@ class ClassicMixin:
                 log.info(f"[Classic] Dropped stale link key: {addr}")
             except Exception as e:
                 log.warning(f"[Classic] Could not drop the link key for {addr}: "
-                            f"{errstr(e) if 'errstr' in globals() else repr(e)}")
+                            f"{errstr(e)}")
         try:
             log.info("[Classic] Pairing again...")
             await asyncio.wait_for(connection.authenticate(), timeout=20.0)
@@ -223,7 +246,7 @@ class ClassicMixin:
             return True
         except Exception as e:
             log.warning(f"[Classic] Re-pairing failed: "
-                        f"{errstr(e) if 'errstr' in globals() else repr(e)}")
+                        f"{errstr(e)}")
             return False
 
     async def _setup_classic_session(self, session, old=None):
@@ -237,6 +260,9 @@ class ClassicMixin:
         def is_collision(e):
             return isinstance(e, HCI_Error) and e.error_code in CLASSIC_COLLISION_ERRORS
 
+        def is_stale_key(e):
+            return isinstance(e, HCI_Error) and e.error_code in CLASSIC_STALE_KEY_ERRORS
+
         peer_driving = False
         bond_failed = False
         is_peripheral = connection.role != Role.CENTRAL
@@ -248,7 +274,7 @@ class ClassicMixin:
                 log.success("[Classic] Role switch complete, now central")
                 is_peripheral = False
             except Exception as e:
-                log.warning(f"[Classic] Role switch failed: {errstr(e) if 'errstr' in globals() else repr(e)}")
+                log.warning(f"[Classic] Role switch failed: {errstr(e)}")
                 peer_driving = is_collision(e)
 
         if peer_driving or is_peripheral:
@@ -257,13 +283,20 @@ class ClassicMixin:
             log.info("[Classic] Restoring bonding (authenticate + encrypt)...")
             try:
                 if not connection.authenticated:
-                    await asyncio.wait_for(connection.authenticate(), timeout=5.0)
-                await asyncio.wait_for(connection.encrypt(enable=True), timeout=5.0)
+                    await asyncio.wait_for(connection.authenticate(),
+                                           timeout=CLASSIC_AUTH_TIMEOUT)
+                await asyncio.wait_for(connection.encrypt(enable=True),
+                                       timeout=CLASSIC_AUTH_TIMEOUT)
                 log.success("[Classic] Bonding restored")
             except Exception as e:
-                log.warning(f"[Classic] Bonding restore failed: {errstr(e) if 'errstr' in globals() else repr(e)}")
+                log.warning(f"[Classic] Bonding restore failed: {errstr(e)}")
                 peer_driving = is_collision(e)
-                if not peer_driving:
+                # Drop the key when the controller says it is the problem, or
+                # when the peer stayed silent for the whole window above --
+                # both are states a fresh pairing recovers and nothing else
+                # does. A collision is neither: the peer is driving.
+                if not peer_driving and (is_stale_key(e)
+                                         or isinstance(e, asyncio.TimeoutError)):
                     bond_failed = not await self._reset_classic_bond(
                         session, connection)
 
@@ -277,6 +310,12 @@ class ClassicMixin:
                     "An unauthenticated link is torn down by the peer at "
                     "the 30 s LMP Response Timeout, in a loop. Put the "
                     "headset in pairing mode to renew the key."
+                )
+                return
+            if not config.audio_enabled():
+                log.info(
+                    "[Classic] Audio device connected, bypass is off: not "
+                    "opening AVDTP. Turn Bluetooth audio on to stream to it."
                 )
                 return
             log.info("[Classic] Audio device connected. Letting AVDTP and AVRCP listeners take over.")
@@ -482,7 +521,7 @@ class ClassicMixin:
         """Execute pairing flow for a single Classic device."""
         self._pairing_session = None
 
-        log.info(f"[Classic] Pairing with {address}/P...")
+        log.info(f"[Classic] Pairing with {address}...")
         try:
             target_address = Address(address, Address.PUBLIC_DEVICE_ADDRESS)
             connection = await self.device.connect(

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -187,6 +187,36 @@ class ClassicMixin:
 
         await self._classic_active_connect_loop()
 
+    async def _reset_classic_bond(self, session, connection):
+        """Drop the stale link key and pair again.
+
+        A stale key makes authenticate() fail with AUTHENTICATION_FAILURE.
+        Carrying on opens AVDTP over an unauthenticated link and the peer
+        tears the connection down at the 30 s LMP Response Timeout, forever.
+        The BLE path already did this; the Classic path did not.
+
+        Returns True when the link ends up authenticated and encrypted.
+        """
+        addr = str(connection.peer_address)
+        keystore = getattr(self.device, "keystore", None)
+        if keystore is not None:
+            try:
+                await keystore.delete(addr)
+                log.info(f"[Classic] Dropped stale link key: {addr}")
+            except Exception as e:
+                log.warning(f"[Classic] Could not drop the link key for {addr}: "
+                            f"{errstr(e) if 'errstr' in globals() else repr(e)}")
+        try:
+            log.info("[Classic] Pairing again...")
+            await asyncio.wait_for(connection.authenticate(), timeout=20.0)
+            await asyncio.wait_for(connection.encrypt(enable=True), timeout=10.0)
+            log.success("[Classic] Paired again")
+            return True
+        except Exception as e:
+            log.warning(f"[Classic] Re-pairing failed: "
+                        f"{errstr(e) if 'errstr' in globals() else repr(e)}")
+            return False
+
     async def _setup_classic_session(self, session, old=None):
         """Authenticate, open HID channels, and finalize one Classic session."""
         connection = session.connection
@@ -199,6 +229,7 @@ class ClassicMixin:
             return isinstance(e, HCI_Error) and e.error_code in CLASSIC_COLLISION_ERRORS
 
         peer_driving = False
+        bond_failed = False
         is_peripheral = connection.role != Role.CENTRAL
 
         if is_peripheral:
@@ -223,11 +254,22 @@ class ClassicMixin:
             except Exception as e:
                 log.warning(f"[Classic] Bonding restore failed: {errstr(e) if 'errstr' in globals() else repr(e)}")
                 peer_driving = is_collision(e)
+                if not peer_driving:
+                    bond_failed = not await self._reset_classic_bond(
+                        session, connection)
 
         channels = session.channels
 
 
         if session.protocol == Protocol.CLASSIC_AUDIO:
+            if bond_failed:
+                log.warning(
+                    "[Classic] No valid bonding: not opening AVDTP. "
+                    "An unauthenticated link is torn down by the peer at "
+                    "the 30 s LMP Response Timeout, in a loop. Put the "
+                    "headset in pairing mode to renew the key."
+                )
+                return
             log.info("[Classic] Audio device connected. Letting AVDTP and AVRCP listeners take over.")
             log.success(f"[Classic] {self._format_device(session.address)} connected (Audio)")
             self._track_task(asyncio.create_task(self._continue_classic_audio_after_pairing(session)))

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -47,6 +47,10 @@ FALLBACK_HID_DESCRIPTOR = bytes([
 
 
 CLASSIC_PEER_CHANNEL_WAIT = 5.0
+# How long to let a peer that took the central role encrypt the link before
+# driving it ourselves. Opening AVDTP first gets refused with a security block
+# and the peer then drops the ACL, costing a whole reconnect cycle.
+CLASSIC_PEER_SECURITY_WAIT = 4.0
 
 
 class ClassicHIDChannels:
@@ -277,8 +281,26 @@ class ClassicMixin:
                 log.warning(f"[Classic] Role switch failed: {errstr(e)}")
                 peer_driving = is_collision(e)
 
+        if (peer_driving or is_peripheral) and not connection.is_encrypted:
+            # Staying out of the way is right, but not walking on ahead: with
+            # the link still unencrypted, opening AVDTP is refused with
+            # CONNECTION_REFUSED_SECURITY_BLOCK and the peer then drops the
+            # ACL with AUTHENTICATION_FAILURE. Give it a moment to do its
+            # part, and drive it ourselves if it never does.
+            log.info("[Classic] Peer is driving security, waiting for the link")
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + CLASSIC_PEER_SECURITY_WAIT
+            while loop.time() < deadline and not connection.is_encrypted:
+                await asyncio.sleep(0.05)
+            if connection.is_encrypted:
+                log.success("[Classic] Peer encrypted the link")
+            else:
+                log.info("[Classic] Peer did not encrypt; driving it ourselves")
+                peer_driving = False
+                is_peripheral = False
+
         if peer_driving or is_peripheral:
-            log.info("[Classic] Peer is driving security, staying out of its way")
+            log.info("[Classic] Link already encrypted by the peer")
         elif not connection.is_encrypted:
             log.info("[Classic] Restoring bonding (authenticate + encrypt)...")
             try:

--- a/kindle_hid_passthrough/classic.py
+++ b/kindle_hid_passthrough/classic.py
@@ -16,19 +16,20 @@ from bumble.sdp import Client as SDPClient
 
 from config import Protocol, clean_device_name, config, normalize_addr
 from logging_utils import errstr, log
+from bumble.hci import HCI_Error
+
+CLASSIC_COLLISION_ERRORS = (0x23, 0x2A)
 
 FALLBACK_HID_DESCRIPTOR = bytes([
-    0x05, 0x01, 0x09, 0x05, 0xa1, 0x01, 0x85, 0x01,
-    0x05, 0x01, 0x09, 0x30, 0x09, 0x31, 0x09, 0x32, 0x09, 0x35,
-    0x16, 0x00, 0x00, 0x26, 0xff, 0xff, 0x75, 0x10, 0x95, 0x04, 0x81, 0x02,
-    0x05, 0x02, 0x09, 0xc5, 0x09, 0xc4,
-    0x16, 0x00, 0x00, 0x26, 0xff, 0x03, 0x75, 0x10, 0x95, 0x02, 0x81, 0x02,
-    0x05, 0x01, 0x09, 0x39, 0x15, 0x01, 0x25, 0x08,
-    0x35, 0x00, 0x46, 0x3b, 0x01, 0x65, 0x14, 0x75, 0x08, 0x95, 0x01, 0x81, 0x42,
-    0x05, 0x09, 0x19, 0x01, 0x29, 0x10,
-    0x15, 0x00, 0x25, 0x01, 0x75, 0x01, 0x95, 0x10, 0x81, 0x02,
-    0xc0,
+    0x05, 0x01, 0x09, 0x06, 0xA1, 0x01, 0x85, 0x01, 0x05, 0x07, 0x19, 0xE0, 0x29, 0xE7, 0x15, 0x00,
+    0x25, 0x01, 0x75, 0x01, 0x95, 0x08, 0x81, 0x02, 0x95, 0x01, 0x75, 0x08, 0x81, 0x01, 0x95, 0x05,
+    0x75, 0x01, 0x05, 0x08, 0x19, 0x01, 0x29, 0x05, 0x91, 0x02, 0x95, 0x01, 0x75, 0x03, 0x91, 0x01,
+    0x95, 0x06, 0x75, 0x08, 0x15, 0x00, 0x25, 0x65, 0x05, 0x07, 0x19, 0x00, 0x29, 0x65, 0x81, 0x00,
+    0xC0
 ])
+
+
+CLASSIC_PEER_CHANNEL_WAIT = 5.0
 
 
 class ClassicHIDChannels:
@@ -164,11 +165,18 @@ class ClassicMixin:
 
             addr = normalize_addr(addr_str)
             old = self.sessions.get(addr)
-            session = self._new_session(addr, Protocol.CLASSIC, connection)
-            session.channels = ClassicHIDChannels(
-                connection,
-                lambda pdu: self._on_classic_interrupt_data(session, pdu),
-                lambda: self._on_virtual_cable_unplug(session))
+            proto = Protocol.CLASSIC
+            for dev in self.classic_devices:
+                if dev.address == addr or dev.address == '*':
+                    proto = dev.protocol
+                    break
+
+            session = self._new_session(addr, proto, connection)
+            if proto != Protocol.CLASSIC_AUDIO:
+                session.channels = ClassicHIDChannels(
+                    connection,
+                    lambda pdu: self._on_classic_interrupt_data(session, pdu),
+                    lambda: self._on_virtual_cable_unplug(session))
             self._register_session(session)
             session.setup_task = self._track_task(asyncio.create_task(
                 self._run_session_setup(
@@ -187,24 +195,54 @@ class ClassicMixin:
         if old is not None:
             await self._teardown_session(old)
 
-        if connection.role != Role.CENTRAL:
+        def is_collision(e):
+            return isinstance(e, HCI_Error) and e.error_code in CLASSIC_COLLISION_ERRORS
+
+        peer_driving = False
+        is_peripheral = connection.role != Role.CENTRAL
+
+        if is_peripheral:
             log.info("[Classic] Requesting role switch to central...")
             try:
                 await asyncio.wait_for(connection.switch_role(Role.CENTRAL), timeout=5.0)
                 log.success("[Classic] Role switch complete, now central")
+                is_peripheral = False
             except Exception as e:
-                log.warning(f"[Classic] Role switch failed: {errstr(e)}")
+                log.warning(f"[Classic] Role switch failed: {errstr(e) if 'errstr' in globals() else repr(e)}")
+                peer_driving = is_collision(e)
 
-        if not connection.is_encrypted:
+        if peer_driving or is_peripheral:
+            log.info("[Classic] Peer is driving security, staying out of its way")
+        elif not connection.is_encrypted:
             log.info("[Classic] Restoring bonding (authenticate + encrypt)...")
             try:
-                await asyncio.wait_for(connection.authenticate(), timeout=5.0)
+                if not connection.authenticated:
+                    await asyncio.wait_for(connection.authenticate(), timeout=5.0)
                 await asyncio.wait_for(connection.encrypt(enable=True), timeout=5.0)
                 log.success("[Classic] Bonding restored")
             except Exception as e:
-                log.warning(f"[Classic] Bonding restore failed: {errstr(e)}")
+                log.warning(f"[Classic] Bonding restore failed: {errstr(e) if 'errstr' in globals() else repr(e)}")
+                peer_driving = is_collision(e)
 
         channels = session.channels
+
+
+        if session.protocol == Protocol.CLASSIC_AUDIO:
+            log.info("[Classic] Audio device connected. Letting AVDTP and AVRCP listeners take over.")
+            log.success(f"[Classic] {self._format_device(session.address)} connected (Audio)")
+            self._track_task(asyncio.create_task(self._continue_classic_audio_after_pairing(session)))
+            return
+
+        if (peer_driving or is_peripheral) and not channels.intr_channel:
+            log.info("[Classic] Waiting for the peer to open the HID channels...")
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + CLASSIC_PEER_CHANNEL_WAIT
+            while loop.time() < deadline and not channels.intr_channel:
+                await asyncio.sleep(0.05)
+            if channels.intr_channel:
+                log.success("[Classic] Peer opened the HID channels")
+            else:
+                log.info("[Classic] Peer did not open them, paging outward")
 
         if not channels.ctrl_channel:
             log.info("[Classic] Connecting to HID control channel...")
@@ -223,7 +261,10 @@ class ClassicMixin:
                 log.warning(f"[Classic] Interrupt channel: {errstr(e)}")
 
         if not channels.intr_channel:
-            raise InvalidStateError("[Classic] HID channels not opened by peer")
+            if session.protocol == Protocol.CLASSIC_AUDIO:
+                log.info("[Classic] Audio device did not open HID channels, keeping alive for AVDTP")
+            else:
+                raise InvalidStateError("[Classic] HID channels not opened by peer")
 
         self._classic_set_report_protocol(session)
 
@@ -322,6 +363,7 @@ class ClassicMixin:
     def _classic_set_report_protocol(self, session):
         """Send HIDP SET_PROTOCOL(Report) on the control channel."""
         channels = session.channels
+
         if not channels or not channels.ctrl_channel:
             return
         try:
@@ -385,10 +427,11 @@ class ClassicMixin:
         session.vc_unplug = True
         self._track_task(asyncio.create_task(self._teardown_session(session)))
 
-    async def _pair_classic(self, address: str) -> bool:
-        """Pair with a Classic Bluetooth device."""
-        log.info(f"[Classic] Pairing with {address}...")
+    async def _pair_classic(self, address: str, protocol: Protocol = Protocol.CLASSIC) -> bool:
+        """Execute pairing flow for a single Classic device."""
+        self._pairing_session = None
 
+        log.info(f"[Classic] Pairing with {address}/P...")
         try:
             target_address = Address(address, Address.PUBLIC_DEVICE_ADDRESS)
             connection = await self.device.connect(
@@ -404,7 +447,7 @@ class ClassicMixin:
             log.error(f"[Classic] Connection failed: {e}")
             return False
 
-        session = self._new_session(normalize_addr(address), Protocol.CLASSIC, connection)
+        session = self._new_session(normalize_addr(address), protocol, connection)
         self._pairing_session = session
 
         link_key_received = asyncio.Event()
@@ -503,12 +546,17 @@ class ClassicMixin:
 
     async def _continue_classic_after_pairing(self, session):
         """Continue Classic connection after pairing."""
+        if session.protocol == Protocol.CLASSIC_AUDIO:
+            log.info("[Classic] Audio device connected. Letting AVDTP listener take over.")
+            return
+
         self._ensure_classic_psm_servers()
         session.channels = ClassicHIDChannels(
             session.connection,
             lambda pdu: self._on_classic_interrupt_data(session, pdu),
             lambda: self._on_virtual_cable_unplug(session))
         channels = session.channels
+
         log.info("[Classic] HID Host created")
 
         log.info("[Classic] Connecting to HID control channel...")

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -125,6 +125,7 @@ class Config:
         # Paths
         self.cache_dir = self._get('paths', 'cache_dir', f'{self.base_path}/cache')
         self.pairing_keys_file = os.path.join(self.cache_dir, 'pairing_keys.json')
+        self.audio_state_file = os.path.join(self.cache_dir, 'audio_enabled')
         self.devices_config_file = self._get('paths', 'devices_config',
                                              f'{self.base_path}/devices.conf')
         self.log_file = self._get('logging', 'log_file', '/var/log/hid_passthrough.log')
@@ -154,6 +155,19 @@ class Config:
         self.protocol = self._parse_protocol(protocol_str)
 
         self.media_remote_enabled = self._getboolean('media_remote', 'enabled', True)
+
+    def audio_enabled(self) -> bool:
+        """Whether the user asked for the Bluetooth audio bypass.
+
+        Written by the controller and read here so the connect path and the
+        switch cannot disagree: with the bypass off, an audio device must not
+        get an AVDTP stream it would only feed silence into.
+        """
+        try:
+            with open(self.audio_state_file) as f:
+                return f.read().strip() == "1"
+        except OSError:
+            return False
 
     def _detect_transport(self) -> str:
         """Auto-detect HCI transport from Kindle hardware.

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -374,7 +374,8 @@ class Config:
                     f.write(f"{addr_norm} {protocol.value}\n")
             logger.info(f"Added: {addr_norm} {protocol.value} ({name or 'unnamed'})")
             import button_mapper
-            button_mapper.register_device(addr_norm, name)
+            button_mapper.register_device(
+                addr_norm, name, audio=button_mapper._is_audio(protocol))
         except Exception as e:
             logger.error(f"Failed to save device: {e}")
 

--- a/kindle_hid_passthrough/config.py
+++ b/kindle_hid_passthrough/config.py
@@ -79,6 +79,7 @@ class Protocol(Enum):
     """Supported Bluetooth protocols."""
     BLE = "ble"
     CLASSIC = "classic"
+    CLASSIC_AUDIO = "classic_audio"
 
 
 class Config:
@@ -201,6 +202,8 @@ class Config:
         """Parse protocol string to Protocol enum."""
         if protocol_str in ('classic', 'br/edr', 'bredr'):
             return Protocol.CLASSIC
+        if protocol_str == 'classic_audio':
+            return Protocol.CLASSIC_AUDIO
         return Protocol.BLE
 
     def _get(self, section: str, key: str, default: str) -> str:

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -38,10 +38,14 @@ class DaemonController:
         # HID on/off survives a reboot: /start and /stop write it to disk
         # and boot honours what the user left. It used to always come up on.
         self._bt_enabled = self._load_bt_state()
+        # The bypass stops the stock audiomgrd and puts a mock in its place, so
+        # it is opt-in and off until asked for: a device where it does not work
+        # has to be able to keep its own audio daemon.
+        self._audio_enabled = self._load_audio_state()
         if not self._bt_enabled:
             logger.info("HID was left off; daemon starts suspended")
             daemon._suspended = True
-        else:
+        elif self._audio_enabled:
             self._spawn_audio_hack(True)
 
         # Scan state
@@ -69,6 +73,29 @@ class DaemonController:
 
     def _bt_state_path(self):
         return os.path.join(config.cache_dir, "bt_enabled")
+
+    def _audio_state_path(self):
+        return os.path.join(config.cache_dir, "audio_enabled")
+
+    def _load_audio_state(self) -> bool:
+        """Off unless the user turned it on. Unlike HID, which the daemon
+        exists for, the bypass replaces a system daemon and cannot be the
+        default on hardware nobody has tested it on."""
+        try:
+            with open(self._audio_state_path()) as f:
+                return f.read().strip() == "1"
+        except OSError:
+            return False
+
+    def _persist_audio_state(self, value: bool):
+        try:
+            os.makedirs(config.cache_dir, exist_ok=True)
+            tmp = self._audio_state_path() + ".tmp"
+            with open(tmp, "w") as f:
+                f.write("1" if value else "0")
+            os.replace(tmp, self._audio_state_path())
+        except OSError as e:
+            logger.warning(f"Could not persist audio_enabled: {errstr(e)}")
 
     def _load_bt_state(self) -> bool:
         try:
@@ -137,6 +164,25 @@ class DaemonController:
         self._bt_enabled = value
         if changed:
             self._persist_bt_state(value)
+            if self._audio_enabled:
+                self._spawn_audio_hack(value)
+
+    @property
+    def audio_enabled(self) -> bool:
+        return self._audio_enabled
+
+    @audio_enabled.setter
+    def audio_enabled(self, value):
+        value = bool(value)
+        changed = value != getattr(self, "_audio_enabled", None)
+        self._audio_enabled = value
+        if not changed:
+            return
+        self._persist_audio_state(value)
+        # Only touch the stock daemon while HID is on. With HID off there is no
+        # Bluetooth sink to route to, and stopping audiomgrd then would leave
+        # the device with no audio at all instead of with its own.
+        if self._bt_enabled:
             self._spawn_audio_hack(value)
 
     def get_status(self) -> dict:
@@ -150,6 +196,7 @@ class DaemonController:
             "scanning": self.is_scanning,
             "pairing": self.is_pairing,
             "cursor_running": self.cursor_running(),
+            "audio_enabled": self.audio_enabled,
         }
 
         conn = self.daemon.connection_state

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -110,6 +110,29 @@ class DaemonController:
         except OSError as e:
             logger.warning(f"Could not persist bt_enabled: {errstr(e)}")
 
+    def _audio_mock_running(self) -> bool:
+        """Whether our LIPC mock is the audiomgrd that is actually up.
+
+        The switch records what the user asked for; this reports what is
+        happening. They drifted apart in practice -- the stock daemon came
+        back while /status still said the bypass was on -- and an application
+        asking audiomgrd for an output then correctly got "none".
+        """
+        try:
+            pids = os.listdir("/proc")
+        except OSError:
+            return False
+        for pid in pids:
+            if not pid.isdigit():
+                continue
+            try:
+                with open(f"/proc/{pid}/cmdline", "rb") as f:
+                    if b"lipc_audio_mock.lua" in f.read():
+                        return True
+            except OSError:
+                continue
+        return False
+
     def _audio_hack_script(self, enable: bool):
         name = "start_audio_hack.sh" if enable else "stop_audio_hack.sh"
         for d in self._AUDIO_HACK_DIRS:
@@ -193,6 +216,7 @@ class DaemonController:
             "pairing": self.is_pairing,
             "cursor_running": self.cursor_running(),
             "audio_enabled": self.audio_enabled,
+            "audio_running": self._audio_mock_running(),
         }
 
         conn = self.daemon.connection_state
@@ -218,8 +242,22 @@ class DaemonController:
 
     async def _resume_if_enabled(self):
         """Resume unless BT was toggled off while the op ran."""
-        if self.bt_enabled:
-            await self.daemon.resume()
+        if not self.bt_enabled:
+            return
+        self._restore_audio_hack_if_needed()
+        await self.daemon.resume()
+
+    def _restore_audio_hack_if_needed(self):
+        """Put the bypass back if it went away while we were not looking.
+
+        audiomgrd is an upstart job with respawn, so anything that starts it
+        keeps it alive and takes the LIPC name with it. The start script is
+        idempotent and checks the property itself, so this costs nothing when
+        the bypass is healthy.
+        """
+        if self._audio_enabled and not self._audio_mock_running():
+            logger.info("Audio bypass was down, restoring it")
+            self._spawn_audio_hack(True)
 
     def _get_devices_cached(self) -> list:
         """Device list from devices.conf, cached by file mtime."""

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -212,7 +212,10 @@ class DaemonController:
             asyncio.run_coroutine_threadsafe(self._do_resume(), self.loop)
             return
 
-        protocol = Protocol.CLASSIC if protocol_str == 'classic' else Protocol.BLE
+        try:
+            protocol = Protocol(protocol_str or 'ble')
+        except ValueError:
+            protocol = Protocol.CLASSIC if protocol_str == 'classic' else Protocol.BLE
         asyncio.run_coroutine_threadsafe(
             self._do_connect(address, protocol), self.loop
         )

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -171,7 +171,7 @@ class DaemonController:
         script = self._audio_hack_script(enable)
         if script is None:
             return
-        action = "start" if enable else "stop"
+        action, done = ("start", "started") if enable else ("stop", "stopped")
         try:
             proc = subprocess.run(["/bin/sh", script], timeout=30,
                                   stdout=subprocess.PIPE,
@@ -185,7 +185,7 @@ class DaemonController:
         # whose /mnt/us is FUSE the script aborted creating a symlink while
         # the log still said the hack had started.
         if proc.returncode == 0:
-            logger.info(f"Audio hack {action}ed")
+            logger.info(f"Audio hack {done}")
             return
         logger.warning(f"Audio hack {action} failed (exit {proc.returncode})")
         output = (proc.stdout or b"").decode("utf-8", "replace")

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -75,17 +75,13 @@ class DaemonController:
         return os.path.join(config.cache_dir, "bt_enabled")
 
     def _audio_state_path(self):
-        return os.path.join(config.cache_dir, "audio_enabled")
+        return config.audio_state_file
 
     def _load_audio_state(self) -> bool:
         """Off unless the user turned it on. Unlike HID, which the daemon
         exists for, the bypass replaces a system daemon and cannot be the
         default on hardware nobody has tested it on."""
-        try:
-            with open(self._audio_state_path()) as f:
-                return f.read().strip() == "1"
-        except OSError:
-            return False
+        return config.audio_enabled()
 
     def _persist_audio_state(self, value: bool):
         try:

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -35,7 +35,14 @@ class DaemonController:
 
         self._op_lock = asyncio.Lock()
         self._suspended_by_system = False
-        self.bt_enabled = True
+        # HID on/off survives a reboot: /start and /stop write it to disk
+        # and boot honours what the user left. It used to always come up on.
+        self._bt_enabled = self._load_bt_state()
+        if not self._bt_enabled:
+            logger.info("HID was left off; daemon starts suspended")
+            daemon._suspended = True
+        else:
+            self._spawn_audio_hack(True)
 
         # Scan state
         self.scan_result = None
@@ -54,6 +61,69 @@ class DaemonController:
         # Mouse cursor overlay process
         self._cursor_proc = None
         self._cursor_lock = threading.Lock()
+
+    # ---- Persisted HID state + audio bypass hack ----
+
+    # Shipped location first, development checkout second.
+    _AUDIO_HACK_DIRS = ("assets/audio-hack", "teamwork_audio_hack")
+
+    def _bt_state_path(self):
+        return os.path.join(config.cache_dir, "bt_enabled")
+
+    def _load_bt_state(self) -> bool:
+        try:
+            with open(self._bt_state_path()) as f:
+                return f.read().strip() != "0"
+        except OSError:
+            return True
+
+    def _persist_bt_state(self, value: bool):
+        try:
+            os.makedirs(config.cache_dir, exist_ok=True)
+            tmp = self._bt_state_path() + ".tmp"
+            with open(tmp, "w") as f:
+                f.write("1" if value else "0")
+            os.replace(tmp, self._bt_state_path())
+        except OSError as e:
+            logger.warning(f"Could not persist bt_enabled: {errstr(e)}")
+
+    def _audio_hack_script(self, enable: bool):
+        name = "start_audio_hack.sh" if enable else "stop_audio_hack.sh"
+        for d in self._AUDIO_HACK_DIRS:
+            path = os.path.join(config.base_path, d, name)
+            if os.path.isfile(path):
+                return path
+        return None
+
+    def _spawn_audio_hack(self, enable: bool):
+        """Bring the audio LIPC mock up or down together with HID."""
+        threading.Thread(target=self._run_audio_hack, args=(enable,),
+                         daemon=True).start()
+
+    def _run_audio_hack(self, enable: bool):
+        script = self._audio_hack_script(enable)
+        if script is None:
+            return
+        try:
+            subprocess.run(["/bin/sh", script], timeout=30,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            logger.info(f"Audio hack {'started' if enable else 'stopped'}")
+        except Exception as e:
+            logger.warning(f"Audio hack {'start' if enable else 'stop'} "
+                           f"failed: {errstr(e)}")
+
+    @property
+    def bt_enabled(self) -> bool:
+        return self._bt_enabled
+
+    @bt_enabled.setter
+    def bt_enabled(self, value):
+        value = bool(value)
+        changed = value != getattr(self, "_bt_enabled", None)
+        self._bt_enabled = value
+        if changed:
+            self._persist_bt_state(value)
+            self._spawn_audio_hack(value)
 
     def get_status(self) -> dict:
         """Thread-safe read of daemon state. Called from HTTP thread."""

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -19,6 +19,11 @@ from logging_utils import errstr
 
 logger = logging.getLogger(__name__)
 
+# The stock binary the audio bypass swaps out, and where it keeps it. The
+# wrapper delegates to .real, so the pair is what "installed" means.
+GST_BIN = "/usr/bin/gst-launch-0.10"
+GST_REAL_BIN = GST_BIN + ".real"
+
 __all__ = ['DaemonController']
 
 
@@ -133,6 +138,22 @@ class DaemonController:
                 continue
         return False
 
+    def _gst_wrapper_installed(self) -> bool:
+        """Whether our gst-launch wrapper is the binary the system will run.
+
+        The mock alone is not the bypass. It answers audioOutputConnected,
+        but nothing writes into the FIFO until the wrapper rewrites the
+        pipeline's sink, so the reader drains an empty pipe and the sink
+        receives silence while every switch still reads as on.
+        """
+        if not os.path.isfile(GST_REAL_BIN):
+            return False
+        try:
+            with open(GST_BIN, "rb") as f:
+                return f.read(2) == b"#!"
+        except OSError:
+            return False
+
     def _audio_hack_script(self, enable: bool):
         name = "start_audio_hack.sh" if enable else "stop_audio_hack.sh"
         for d in self._AUDIO_HACK_DIRS:
@@ -190,6 +211,11 @@ class DaemonController:
     def audio_enabled(self) -> bool:
         return self._audio_enabled
 
+    @property
+    def audio_running(self) -> bool:
+        """Whether the bypass is actually up, both halves of it."""
+        return self._audio_mock_running() and self._gst_wrapper_installed()
+
     @audio_enabled.setter
     def audio_enabled(self, value):
         value = bool(value)
@@ -216,7 +242,7 @@ class DaemonController:
             "pairing": self.is_pairing,
             "cursor_running": self.cursor_running(),
             "audio_enabled": self.audio_enabled,
-            "audio_running": self._audio_mock_running(),
+            "audio_running": self.audio_running,
         }
 
         conn = self.daemon.connection_state
@@ -251,11 +277,12 @@ class DaemonController:
         """Put the bypass back if it went away while we were not looking.
 
         audiomgrd is an upstart job with respawn, so anything that starts it
-        keeps it alive and takes the LIPC name with it. The start script is
-        idempotent and checks the property itself, so this costs nothing when
-        the bypass is healthy.
+        keeps it alive and takes the LIPC name with it. An update restores
+        the stock gst-launch the same way. The start script is idempotent and
+        checks both halves itself, so this costs nothing when the bypass is
+        healthy.
         """
-        if self._audio_enabled and not self._audio_mock_running():
+        if self._audio_enabled and not self.audio_running:
             logger.info("Audio bypass was down, restoring it")
             self._spawn_audio_hack(True)
 

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -104,13 +104,27 @@ class DaemonController:
         script = self._audio_hack_script(enable)
         if script is None:
             return
+        action = "start" if enable else "stop"
         try:
-            subprocess.run(["/bin/sh", script], timeout=30,
-                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            logger.info(f"Audio hack {'started' if enable else 'stopped'}")
+            proc = subprocess.run(["/bin/sh", script], timeout=30,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
         except Exception as e:
-            logger.warning(f"Audio hack {'start' if enable else 'stop'} "
-                           f"failed: {errstr(e)}")
+            logger.warning(f"Audio hack {action} failed: {errstr(e)}")
+            return
+
+        # Report what the script actually did. Discarding its output and
+        # logging success unconditionally hid a real failure: on a device
+        # whose /mnt/us is FUSE the script aborted creating a symlink while
+        # the log still said the hack had started.
+        if proc.returncode == 0:
+            logger.info(f"Audio hack {action}ed")
+            return
+        logger.warning(f"Audio hack {action} failed (exit {proc.returncode})")
+        output = (proc.stdout or b"").decode("utf-8", "replace")
+        for line in output.splitlines():
+            if line.strip():
+                logger.warning(f"[audio-hack] {line.rstrip()}")
 
     @property
     def bt_enabled(self) -> bool:

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -288,6 +288,15 @@ async def main():
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, on_signal)
 
+    def handle_exception(loop, context):
+        msg = context.get("exception", context["message"])
+        logger.error(f"Unhandled exception in asyncio loop: {msg}")
+        if "channel not open" in str(msg) or "InvalidStateError" in str(msg):
+            logger.error("Bumble L2CAP/AVDTP channel dropped. Reconnecting...")
+            shutdown.set()
+
+    loop.set_exception_handler(handle_exception)
+
     log.info(f"Kindle HID Passthrough v{get_version()} (daemon)")
     daemon_task = asyncio.create_task(daemon.run())
 

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -291,9 +291,11 @@ async def main():
     def handle_exception(loop, context):
         msg = context.get("exception", context["message"])
         logger.error(f"Unhandled exception in asyncio loop: {msg}")
-        if "channel not open" in str(msg) or "InvalidStateError" in str(msg):
-            logger.error("Bumble L2CAP/AVDTP channel dropped. Reconnecting...")
-            shutdown.set()
+        # An L2CAP write racing an ACL teardown surfaces here whenever a peer
+        # goes out of range. It is not fatal: the reconnect loop handles it,
+        # and shutdown.set() only exits the process -- which upstart respawns,
+        # counting towards the boot_attempts limit that permanently disables
+        # autostart after three tries.
 
     loop.set_exception_handler(handle_exception)
 

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -631,10 +631,7 @@ class HIDHost(ClassicMixin, BLEMixin):
             else:
                 await self._continue_ble_after_pairing(session)
             proto_name = session.protocol.value.upper()
-            from kindle_hid_passthrough.uhid_handler import create_uhid_device
-            if not session.uhid_device:
-                desc = await self._query_classic_sdp(session)
-                session.uhid_device = create_uhid_device(session, desc)
+
             log.success(f"\n[{proto_name}] Paired and receiving HID reports.")
         else:
             log.info("Paired device disconnected; the connect loops will pick it up")

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -2,12 +2,10 @@
 """HID Host — runs BLE + Classic handlers on a single Bumble device."""
 
 import asyncio
-from bumble.core import ProtocolError
-from bumble import avrcp, avc
-
 from dataclasses import dataclass
 from typing import List, Optional
 
+from bumble import avc, avrcp
 from bumble.core import InvalidStateError
 from bumble.hci import (
     HCI_LE_SET_PRIVACY_MODE_COMMAND,
@@ -23,7 +21,7 @@ from bt_setup import ensure_uhid
 from classic import ClassicMixin
 from config import Protocol, clean_device_name, config, get_version, normalize_addr
 from device_cache import DeviceCache
-from logging_utils import log
+from logging_utils import errstr, log
 from media_remote import MEDIA_REMOTE_COD, MediaRemote
 from pairing import create_keystore, create_pairing_config
 from transport import create_bumble_device
@@ -140,16 +138,14 @@ class KindleAvrcpDelegate(avrcp.Delegate):
         pressed: bool,
         operation_data: bytes
     ) -> None:
-        import logging
-        log = logging.getLogger(__name__)
         log.info(f"[AVRCP] Key {operation_id.name} {'pressed' if pressed else 'released'}")
-        
+
         target_session = None
         for session in self.host.sessions.values():
             if session.protocol.value == "classic_audio" and session.uhid_device:
                 target_session = session
                 break
-                
+
         if not target_session:
             return
 
@@ -173,6 +169,12 @@ class KindleAvrcpDelegate(avrcp.Delegate):
             bitmask = 0x08 # Bit 3
         elif operation_id == avc.PassThroughFrame.OperationId.VOLUME_DOWN:
             bitmask = 0x10 # Bit 4
+
+        if bitmask == 0:
+            # A key the injected descriptor does not declare. Sending the
+            # report anyway announced "every key released" to the kernel,
+            # which cancels a key the peer is still holding down.
+            return
 
         # Send report with Report ID 1
         report = bytes([0x01, bitmask if pressed else 0x00])
@@ -310,22 +312,14 @@ class HIDHost(ClassicMixin, BLEMixin):
             )
             log.info(f"Classic enabled: CoD 0x{class_of_device:06X}")
 
-            from bumble.a2dp import (
-                A2DP_SBC_CODEC_TYPE,
-                SbcMediaCodecInformation,
-                make_audio_source_service_sdp_records,
-            )
-            from bumble.avdtp import (
-                AVDTP_AUDIO_MEDIA_TYPE,
-                Listener,
-                MediaCodecCapabilities,
-            )
+            from bumble.a2dp import make_audio_source_service_sdp_records
+            from bumble.avdtp import Listener
 
             # A2DP Source setup
             self.a2dp_listener = Listener.for_device(device=self.device)
             self.avrcp_protocol = avrcp.Protocol(KindleAvrcpDelegate(self))
             self.avrcp_protocol.listen(self.device)
-            
+
             handle = 0x00010002
             self.device.sdp_service_records.update({
                 handle: make_audio_source_service_sdp_records(service_record_handle=handle)
@@ -551,6 +545,11 @@ class HIDHost(ClassicMixin, BLEMixin):
         if session.closed:
             await session.teardown_done.wait()
             return
+        if session.protocol == Protocol.CLASSIC_AUDIO:
+            # The pump dies on its own when the RTP channel goes, but the
+            # streamer stays behind holding the FIFO open, and _audio_session
+            # keeps reporting a live session to /media/*.
+            await self._close_audio_session()
         was_pointer = session.is_pointer and session.uhid_device is not None
         await session.cleanup()
         if was_pointer and self._pointer_count() == 0:
@@ -670,10 +669,18 @@ class HIDHost(ClassicMixin, BLEMixin):
 
 
     async def _continue_classic_audio_after_pairing(self, session):
-        from bumble.avdtp import Protocol as AvdtpProtocol, StreamEndPointType, State, MediaPacketPump, RealtimeClock
-        from bumble.rtp import MediaPacket
-        from bumble.avdtp import MediaCodecCapabilities, AVDTP_AUDIO_MEDIA_TYPE
         from bumble.a2dp import A2DP_SBC_CODEC_TYPE, SbcMediaCodecInformation
+        from bumble.avdtp import (
+            AVDTP_AUDIO_MEDIA_TYPE,
+            MediaCodecCapabilities,
+            MediaPacketPump,
+            RealtimeClock,
+            StreamEndPointType,
+        )
+        from bumble.avdtp import (
+            Protocol as AvdtpProtocol,
+        )
+        from bumble.rtp import MediaPacket
 
         log.info("[Classic] Audio device connected. Initiating AVDTP...")
 
@@ -681,7 +688,7 @@ class HIDHost(ClassicMixin, BLEMixin):
         # own sequence numbers into the same channel and the sink decodes the
         # interleaved streams as noise.
         await self._close_audio_session()
-        
+
         codec_caps = MediaCodecCapabilities(
             media_type=AVDTP_AUDIO_MEDIA_TYPE,
             media_codec_type=A2DP_SBC_CODEC_TYPE,
@@ -720,13 +727,14 @@ class HIDHost(ClassicMixin, BLEMixin):
                     log.error(f"Failed to establish AVDTP connection: {e}")
                     return
 
-        from audio_pipe import FifoAudioStreamer, SAMPLES_PER_FRAME, FRAMES_PER_PACKET
-        audio_streamer = FifoAudioStreamer(fifo_path="/tmp/kindle_audio.fifo")
+        from audio_pipe import FRAMES_PER_PACKET, SAMPLES_PER_FRAME, FifoAudioStreamer
+        audio_streamer = FifoAudioStreamer()
         samples_per_packet = SAMPLES_PER_FRAME * FRAMES_PER_PACKET
 
         async def packet_generator():
             seq = 0
             ts = 0
+            samples = 0
             try:
                 while True:
                     payload = audio_streamer.get_next_payload()
@@ -735,36 +743,55 @@ class HIDHost(ClassicMixin, BLEMixin):
                         sequence_number=seq, timestamp=ts, ssrc=0,
                         csrc_list=[], payload_type=96, payload=payload
                     )
-                    packet.timestamp_seconds = ts / 44100.0
+                    # The RTP timestamp wraps at 32 bits, but the pump paces
+                    # off timestamp_seconds: feeding it the wrapped value makes
+                    # the clock jump back to zero after ~27 h of streaming and
+                    # the pump then sends without ever sleeping again.
+                    packet.timestamp_seconds = samples / 44100.0
                     yield packet
                     seq = (seq + 1) & 0xFFFF
-                    ts = (ts + samples_per_packet) & 0xFFFFFFFF
+                    samples += samples_per_packet
+                    ts = samples & 0xFFFFFFFF
             finally:
                 audio_streamer.close()
 
         pump = MediaPacketPump(packet_generator(), RealtimeClock())
         self._audio_session = (pump, audio_streamer)
-        
-        # This creates the LocalSource, binds the pump, and registers it to the protocol
-        source = avdtp_protocol.add_source(codec_caps, pump)
 
-        endpoints = await avdtp_protocol.discover_remote_endpoints()
-        sink_endpoint = next((e for e in endpoints if e.tsep == StreamEndPointType.SNK), None)
-        if not sink_endpoint:
-            log.error("No AVDTP SINK endpoints found on remote")
+        # From here the session owns an open FIFO, so every way out has to
+        # release it: leaving _audio_session populated by a stream that never
+        # started made /media/* report a live session and leaked the
+        # descriptor for the life of the process.
+        try:
+            # Creates the LocalSource, binds the pump, registers it to the protocol
+            source = avdtp_protocol.add_source(codec_caps, pump)
+
+            endpoints = await avdtp_protocol.discover_remote_endpoints()
+            sink_endpoint = next(
+                (e for e in endpoints if e.tsep == StreamEndPointType.SNK), None)
+            if not sink_endpoint:
+                log.error("No AVDTP SINK endpoints found on remote")
+                await self._close_audio_session()
+                return
+
+            log.info(f"Found remote SINK endpoint: {sink_endpoint.seid}")
+
+            stream = await avdtp_protocol.create_stream(source, sink_endpoint)
+            log.info("Configured stream. Opening...")
+
+            await stream.open()
+            log.info("Stream opened. Starting...")
+
+            # Starting the stream makes Bumble call source.start(), which
+            # starts the pump in a task it tracks itself.
+            await stream.start()
+        except asyncio.CancelledError:
+            await self._close_audio_session()
+            raise
+        except Exception as e:
+            log.error(f"[Classic Audio] AVDTP setup failed: {errstr(e)}")
+            await self._close_audio_session()
             return
-
-        log.info(f"Found remote SINK endpoint: {sink_endpoint.seid}")
-        
-        stream = await avdtp_protocol.create_stream(source, sink_endpoint)
-        log.info("Configured stream. Opening...")
-        
-        await stream.open()
-        log.info("Stream opened. Starting...")
-        
-        # When we start the stream, Bumble automatically calls source.start() which starts the pump
-        # inside an internal asyncio task tracking it automatically!
-        await stream.start()
         log.success("[Classic Audio] AVDTP streaming started! Injecting silence...")
 
         # FIX: Create UHID device for AVRCP media keys
@@ -882,7 +909,10 @@ class HIDHost(ClassicMixin, BLEMixin):
 
     async def cleanup(self):
         """Clean up resources."""
-        await self._close_audio_session()
+        # Producers first: _close_audio_session awaits, and the task that sets
+        # up AVDTP spends seconds between connect and start. Closing first let
+        # that task install a fresh streamer into the session we had just
+        # emptied, and its FIFO descriptor was then never released.
         if self._connection_tasks:
             pending = list(self._connection_tasks)
             for task in pending:
@@ -893,6 +923,7 @@ class HIDHost(ClassicMixin, BLEMixin):
             except Exception:
                 pass
             self._connection_tasks.clear()
+        await self._close_audio_session()
 
         had_pointer = self._pointer_count() > 0
         for session in list(self.sessions.values()):

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -435,16 +435,6 @@ class HIDHost(ClassicMixin, BLEMixin):
                 raise InvalidStateError("No device connected within timeout")
 
     def _notify_sessions_changed(self):
-        import os
-        try:
-            if self.sessions:
-                os.system("lipc-set-prop com.lab126.audiomgrd audioOutput A2DP")
-                os.system("lipc-set-prop com.lab126.audiomgrd audioState PLAYING")
-            else:
-                os.system("lipc-set-prop com.lab126.audiomgrd audioOutput NONE")
-                os.system("lipc-set-prop com.lab126.audiomgrd audioState STOPPED")
-        except Exception:
-            pass
         if self._sessions_changed:
             self._sessions_changed.set()
 

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -686,8 +686,15 @@ class HIDHost(ClassicMixin, BLEMixin):
                 avdtp_protocol = await AvdtpProtocol.connect(session.connection)
                 self.a2dp_listener.set_server(session.connection, avdtp_protocol)
             except Exception as e:
-                log.error(f"Failed to connect AVDTP: {e}")
-                return
+                log.warning(f"Failed to connect AVDTP: {e}")
+                # Race condition: Remote might be connecting to us. Wait a bit and check servers.
+                await asyncio.sleep(1.0)
+                avdtp_protocol = self.a2dp_listener.servers.get(session.connection.handle)
+                if avdtp_protocol:
+                    log.info("Picked up inbound AVDTP connection from remote after outbound failure")
+                else:
+                    log.error(f"Failed to establish AVDTP connection: {e}")
+                    return
 
         from audio_pipe import FifoAudioStreamer, SAMPLES_PER_FRAME, FRAMES_PER_PACKET
         audio_streamer = FifoAudioStreamer(fifo_path="/tmp/kindle_audio.fifo")

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -631,6 +631,25 @@ class HIDHost(ClassicMixin, BLEMixin):
         from bumble.a2dp import A2DP_SBC_CODEC_TYPE, SbcMediaCodecInformation
 
         log.info("[Classic] Audio device connected. Initiating AVDTP...")
+
+        # Uma sessao de audio por vez. Sem isto cada reconexao deixa o pump
+        # anterior vivo empurrando RTP com sequencia propria no mesmo canal:
+        # o sink recebe dois fluxos embaralhados e decodifica ruido.
+        prev = getattr(self, "_audio_session", None)
+        if prev:
+            log.info("[Classic Audio] Closing previous audio session...")
+            prev_pump, prev_streamer = prev
+            self._audio_session = None
+            try:
+                if prev_pump is not None:
+                    await prev_pump.stop()
+            except Exception as e:
+                log.warning(f"[Classic Audio] previous pump did not stop: {e}")
+            try:
+                if prev_streamer is not None:
+                    prev_streamer.close()
+            except Exception as e:
+                log.warning(f"[Classic Audio] previous streamer did not close: {e}")
         
         codec_caps = MediaCodecCapabilities(
             media_type=AVDTP_AUDIO_MEDIA_TYPE,
@@ -686,6 +705,7 @@ class HIDHost(ClassicMixin, BLEMixin):
                 audio_streamer.close()
 
         pump = MediaPacketPump(packet_generator(), RealtimeClock())
+        self._audio_session = (pump, audio_streamer)
         
         # This creates the LocalSource, binds the pump, and registers it to the protocol
         source = avdtp_protocol.add_source(codec_caps, pump)

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -5,9 +5,6 @@ import asyncio
 from bumble.core import ProtocolError
 from bumble import avrcp, avc
 
-from bumble.core import ProtocolError
-from bumble import avrcp, avc
-
 from dataclasses import dataclass
 from typing import List, Optional
 

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -152,12 +152,13 @@ class KindleAvrcpDelegate(avrcp.Delegate):
         # We use a 1-byte report for Report ID 1.
         # Bits: [0: Next, 1: Prev, 2: Play/Pause, 3: VolUp, 4: VolDown, 5-7: padding]
         bitmask = 0x00
+        # Media keys are forwarded to the button mapper and nothing else: the
+        # daemon must not act on a key the user never mapped. Pressing
+        # Play/Pause used to toggle the audio pause here as well, so an unmapped
+        # button still paused, and a button mapped to something else did both.
+        # Universal pause lives behind /media/toggle, /media/play and
+        # /media/pause, which the mapper -- or anything else -- can call.
         if operation_id in (avc.PassThroughFrame.OperationId.PLAY, avc.PassThroughFrame.OperationId.PAUSE):
-            if pressed and hasattr(self.host, '_audio_session') and self.host._audio_session:
-                audio_streamer = self.host._audio_session[1]
-                if audio_streamer:
-                    audio_streamer.toggle_pause()
-                    log.info(f"Audio pause state toggled to {audio_streamer.paused}")
             bitmask = 0x04 # Bit 2
         elif operation_id in (avc.PassThroughFrame.OperationId.FORWARD, avc.PassThroughFrame.OperationId.UP, avc.PassThroughFrame.OperationId.RIGHT):
             bitmask = 0x01 # Bit 0

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -156,6 +156,11 @@ class KindleAvrcpDelegate(avrcp.Delegate):
         # Bits: [0: Next, 1: Prev, 2: Play/Pause, 3: VolUp, 4: VolDown, 5-7: padding]
         bitmask = 0x00
         if operation_id in (avc.PassThroughFrame.OperationId.PLAY, avc.PassThroughFrame.OperationId.PAUSE):
+            if pressed and hasattr(self.host, '_audio_session') and self.host._audio_session:
+                audio_streamer = self.host._audio_session[1]
+                if audio_streamer:
+                    audio_streamer.toggle_pause()
+                    log.info(f"Audio pause state toggled to {audio_streamer.paused}")
             bitmask = 0x04 # Bit 2
         elif operation_id in (avc.PassThroughFrame.OperationId.FORWARD, avc.PassThroughFrame.OperationId.UP, avc.PassThroughFrame.OperationId.RIGHT):
             bitmask = 0x01 # Bit 0

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -731,6 +731,10 @@ class HIDHost(ClassicMixin, BLEMixin):
         await stream.start()
         log.success("[Classic Audio] AVDTP streaming started! Injecting silence...")
 
+        # FIX: Create UHID device for AVRCP media keys
+        if not session.uhid_device:
+            self._create_uhid_device(session)
+
     # ==================== COMMON ====================
 
     def _forward_report(self, session: DeviceSession, data: bytes):

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -312,7 +312,7 @@ class HIDHost(ClassicMixin, BLEMixin):
             )
 
         if self.media_remote:
-            self.media_remote.setup(self.device)
+            self.media_remote.setup(self.device, getattr(self, 'a2dp_listener', None), getattr(self, 'avrcp_protocol', None))
 
         if self.ble_devices:
             log.info("BLE enabled")

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -2,6 +2,12 @@
 """HID Host — runs BLE + Classic handlers on a single Bumble device."""
 
 import asyncio
+from bumble.core import ProtocolError
+from bumble import avrcp, avc
+
+from bumble.core import ProtocolError
+from bumble import avrcp, avc
+
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -114,7 +120,49 @@ class DeviceSession:
             self.teardown_done.set()
 
 
+
+class KindleAvrcpDelegate(avrcp.Delegate):
+    def __init__(self, host):
+        super().__init__()
+        self.host = host
+
+    async def on_key_event(
+        self,
+        operation_id: avc.PassThroughFrame.OperationId,
+        pressed: bool,
+        operation_data: bytes
+    ) -> None:
+        import logging
+        log = logging.getLogger(__name__)
+        log.info(f"[AVRCP] Key {operation_id.name} {'pressed' if pressed else 'released'}")
+        
+        target_session = None
+        for session in self.host.sessions.values():
+            if session.protocol.value == "classic_audio" and session.uhid_device:
+                target_session = session
+                break
+                
+        if not target_session:
+            return
+
+        keycode = 0x00
+        if operation_id in (avc.PassThroughFrame.OperationId.PLAY, avc.PassThroughFrame.OperationId.PAUSE):
+            keycode = 0x4E # PageDown
+        elif operation_id in (avc.PassThroughFrame.OperationId.FORWARD, avc.PassThroughFrame.OperationId.VOLUME_UP, avc.PassThroughFrame.OperationId.UP, avc.PassThroughFrame.OperationId.RIGHT):
+            keycode = 0x4E # PageDown
+        elif operation_id in (avc.PassThroughFrame.OperationId.BACKWARD, avc.PassThroughFrame.OperationId.VOLUME_DOWN, avc.PassThroughFrame.OperationId.DOWN, avc.PassThroughFrame.OperationId.LEFT):
+            keycode = 0x4B # PageUp
+        else:
+            keycode = 0x4E
+
+        report = bytes([0x01, 0x00, 0x00, keycode if pressed else 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        try:
+            target_session.uhid_device.send_input(report)
+        except Exception as e:
+            log.error(f"Failed to send AVRCP input: {e}")
+
 class HIDHost(ClassicMixin, BLEMixin):
+
     """HID Host supporting both BLE and Classic Bluetooth.
 
     Protocol-specific handlers live in ClassicMixin and BLEMixin.
@@ -176,7 +224,7 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         for addr, protocol, name in devices:
             dev = DeviceConfig(address=addr, protocol=protocol, name=name)
-            if protocol == Protocol.CLASSIC:
+            if protocol in (Protocol.CLASSIC, Protocol.CLASSIC_AUDIO):
                 self.classic_devices.append(dev)
             else:
                 self.ble_devices.append(dev)
@@ -211,12 +259,34 @@ class HIDHost(ClassicMixin, BLEMixin):
         # Classic-specific setup
         if self.classic_devices or self.media_remote:
             class_of_device = (MEDIA_REMOTE_COD if self.media_remote
-                               else 0x000104)
+                               else 0x200104)
             await self.device.host.send_command(
                 HCI_Write_Class_Of_Device_Command(class_of_device=class_of_device),
                 check_result=True
             )
             log.info(f"Classic enabled: CoD 0x{class_of_device:06X}")
+
+            from bumble.a2dp import (
+                A2DP_SBC_CODEC_TYPE,
+                SbcMediaCodecInformation,
+                make_audio_source_service_sdp_records,
+            )
+            from bumble.avdtp import (
+                AVDTP_AUDIO_MEDIA_TYPE,
+                Listener,
+                MediaCodecCapabilities,
+            )
+
+            # A2DP Source setup
+            self.a2dp_listener = Listener.for_device(device=self.device)
+            self.avrcp_protocol = avrcp.Protocol(KindleAvrcpDelegate(self))
+            self.avrcp_protocol.listen(self.device)
+            
+            handle = 0x00010002
+            self.device.sdp_service_records.update({
+                handle: make_audio_source_service_sdp_records(service_record_handle=handle)
+            })
+            log.info("A2DP Source SDP records configured. AVDTP Listener active.")
 
             local_name_bytes = config.device_name.encode('utf-8') + b'\x00'
             await self.device.host.send_command(
@@ -365,6 +435,16 @@ class HIDHost(ClassicMixin, BLEMixin):
                 raise InvalidStateError("No device connected within timeout")
 
     def _notify_sessions_changed(self):
+        import os
+        try:
+            if self.sessions:
+                os.system("lipc-set-prop com.lab126.audiomgrd audioOutput A2DP")
+                os.system("lipc-set-prop com.lab126.audiomgrd audioState PLAYING")
+            else:
+                os.system("lipc-set-prop com.lab126.audiomgrd audioOutput NONE")
+                os.system("lipc-set-prop com.lab126.audiomgrd audioState STOPPED")
+        except Exception:
+            pass
         if self._sessions_changed:
             self._sessions_changed.set()
 
@@ -508,15 +588,15 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         self._parse_devices()
 
-        bucket = self.classic_devices if protocol == Protocol.CLASSIC else self.ble_devices
+        bucket = self.classic_devices if protocol in (Protocol.CLASSIC, Protocol.CLASSIC_AUDIO) else self.ble_devices
         norm = normalize_addr(address)
         if not any(d.address != '*' and normalize_addr(d.address) == norm for d in bucket):
             bucket.append(DeviceConfig(address=address, protocol=protocol, name=name))
 
         await self.start(pairing=True)
 
-        if protocol == Protocol.CLASSIC:
-            return await self._pair_classic(address)
+        if protocol in (Protocol.CLASSIC, Protocol.CLASSIC_AUDIO):
+            return await self._pair_classic(address, protocol)
         else:
             return await self._pair_ble(address)
 
@@ -532,11 +612,18 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         if session.is_alive():
             self._register_session(session)
-            if session.protocol == Protocol.CLASSIC:
-                await self._continue_classic_after_pairing(session)
+            if session.protocol in (Protocol.CLASSIC, Protocol.CLASSIC_AUDIO):
+                if session.protocol == Protocol.CLASSIC:
+                    await self._continue_classic_after_pairing(session)
+                else:
+                    await self._continue_classic_audio_after_pairing(session)
             else:
                 await self._continue_ble_after_pairing(session)
             proto_name = session.protocol.value.upper()
+            from kindle_hid_passthrough.uhid_handler import create_uhid_device
+            if not session.uhid_device:
+                desc = await self._query_classic_sdp(session)
+                session.uhid_device = create_uhid_device(session, desc)
             log.success(f"\n[{proto_name}] Paired and receiving HID reports.")
         else:
             log.info("Paired device disconnected; the connect loops will pick it up")
@@ -544,6 +631,93 @@ class HIDHost(ClassicMixin, BLEMixin):
         self._parse_devices()
         await self._load_keystore_addresses()
         await self._serve()
+
+
+
+    async def _continue_classic_audio_after_pairing(self, session):
+        from bumble.avdtp import Protocol as AvdtpProtocol, StreamEndPointType, State, MediaPacketPump, RealtimeClock
+        from bumble.rtp import MediaPacket
+        from bumble.avdtp import MediaCodecCapabilities, AVDTP_AUDIO_MEDIA_TYPE
+        from bumble.a2dp import A2DP_SBC_CODEC_TYPE, SbcMediaCodecInformation
+
+        log.info("[Classic] Audio device connected. Initiating AVDTP...")
+        
+        codec_caps = MediaCodecCapabilities(
+            media_type=AVDTP_AUDIO_MEDIA_TYPE,
+            media_codec_type=A2DP_SBC_CODEC_TYPE,
+            media_codec_information=SbcMediaCodecInformation(
+                sampling_frequency=SbcMediaCodecInformation.SamplingFrequency.SF_44100,
+                channel_mode=SbcMediaCodecInformation.ChannelMode.JOINT_STEREO,
+                block_length=SbcMediaCodecInformation.BlockLength.BL_16,
+                subbands=SbcMediaCodecInformation.Subbands.S_8,
+                allocation_method=SbcMediaCodecInformation.AllocationMethod.LOUDNESS,
+                minimum_bitpool_value=2,
+                maximum_bitpool_value=53,
+            ),
+        )
+
+        avdtp_protocol = self.a2dp_listener.servers.get(session.connection.handle)
+        if avdtp_protocol and getattr(avdtp_protocol, 'l2cap_channel', None):
+            from bumble.l2cap import ClassicChannel
+            if avdtp_protocol.l2cap_channel.state != ClassicChannel.State.OPEN:
+                del self.a2dp_listener.servers[session.connection.handle]
+                avdtp_protocol = None
+        if avdtp_protocol:
+            log.info("AVDTP already connected by remote")
+        else:
+            try:
+                log.info("Connecting AVDTP to remote...")
+                avdtp_protocol = await AvdtpProtocol.connect(session.connection)
+                self.a2dp_listener.set_server(session.connection, avdtp_protocol)
+            except Exception as e:
+                log.error(f"Failed to connect AVDTP: {e}")
+                return
+
+        from audio_pipe import FifoAudioStreamer, SAMPLES_PER_FRAME, FRAMES_PER_PACKET
+        audio_streamer = FifoAudioStreamer(fifo_path="/tmp/kindle_audio.fifo")
+        samples_per_packet = SAMPLES_PER_FRAME * FRAMES_PER_PACKET
+
+        async def packet_generator():
+            seq = 0
+            ts = 0
+            try:
+                while True:
+                    payload = audio_streamer.get_next_payload()
+                    packet = MediaPacket(
+                        version=2, padding=0, extension=0, marker=0,
+                        sequence_number=seq, timestamp=ts, ssrc=0,
+                        csrc_list=[], payload_type=96, payload=payload
+                    )
+                    packet.timestamp_seconds = ts / 44100.0
+                    yield packet
+                    seq = (seq + 1) & 0xFFFF
+                    ts = (ts + samples_per_packet) & 0xFFFFFFFF
+            finally:
+                audio_streamer.close()
+
+        pump = MediaPacketPump(packet_generator(), RealtimeClock())
+        
+        # This creates the LocalSource, binds the pump, and registers it to the protocol
+        source = avdtp_protocol.add_source(codec_caps, pump)
+
+        endpoints = await avdtp_protocol.discover_remote_endpoints()
+        sink_endpoint = next((e for e in endpoints if e.tsep == StreamEndPointType.SNK), None)
+        if not sink_endpoint:
+            log.error("No AVDTP SINK endpoints found on remote")
+            return
+
+        log.info(f"Found remote SINK endpoint: {sink_endpoint.seid}")
+        
+        stream = await avdtp_protocol.create_stream(source, sink_endpoint)
+        log.info("Configured stream. Opening...")
+        
+        await stream.open()
+        log.info("Stream opened. Starting...")
+        
+        # When we start the stream, Bumble automatically calls source.start() which starts the pump
+        # inside an internal asyncio task tracking it automatically!
+        await stream.start()
+        log.success("[Classic Audio] AVDTP streaming started! Injecting silence...")
 
     # ==================== COMMON ====================
 

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -632,24 +632,10 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         log.info("[Classic] Audio device connected. Initiating AVDTP...")
 
-        # Uma sessao de audio por vez. Sem isto cada reconexao deixa o pump
-        # anterior vivo empurrando RTP com sequencia propria no mesmo canal:
-        # o sink recebe dois fluxos embaralhados e decodifica ruido.
-        prev = getattr(self, "_audio_session", None)
-        if prev:
-            log.info("[Classic Audio] Closing previous audio session...")
-            prev_pump, prev_streamer = prev
-            self._audio_session = None
-            try:
-                if prev_pump is not None:
-                    await prev_pump.stop()
-            except Exception as e:
-                log.warning(f"[Classic Audio] previous pump did not stop: {e}")
-            try:
-                if prev_streamer is not None:
-                    prev_streamer.close()
-            except Exception as e:
-                log.warning(f"[Classic Audio] previous streamer did not close: {e}")
+        # One audio session at a time: a stale pump keeps pushing RTP with its
+        # own sequence numbers into the same channel and the sink decodes the
+        # interleaved streams as noise.
+        await self._close_audio_session()
         
         codec_caps = MediaCodecCapabilities(
             media_type=AVDTP_AUDIO_MEDIA_TYPE,
@@ -798,8 +784,34 @@ class HIDHost(ClassicMixin, BLEMixin):
         except Exception as e:
             log.warning(f"cursor hook failed: {e}")
 
+    async def _close_audio_session(self):
+        """Stop the pump and close the FIFO of the current audio session.
+
+        Called both before opening a new session and from cleanup(). A
+        suspend/resume builds a fresh host, so keying the teardown only on the
+        next session start leaked one FIFO descriptor per on/off cycle:
+        measured 2 -> 3 -> 4 open descriptors over two /stop + /start cycles.
+        """
+        prev = getattr(self, "_audio_session", None)
+        if not prev:
+            return
+        log.info("[Classic Audio] Closing previous audio session...")
+        prev_pump, prev_streamer = prev
+        self._audio_session = None
+        try:
+            if prev_pump is not None:
+                await prev_pump.stop()
+        except Exception as e:
+            log.warning(f"[Classic Audio] previous pump did not stop: {e}")
+        try:
+            if prev_streamer is not None:
+                prev_streamer.close()
+        except Exception as e:
+            log.warning(f"[Classic Audio] previous streamer did not close: {e}")
+
     async def cleanup(self):
         """Clean up resources."""
+        await self._close_audio_session()
         if self._connection_tasks:
             pending = list(self._connection_tasks)
             for task in pending:

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -151,17 +151,23 @@ class KindleAvrcpDelegate(avrcp.Delegate):
         if not target_session:
             return
 
-        keycode = 0x00
-        if operation_id in (avc.PassThroughFrame.OperationId.PLAY, avc.PassThroughFrame.OperationId.PAUSE):
-            keycode = 0x4E # PageDown
-        elif operation_id in (avc.PassThroughFrame.OperationId.FORWARD, avc.PassThroughFrame.OperationId.VOLUME_UP, avc.PassThroughFrame.OperationId.UP, avc.PassThroughFrame.OperationId.RIGHT):
-            keycode = 0x4E # PageDown
-        elif operation_id in (avc.PassThroughFrame.OperationId.BACKWARD, avc.PassThroughFrame.OperationId.VOLUME_DOWN, avc.PassThroughFrame.OperationId.DOWN, avc.PassThroughFrame.OperationId.LEFT):
-            keycode = 0x4B # PageUp
-        else:
-            keycode = 0x4E
 
-        report = bytes([0x01, 0x00, 0x00, keycode if pressed else 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        # We use a 1-byte report for Report ID 1.
+        # Bits: [0: Next, 1: Prev, 2: Play/Pause, 3: VolUp, 4: VolDown, 5-7: padding]
+        bitmask = 0x00
+        if operation_id in (avc.PassThroughFrame.OperationId.PLAY, avc.PassThroughFrame.OperationId.PAUSE):
+            bitmask = 0x04 # Bit 2
+        elif operation_id in (avc.PassThroughFrame.OperationId.FORWARD, avc.PassThroughFrame.OperationId.UP, avc.PassThroughFrame.OperationId.RIGHT):
+            bitmask = 0x01 # Bit 0
+        elif operation_id in (avc.PassThroughFrame.OperationId.BACKWARD, avc.PassThroughFrame.OperationId.DOWN, avc.PassThroughFrame.OperationId.LEFT):
+            bitmask = 0x02 # Bit 1
+        elif operation_id == avc.PassThroughFrame.OperationId.VOLUME_UP:
+            bitmask = 0x08 # Bit 3
+        elif operation_id == avc.PassThroughFrame.OperationId.VOLUME_DOWN:
+            bitmask = 0x10 # Bit 4
+
+        # Send report with Report ID 1
+        report = bytes([0x01, bitmask if pressed else 0x00])
         try:
             target_session.uhid_device.send_input(report)
         except Exception as e:
@@ -751,6 +757,18 @@ class HIDHost(ClassicMixin, BLEMixin):
 
     def _create_uhid_device(self, session: DeviceSession):
         """Create UHID virtual device."""
+
+        if not session.report_map and session.protocol.value == "classic_audio":
+            # Dummy Consumer Control (Media Keys) Descriptor
+            session.report_map = bytes([
+                0x05, 0x0C, 0x09, 0x01, 0xA1, 0x01, 0x85, 0x01,
+                0x15, 0x00, 0x25, 0x01, 0x75, 0x01, 0x95, 0x05,
+                0x09, 0xB5, 0x09, 0xB6, 0x09, 0xCD, 0x09, 0xE9,
+                0x09, 0xEA, 0x81, 0x02, 0x95, 0x03, 0x81, 0x03,
+                0xC0
+            ])
+            log.info("Injected dummy Media Keys descriptor for audio device")
+
         if not session.report_map:
             log.warning("No report descriptor for UHID")
             return

--- a/kindle_hid_passthrough/main.py
+++ b/kindle_hid_passthrough/main.py
@@ -217,7 +217,10 @@ def main():
 
     protocol_override = None
     if args.protocol:
-        protocol_override = Protocol.CLASSIC if args.protocol == 'classic' else Protocol.BLE
+        try:
+            protocol_override = Protocol(args.protocol)
+        except ValueError:
+            protocol_override = Protocol.CLASSIC if args.protocol == 'classic' else Protocol.BLE
 
     if args.pair:
         asyncio.run(pair_mode(protocol_override, sequential=args.sequential))

--- a/kindle_hid_passthrough/main.py
+++ b/kindle_hid_passthrough/main.py
@@ -188,7 +188,8 @@ def main():
                         help='Run as daemon with auto-reconnect + API server')
     parser.add_argument('--address', type=str,
                         help='Device address (overrides devices.conf)')
-    parser.add_argument('--protocol', type=str, choices=['ble', 'classic'],
+    parser.add_argument('--protocol', type=str,
+                        choices=['ble', 'classic', 'classic_audio'],
                         help='Filter by protocol (pairing) or override (run)')
     parser.add_argument('--sequential', action='store_true',
                         help='Scan BLE and Classic sequentially')

--- a/kindle_hid_passthrough/media_remote.py
+++ b/kindle_hid_passthrough/media_remote.py
@@ -51,6 +51,19 @@ class _Delegate(avrcp.Delegate):
         super().__init__(supported_events=[avrcp.EventId.VOLUME_CHANGED])
         self.remote = remote
         self.volume = RECENTER_VOLUME
+        self._also = None
+
+    def chain_key_events_to(self, delegate):
+        """Also hand passthrough keys to another delegate.
+
+        The protocol holds one delegate, and both consumers need something
+        from it: this one declares VOLUME_CHANGED and implements
+        set_absolute_volume, the host's turns media keys into HID reports.
+        Keeping this one and forwarding keys preserves both; wrapping them in
+        a plain multiplexer lost supported_events and the volume override,
+        which silently disabled page turns from the phone.
+        """
+        self._also = delegate if delegate is not self else None
 
     async def set_absolute_volume(self, volume: int) -> None:
         previous = self.volume
@@ -59,6 +72,8 @@ class _Delegate(avrcp.Delegate):
 
     async def on_key_event(self, key, pressed, data) -> None:
         self.remote.on_passthrough(key, pressed)
+        if self._also is not None:
+            await self._also.on_key_event(key, pressed, data)
 
 
 class MediaRemote:
@@ -78,50 +93,32 @@ class MediaRemote:
 
         Must run inside the event loop: avrcp.Protocol creates futures.
         """
-        device.sdp_service_records = {
-            0x00010001: a2dp.make_audio_sink_service_sdp_records(0x00010001),
-            0x00010002: avrcp.ControllerServiceSdpRecord(
-                0x00010002).to_service_attributes(),
-            0x00010003: avrcp.TargetServiceSdpRecord(
-                0x00010003,
+        # update, not assignment: the host publishes the A2DP Source record
+        # before calling this, and replacing the dict dropped it -- the Kindle
+        # then advertised a sink and no source. Handles must not collide with
+        # the host's 0x00010002 either.
+        device.sdp_service_records.update({
+            0x00010011: a2dp.make_audio_sink_service_sdp_records(0x00010011),
+            0x00010012: avrcp.ControllerServiceSdpRecord(
+                0x00010012).to_service_attributes(),
+            0x00010013: avrcp.TargetServiceSdpRecord(
+                0x00010013,
                 supported_features=(avrcp.TargetFeatures.CATEGORY_1
                                     | avrcp.TargetFeatures.CATEGORY_2),
             ).to_service_attributes(),
-        }
+        })
         if listener is None:
             listener = avdtp.Listener.for_device(device)
         listener.on(listener.EVENT_CONNECTION, self._on_avdtp_connection)
-        
+
         if avrcp_protocol is None:
             self.avrcp = avrcp.Protocol(delegate=self.delegate)
             self.avrcp.listen(device)
         else:
             self.avrcp = avrcp_protocol
-            # Note: The delegate of the shared avrcp_protocol needs to handle both!
-            # Since host.py provides KindleAvrcpDelegate, and media_remote has its own delegate,
-            # this might mean media_remote will miss events. We should use a multiplexing delegate or 
-            # just hook into the existing one. For now we will overwrite the delegate to self.delegate
-            # or maybe chaining them is better. Wait!
-            
-            # Since MediaRemote uses AVRCP to receive Volume keys and map to page turns,
-            # and KindleAvrcpDelegate uses it for Play/Pause, we need both.
-            # Let's chain them!
-            original_delegate = self.avrcp.delegate
-            
-            class MultiplexDelegate(avrcp.Delegate):
-                def __init__(self, d1, d2):
-                    super().__init__()
-                    self.d1 = d1
-                    self.d2 = d2
-                
-                async def on_key_event(self, op_id, pressed, data):
-                    if hasattr(self.d1, 'on_key_event'):
-                        await self.d1.on_key_event(op_id, pressed, data)
-                    if hasattr(self.d2, 'on_key_event'):
-                        await self.d2.on_key_event(op_id, pressed, data)
-            
-            self.avrcp.delegate = MultiplexDelegate(original_delegate, self.delegate)
-            
+            self.delegate.chain_key_events_to(self.avrcp.delegate)
+            self.avrcp.delegate = self.delegate
+
         log.info("[Media] Remote ready (A2DP sink + AVRCP target)")
 
     def adopt(self, connection):

--- a/kindle_hid_passthrough/media_remote.py
+++ b/kindle_hid_passthrough/media_remote.py
@@ -73,7 +73,7 @@ class MediaRemote:
         self._recenter_handle = None
         self._grace_until = 0.0
 
-    def setup(self, device):
+    def setup(self, device, listener=None, avrcp_protocol=None):
         """Register SDP records and profile listeners on the bumble device.
 
         Must run inside the event loop: avrcp.Protocol creates futures.
@@ -88,10 +88,40 @@ class MediaRemote:
                                     | avrcp.TargetFeatures.CATEGORY_2),
             ).to_service_attributes(),
         }
-        listener = avdtp.Listener.for_device(device)
+        if listener is None:
+            listener = avdtp.Listener.for_device(device)
         listener.on(listener.EVENT_CONNECTION, self._on_avdtp_connection)
-        self.avrcp = avrcp.Protocol(delegate=self.delegate)
-        self.avrcp.listen(device)
+        
+        if avrcp_protocol is None:
+            self.avrcp = avrcp.Protocol(delegate=self.delegate)
+            self.avrcp.listen(device)
+        else:
+            self.avrcp = avrcp_protocol
+            # Note: The delegate of the shared avrcp_protocol needs to handle both!
+            # Since host.py provides KindleAvrcpDelegate, and media_remote has its own delegate,
+            # this might mean media_remote will miss events. We should use a multiplexing delegate or 
+            # just hook into the existing one. For now we will overwrite the delegate to self.delegate
+            # or maybe chaining them is better. Wait!
+            
+            # Since MediaRemote uses AVRCP to receive Volume keys and map to page turns,
+            # and KindleAvrcpDelegate uses it for Play/Pause, we need both.
+            # Let's chain them!
+            original_delegate = self.avrcp.delegate
+            
+            class MultiplexDelegate(avrcp.Delegate):
+                def __init__(self, d1, d2):
+                    super().__init__()
+                    self.d1 = d1
+                    self.d2 = d2
+                
+                async def on_key_event(self, op_id, pressed, data):
+                    if hasattr(self.d1, 'on_key_event'):
+                        await self.d1.on_key_event(op_id, pressed, data)
+                    if hasattr(self.d2, 'on_key_event'):
+                        await self.d2.on_key_event(op_id, pressed, data)
+            
+            self.avrcp.delegate = MultiplexDelegate(original_delegate, self.delegate)
+            
         log.info("[Media] Remote ready (A2DP sink + AVRCP target)")
 
     def adopt(self, connection):

--- a/kindle_hid_passthrough/scanner.py
+++ b/kindle_hid_passthrough/scanner.py
@@ -214,20 +214,23 @@ class Scanner:
 
             # Check if HID device (Peripheral device class)
             is_hid = False
+            is_audio = False
             major_class_name = "Unknown"
             try:
                 _, major_class, _minor_class = DeviceClass.split_class_of_device(class_of_device)
                 major_class_name = DeviceClass.major_device_class_name(major_class)
                 is_hid = major_class_name == "Peripheral"
+                is_audio = major_class_name == "Audio/Video"
             except Exception:
                 major_class = (class_of_device >> 8) & 0x1F
                 is_hid = (major_class == 0x05)  # Peripheral
+                is_audio = (major_class == 0x04) # Audio/Video
                 major_class_name = f"0x{major_class:02X}"
 
             # Log ALL devices found, not just HID
-            log.info(f"  Classic: {addr_str} CoD=0x{class_of_device:06X} ({major_class_name}) HID={is_hid}")
+            log.info(f"  Classic: {addr_str} CoD=0x{class_of_device:06X} ({major_class_name}) HID={is_hid} AUDIO={is_audio}")
 
-            if is_hid:
+            if is_hid or is_audio:
                 name = 'Unknown'
                 if eir_data:
                     try:
@@ -241,10 +244,11 @@ class Scanner:
                     except Exception:
                         pass
 
+                protocol = Protocol.CLASSIC_AUDIO if is_audio else Protocol.CLASSIC
                 device = DiscoveredDevice(
                     address=addr_str,
                     name=name,
-                    protocol=Protocol.CLASSIC,
+                    protocol=protocol,
                     rssi=rssi or -100
                 )
                 devices_found.append(device)

--- a/koreader-plugin/hidpassthrough.koplugin/koreader_actions.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/koreader_actions.lua
@@ -2,11 +2,6 @@
 -- entries whose event takes no argument. Regenerate with
 -- scripts/gen_koreader_actions.py when KOReader gains actions.
 return {
-    { section = "Audio", actions = {
-        { event = "AudiobookToggle", title = "Play/Pause audiobook" },
-        { event = "AudiobookStop", title = "Stop audiobook" },
-    } },
-
     { section = "General", actions = {
         { event = "ShowBookMetadataArchive", title = "Book metadata archive" },
         { event = "ShowBookmarkBrowser", title = "Bookmark browser" },

--- a/koreader-plugin/hidpassthrough.koplugin/koreader_actions.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/koreader_actions.lua
@@ -2,6 +2,11 @@
 -- entries whose event takes no argument. Regenerate with
 -- scripts/gen_koreader_actions.py when KOReader gains actions.
 return {
+    { section = "Audio", actions = {
+        { event = "AudiobookToggle", title = "Play/Pause audiobook" },
+        { event = "AudiobookStop", title = "Stop audiobook" },
+    } },
+
     { section = "General", actions = {
         { event = "ShowBookMetadataArchive", title = "Book metadata archive" },
         { event = "ShowBookmarkBrowser", title = "Bookmark browser" },
@@ -23,9 +28,7 @@ return {
         { event = "ShowWikipediaLookup", title = "Wikipedia lookup" },
     } },
     { section = "Reader", actions = {
-                { event = "AudiobookToggle", title = "Play/Pause audiobook" },
-        { event = "AudiobookStop", title = "Stop audiobook" },
-        { event = "AddCurrentLocationToStack", title = "Add current location to history" },
+                { event = "AddCurrentLocationToStack", title = "Add current location to history" },
         { event = "Back", title = "Back" },
         { event = "GoBackLink", title = "Back to previous location" },
         { event = "ShowBookCover", title = "Book cover" },

--- a/koreader-plugin/hidpassthrough.koplugin/koreader_actions.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/koreader_actions.lua
@@ -23,6 +23,8 @@ return {
         { event = "ShowWikipediaLookup", title = "Wikipedia lookup" },
     } },
     { section = "Reader", actions = {
+                { event = "AudiobookToggle", title = "Play/Pause audiobook" },
+        { event = "AudiobookStop", title = "Stop audiobook" },
         { event = "AddCurrentLocationToStack", title = "Add current location to history" },
         { event = "Back", title = "Back" },
         { event = "GoBackLink", title = "Back to previous location" },

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -835,8 +835,8 @@ function HIDPassthrough:_spawnBinary()
     end
     -- setsid so it survives KOReader exiting; exit code is meaningless.
     local cmd = string.format(
-        "(setsid %s --daemon </dev/null >/dev/null 2>&1 &) 2>/dev/null || "
-        .. "(%s --daemon </dev/null >/dev/null 2>&1 &)",
+        "(setsid %s --daemon </dev/null >>/mnt/us/kindle_hid_passthrough/daemon.log 2>&1 &) 2>/dev/null || "
+        .. "(%s --daemon </dev/null >>/mnt/us/kindle_hid_passthrough/daemon.log 2>&1 &)",
         self.DAEMON_BINARY, self.DAEMON_BINARY
     )
     logger.info("HIDPassthrough: spawning daemon:", cmd)

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -620,8 +620,30 @@ function HIDPassthrough:mapperCapture(dev, touchmenu_instance, device_depth)
     -- the picker has to be pushed onto, so remember it and check on the way
     -- back rather than pushing onto whatever the user browsed to meanwhile.
     local menu_at_start = touchmenu_instance and touchmenu_instance.item_table
+    -- The mapper does the capture, not us, and only one process can hold an
+    -- evdev grab. While KOReader holds this node the mapper's reader gets
+    -- nothing and every capture ends in a timeout, so hand the node over for
+    -- the length of the call. Nothing to do when the mode already gave it away.
+    local held = input_fds[node] ~= nil
+    if held then releaseNode(node) end
     UIManager:scheduleIn(0.1, function()
         local cap, err = mapper.capture(node, 8000)
+        if held then
+            -- The capture reader lets go when the call returns; give it the
+            -- same moment _applyMapperMode does before grabbing again, and
+            -- drop our stale entry first or the reopen is a no-op.
+            UIManager:scheduleIn(1.5, function()
+                releaseNode(node)
+                if not self:_reclaimInput(node) then
+                    logger.warn("HIDPassthrough: could not take", node,
+                        "back after capture")
+                    UIManager:show(InfoMessage:new{
+                        text = _("Reconnect the device for KOReader to pick it up again."),
+                        timeout = 4,
+                    })
+                end
+            end)
+        end
         UIManager:close(msg)
         if not cap then
             UIManager:show(InfoMessage:new{

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -114,6 +114,21 @@ function HIDPassthrough:isRunning()
     return self:getState() == "on"
 end
 
+-- The audio bypass is its own switch, not part of HID. It stops the stock
+-- audio daemon and puts a mock in its place, which is worth doing only if it
+-- works here: on a device where it does not, the reader still needs its own
+-- audio, so this has to be something the user can leave off.
+function HIDPassthrough:audioEnabled()
+    local data = self:_httpGetJson("/audio")
+    return data ~= nil and data.enabled == true
+end
+
+function HIDPassthrough:setAudioEnabled(want)
+    local data, err = self:_httpGetJson("/audio?enable=" .. (want and "1" or "0"))
+    if not data then return false, err end
+    return data.enabled == want, nil
+end
+
 ------------------------------------------------------------------------------
 -- Key mappings
 ------------------------------------------------------------------------------
@@ -744,9 +759,9 @@ function HIDPassthrough:_actionSections()
         end
 
         -- The daemon pauses by holding its own audio FIFO, so this stops
-        -- whatever is playing without the application cooperating. Kept apart
-        -- from KOReader's audio events below, which only reach the plugin that
-        -- owns the playback and do nothing when another one is playing.
+        -- whatever is playing without the application cooperating. It replaced
+        -- the per-plugin audiobook events this branch used to list: those only
+        -- reach the plugin that owns the playback and do nothing otherwise.
         if util.pathExists(self:_mapper().MEDIA) then
             local items = {}
             for dummy, a in ipairs(MEDIA_ACTIONS) do -- luacheck: ignore dummy
@@ -755,7 +770,7 @@ function HIDPassthrough:_actionSections()
                     script = self:_mapper().mediaScript(a.command),
                 })
             end
-            table.insert(sections, { title = _("Any audio"), items = items })
+            table.insert(sections, { title = _("Audio"), items = items })
         end
 
         local ok, koactions = pcall(dofile,
@@ -1829,6 +1844,21 @@ function HIDPassthrough:_doToggle(touchmenu_instance)
     end
 end
 
+function HIDPassthrough:_doToggleAudio(touchmenu_instance)
+    local want = not self:audioEnabled()
+    local ok, err = self:setAudioEnabled(want)
+    local msg
+    if ok then
+        msg = want and _("Bluetooth audio on.") or _("Bluetooth audio off.")
+    else
+        msg = T(_("Could not change it: %1"), tostring(err or "failed"))
+    end
+    UIManager:show(InfoMessage:new{ text = msg, timeout = ok and 2 or 4 })
+    if touchmenu_instance then
+        touchmenu_instance:updateItems()
+    end
+end
+
 function HIDPassthrough:addToMainMenu(menu_items)
     menu_items.hid_passthrough = {
         text = _("BT Manager - HID Passthrough"),
@@ -1849,6 +1879,17 @@ function HIDPassthrough:addToMainMenu(menu_items)
                 callback = function(touchmenu_instance)
                     self:_doToggle(touchmenu_instance)
                 end,
+            },
+            {
+                text = _("Bluetooth audio"),
+                help_text = _("Sends what the Kindle plays to the paired headphones. While on, the stock audio daemon is replaced; leave it off if audio misbehaves on this device."),
+                enabled_func = function() return self:isRunning() end,
+                checked_func = function() return self:audioEnabled() end,
+                check_callback_updates_menu = true,
+                callback = function(touchmenu_instance)
+                    self:_doToggleAudio(touchmenu_instance)
+                end,
+                separator = true,
             },
             {
                 text = _("Scan for devices"),

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -383,6 +383,13 @@ local MAPPER_KINDS = {
     { section = "triggers", label = _("Trigger") },
 }
 
+-- Daemon-side media control, mapped to assets/audio-hack/media.sh.
+local MEDIA_ACTIONS = {
+    { command = "toggle", title = _("Play/Pause any audio") },
+    { command = "pause",  title = _("Pause any audio") },
+    { command = "play",   title = _("Resume any audio") },
+}
+
 -- Who owns the device node. Only one process can hold an evdev grab, so this
 -- is the difference between KOReader seeing the keys and the mapper seeing
 -- them. `grab` absent means the daemon decides from the node itself.
@@ -734,6 +741,21 @@ function HIDPassthrough:_actionSections()
             if #items > 0 then
                 table.insert(sections, { title = _("Favorites"), items = items })
             end
+        end
+
+        -- The daemon pauses by holding its own audio FIFO, so this stops
+        -- whatever is playing without the application cooperating. Kept apart
+        -- from KOReader's audio events below, which only reach the plugin that
+        -- owns the playback and do nothing when another one is playing.
+        if util.pathExists(self:_mapper().MEDIA) then
+            local items = {}
+            for dummy, a in ipairs(MEDIA_ACTIONS) do -- luacheck: ignore dummy
+                table.insert(items, {
+                    title = a.title,
+                    script = self:_mapper().mediaScript(a.command),
+                })
+            end
+            table.insert(sections, { title = _("Any audio"), items = items })
         end
 
         local ok, koactions = pcall(dofile,

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -431,8 +431,14 @@ local MEDIA_ACTIONS = {
 local MAPPER_MODES = {
     {
         title = _("Automatic"),
-        note = _("Gamepads are taken over, keyboards are left to KOReader."),
+        note = _("Gamepads and audio remotes are taken over, keyboards are left to KOReader."),
         grab = nil, passthrough = nil,
+        -- An audio device reaches us through the injected Consumer Control
+        -- descriptor, so its node carries media keys and nothing else, keys
+        -- KOReader has no binding for. Leaving it to KOReader is the one
+        -- automatic answer that cannot work, so for audio this mode means
+        -- the same thing the daemon already writes at registration.
+        audio_grab = "true", audio_passthrough = "true",
     },
     {
         title = _("KOReader only"),
@@ -443,6 +449,9 @@ local MAPPER_MODES = {
         title = _("Button Mapper, keys still type"),
         note = _("Mapped buttons run their action, everything else is passed through untouched."),
         grab = "true", passthrough = "true",
+        -- Identical to Automatic once the device is audio; hidden there so
+        -- the picker does not offer the same thing twice.
+        same_as_automatic_for_audio = true,
     },
     {
         title = _("Button Mapper, exclusive"),
@@ -451,13 +460,23 @@ local MAPPER_MODES = {
     },
 }
 
-function HIDPassthrough:_mapperMode(dev)
+-- Which pair of values a mode means for this device. Only audio differs,
+-- and only for Automatic; every other mode is explicit and device-agnostic.
+local function modeValues(mode, proto)
+    if proto == "classic_audio" and mode.audio_grab then
+        return mode.audio_grab, mode.audio_passthrough
+    end
+    return mode.grab, mode.passthrough
+end
+
+function HIDPassthrough:_mapperMode(dev, proto)
     local text = self:_mapper().getConfig() or ""
     local section = "device." .. dev.id
     local grab = self:_mapper().sectionValue(text, section, "grab")
     local passthrough = self:_mapper().sectionValue(text, section, "passthrough")
     for dummy, mode in ipairs(MAPPER_MODES) do -- luacheck: ignore dummy
-        if mode.grab == grab and (mode.grab ~= "true" or mode.passthrough == passthrough) then
+        local want_grab, want_pass = modeValues(mode, proto)
+        if want_grab == grab and (want_grab ~= "true" or want_pass == passthrough) then
             return mode
         end
     end
@@ -477,19 +496,21 @@ local function releaseNode(path)
     end
 end
 
-function HIDPassthrough:_applyMapperMode(dev, mode)
+function HIDPassthrough:_applyMapperMode(dev, mode, proto)
+    local want_grab, want_pass = modeValues(mode, proto)
     local node = self:_mapper().findNode(dev.uniq or "")
     -- Hand the node over before the daemon is told to take it, and take it
     -- back only after the daemon has been told to let go.
-    if node and mode.grab == "true" then
+    if node and want_grab == "true" then
         releaseNode(node)
     end
 
     local ok = self:mapperEdit(function(cur)
         local section = "device." .. dev.id
+        local values = { grab = want_grab, passthrough = want_pass }
         for dummy, key in ipairs({ "grab", "passthrough" }) do -- luacheck: ignore dummy
-            if mode[key] then
-                cur = self:_mapper().setKey(cur, section, key, mode[key])
+            if values[key] then
+                cur = self:_mapper().setKey(cur, section, key, values[key])
             else
                 cur = self:_mapper().removeKey(cur, section, key)
             end
@@ -1384,17 +1405,20 @@ end
 
 function HIDPassthrough:_showMapperModePicker(mdev, addr, proto, name, is_connected)
     local items = {}
+    local current_mode = self:_mapperMode(mdev, proto)
     for dummy, mode in ipairs(MAPPER_MODES) do -- luacheck: ignore dummy
-        local current = self:_mapperMode(mdev).title == mode.title
-        table.insert(items, {
-            text = (current and "● " or "○ ") .. mode.title,
-            callback = function()
-                UIManager:close(self._mode_menu)
-                self._mode_menu = nil
-                self:_applyMapperMode(mdev, mode)
-                self:_showDeviceActions(addr, proto, name, is_connected)
-            end,
-        })
+        if not (proto == "classic_audio" and mode.same_as_automatic_for_audio) then
+            local current = current_mode.title == mode.title
+            table.insert(items, {
+                text = (current and "● " or "○ ") .. mode.title,
+                callback = function()
+                    UIManager:close(self._mode_menu)
+                    self._mode_menu = nil
+                    self:_applyMapperMode(mdev, mode, proto)
+                    self:_showDeviceActions(addr, proto, name, is_connected)
+                end,
+            })
+        end
     end
 
     local menu

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -209,10 +209,37 @@ local function checkKeyDevice(path)
     return info
 end
 
+-- Only one process can hold an evdev grab. On a reconnect the mapper lets go
+-- to re-read its config and takes the node back a moment later; if KOReader
+-- attaches in that window the mapper comes back with EBUSY, drops to shared
+-- mode, and shared mode does not relay -- the mapped key silently stops
+-- firing. The mapper's config is the authority on who owns the node.
+function HIDPassthrough:_mapperGrabs(path)
+    local mapper = self:_mapper()
+    if not mapper.installed() then return false end
+    local uniq = mapper.uniqForNode(path)
+    if not uniq or uniq == "" then return false end
+    local text = mapper.getConfig()
+    if not text then return false end
+    local want = mapper.bareAddr(uniq)
+    for dummy, dev in ipairs(mapper.deviceBlocks(text)) do -- luacheck: ignore dummy
+        if dev.uniq and mapper.bareAddr(dev.uniq) == want then
+            return mapper.sectionValue(text, "device." .. dev.id, "grab") == "true"
+        end
+    end
+    return false
+end
+
 function HIDPassthrough:_attachInput(path, force)
     if input_fds[path] and not force then return end
     if Device.input.opened_devices[path] and not input_fds[path] then
         logger.dbg("HIDPassthrough: leaving", path, "to KOReader")
+        return
+    end
+
+    if self:_mapperGrabs(path) then
+        if input_fds[path] then releaseNode(path) end
+        logger.info("HIDPassthrough: leaving", path, "to Button Mapper, it grabs this device")
         return
     end
 
@@ -449,9 +476,6 @@ local MAPPER_MODES = {
         title = _("Button Mapper, keys still type"),
         note = _("Mapped buttons run their action, everything else is passed through untouched."),
         grab = "true", passthrough = "true",
-        -- Identical to Automatic once the device is audio; hidden there so
-        -- the picker does not offer the same thing twice.
-        same_as_automatic_for_audio = true,
     },
     {
         title = _("Button Mapper, exclusive"),
@@ -459,6 +483,27 @@ local MAPPER_MODES = {
         grab = "true", passthrough = "false",
     },
 }
+
+local DEVICES_CONF = "/mnt/us/kindle_hid_passthrough/devices.conf"
+
+-- The mapper's device list is keyed by config block and carries no protocol,
+-- so the menu built from it cannot say whether a device is audio. devices.conf
+-- can: one line per device, "ADDRESS protocol Name".
+local function protoForUniq(uniq)
+    if not uniq or uniq == "" then return nil end
+    local f = io.open(DEVICES_CONF, "r")
+    if not f then return nil end
+    local want = uniq:gsub("/.*$", ""):upper()
+    local found
+    for line in f:lines() do
+        if not line:match("^%s*#") then
+            local addr, proto = line:match("^%s*(%S+)%s+(%S+)")
+            if addr and addr:upper() == want then found = proto break end
+        end
+    end
+    f:close()
+    return found
+end
 
 -- Which pair of values a mode means for this device. Only audio differs,
 -- and only for Automatic; every other mode is explicit and device-agnostic.
@@ -470,6 +515,7 @@ local function modeValues(mode, proto)
 end
 
 function HIDPassthrough:_mapperMode(dev, proto)
+    proto = proto or protoForUniq(dev.uniq)
     local text = self:_mapper().getConfig() or ""
     local section = "device." .. dev.id
     local grab = self:_mapper().sectionValue(text, section, "grab")
@@ -497,6 +543,7 @@ local function releaseNode(path)
 end
 
 function HIDPassthrough:_applyMapperMode(dev, mode, proto)
+    proto = proto or protoForUniq(dev.uniq)
     local want_grab, want_pass = modeValues(mode, proto)
     local node = self:_mapper().findNode(dev.uniq or "")
     -- Hand the node over before the daemon is told to take it, and take it
@@ -518,7 +565,7 @@ function HIDPassthrough:_applyMapperMode(dev, mode, proto)
         return cur
     end)
 
-    if node and ok and mode.grab ~= "true" then
+    if node and ok and want_grab ~= "true" then
         -- The daemon ungrabs on its own reload tick, so give it a moment
         -- before reopening or this grab lands while it still holds one.
         -- Drop whatever KOReader still thinks it has first: handing the node
@@ -1407,18 +1454,16 @@ function HIDPassthrough:_showMapperModePicker(mdev, addr, proto, name, is_connec
     local items = {}
     local current_mode = self:_mapperMode(mdev, proto)
     for dummy, mode in ipairs(MAPPER_MODES) do -- luacheck: ignore dummy
-        if not (proto == "classic_audio" and mode.same_as_automatic_for_audio) then
-            local current = current_mode.title == mode.title
-            table.insert(items, {
-                text = (current and "● " or "○ ") .. mode.title,
-                callback = function()
-                    UIManager:close(self._mode_menu)
-                    self._mode_menu = nil
-                    self:_applyMapperMode(mdev, mode, proto)
-                    self:_showDeviceActions(addr, proto, name, is_connected)
-                end,
-            })
-        end
+        local current = current_mode.title == mode.title
+        table.insert(items, {
+            text = (current and "● " or "○ ") .. mode.title,
+            callback = function()
+                UIManager:close(self._mode_menu)
+                self._mode_menu = nil
+                self:_applyMapperMode(mdev, mode, proto)
+                self:_showDeviceActions(addr, proto, name, is_connected)
+            end,
+        })
     end
 
     local menu

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -219,7 +219,7 @@ function HIDPassthrough:_mapperGrabs(path)
     if not mapper.installed() then return false end
     local uniq = mapper.uniqForNode(path)
     if not uniq or uniq == "" then return false end
-    local text = mapper.getConfig()
+    local text = mapper.configText()
     if not text then return false end
     local want = mapper.bareAddr(uniq)
     for dummy, dev in ipairs(mapper.deviceBlocks(text)) do -- luacheck: ignore dummy
@@ -266,6 +266,18 @@ end
 -- closed this one behind its back and will not re-adopt without a reconnect.
 -- So open it here regardless of type rather than leave the device dead.
 function HIDPassthrough:_reclaimInput(path)
+    -- Both callers decide to reclaim and then wait a second and a half, long
+    -- enough for the mode to have changed underneath them, and neither has
+    -- any business taking a node the mapper owns. The config is the authority,
+    -- so ask it again here rather than trust what was true when the timer was
+    -- set. Not reclaiming is the right outcome, not a failure, hence true:
+    -- false is what puts a "reconnect the device" message on screen.
+    if self:_mapperGrabs(path) then
+        logger.info("HIDPassthrough: not taking", path,
+            "back, Button Mapper grabs this device")
+        return true
+    end
+
     local FBInkInput = ffi.loadlib("fbink_input", 1)
     local dev = FBInkInput.fbink_input_check(path, C.INPUT_KEY, 0, 0)
     if dev == nil then return false end

--- a/koreader-plugin/hidpassthrough.koplugin/mapper.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/mapper.lua
@@ -11,6 +11,7 @@ local M = {
     BIN     = "/mnt/us/kindle-button-mapper/kindle-button-mapper",
     CONFIG  = "/mnt/us/kindle-button-mapper/config.ini",
     SCRIPTS = "/mnt/us/kindle-button-mapper/scripts",
+    MEDIA   = "/mnt/us/kindle_hid_passthrough/assets/audio-hack/media.sh",
     PIDFILE = "/tmp/kindle-button-mapper-waf.pid",
     LOG     = "/var/log/kindle-button-mapper-waf.log",
     HOST    = "127.0.0.1",
@@ -293,6 +294,14 @@ end
 -- no-argument half of KOReader's Dispatcher list.
 function M.koreaderEventScript(event)
     return string.format("%s/koreader.sh event %s", M.SCRIPTS, event)
+end
+
+-- The daemon's own media control. It pauses by no longer draining the audio
+-- FIFO, so the writer blocks and whatever is playing freezes in place. That
+-- works for any application, unlike a KOReader event, which only reaches the
+-- plugin that happens to own the playback.
+function M.mediaScript(command)
+    return string.format("%s %s", M.MEDIA, command)
 end
 
 -- Human label for a configured value, for the mapping list. `titles` maps both

--- a/koreader-plugin/hidpassthrough.koplugin/mapper.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/mapper.lua
@@ -114,6 +114,18 @@ function M.actions()
 end
 
 -- Evdev node path for a registered device, nil when it isn't connected.
+-- The reverse of findNode: which device a node belongs to. Used to decide
+-- whether KOReader should keep its hands off that node.
+function M.uniqForNode(path)
+    local data = requestJson("GET", "/devices")
+    if not data then return nil end
+    for _, dev in ipairs(data.devices or {}) do
+        if dev.path == path and dev.uniq and dev.uniq ~= "" then
+            return dev.uniq
+        end
+    end
+end
+
 function M.findNode(uniq)
     local data = requestJson("GET", "/devices")
     if not data then return nil end

--- a/koreader-plugin/hidpassthrough.koplugin/mapper.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/mapper.lua
@@ -100,6 +100,19 @@ function M.getConfig()
     return request("GET", "/config")
 end
 
+-- Read-only view of the config, for decisions that have to be right before
+-- anything has spawned the helper. The helper owns the file and writes it on
+-- every POST, so the file is never behind. Edits still go through the helper.
+function M.configText()
+    local f = io.open(M.CONFIG, "r")
+    if f then
+        local text = f:read("*a")
+        f:close()
+        if text and text ~= "" then return text end
+    end
+    return M.getConfig()
+end
+
 function M.setConfig(text)
     return requestJson("POST", "/config", text)
 end
@@ -113,10 +126,42 @@ function M.actions()
     return data and data.actions, err
 end
 
+-- The helper is spawned on demand, so at the moment a device connects there
+-- is nothing listening on the port yet and every question asked over HTTP
+-- comes back nil. That is the one moment the answer has to be right, so read
+-- the kernel's own list instead: it needs no process, it is never late, and
+-- it carries the same two fields the helper reports.
+local PROC_DEVICES = "/proc/bus/input/devices"
+
+local function procNodes()
+    local f = io.open(PROC_DEVICES, "r")
+    if not f then return {} end
+    local out, uniq = {}, nil
+    for line in f:lines() do
+        if line:match("^%s*$") then
+            uniq = nil
+        else
+            local u = line:match("^U:%s*Uniq=(.-)%s*$")
+            if u then uniq = u end
+            local handlers = line:match("^H:%s*Handlers=(.*)$")
+            if handlers then
+                for ev in handlers:gmatch("event%d+") do
+                    out[#out + 1] = { path = "/dev/input/" .. ev, uniq = uniq or "" }
+                end
+            end
+        end
+    end
+    f:close()
+    return out
+end
+
 -- Evdev node path for a registered device, nil when it isn't connected.
 -- The reverse of findNode: which device a node belongs to. Used to decide
 -- whether KOReader should keep its hands off that node.
 function M.uniqForNode(path)
+    for dummy, dev in ipairs(procNodes()) do -- luacheck: ignore dummy
+        if dev.path == path and dev.uniq ~= "" then return dev.uniq end
+    end
     local data = requestJson("GET", "/devices")
     if not data then return nil end
     for _, dev in ipairs(data.devices or {}) do
@@ -127,9 +172,12 @@ function M.uniqForNode(path)
 end
 
 function M.findNode(uniq)
+    local want = M.bareAddr(uniq)
+    for dummy, dev in ipairs(procNodes()) do -- luacheck: ignore dummy
+        if dev.uniq ~= "" and M.bareAddr(dev.uniq) == want then return dev.path end
+    end
     local data = requestJson("GET", "/devices")
     if not data then return nil end
-    local want = M.bareAddr(uniq)
     for _, dev in ipairs(data.devices or {}) do
         if dev.uniq and dev.uniq ~= "" and M.bareAddr(dev.uniq) == want then
             return dev.path

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -268,11 +268,28 @@ installUpstart()
 installAudioWrapper()
 {
   echo " -> Installing GST audio wrapper"
-  /usr/sbin/mntroot rw
-  if [ ! -f /usr/bin/gst-launch-0.10.real ]; then
-    mv /usr/bin/gst-launch-0.10 /usr/bin/gst-launch-0.10.real
+  WRAPPER="$SRC_DIR/assets/audio-hack/gst-launch-wrapper.sh"
+  if [ ! -f "$WRAPPER" ]; then
+    echo " -> wrapper missing from the package, skipping" >&2
+    return 1
   fi
-  cp "$SRC_DIR/assets/audio-hack/gst-launch-wrapper.sh" /usr/bin/gst-launch-0.10
+  /usr/sbin/mntroot rw
+  # Only wrap a stock binary we could actually set aside. Installing the
+  # wrapper without a .real to delegate to makes every gst call exit 127,
+  # and overwriting the stock binary without saving it is unrecoverable.
+  if [ ! -f /usr/bin/gst-launch-0.10.real ]; then
+    if [ ! -f /usr/bin/gst-launch-0.10 ]; then
+      echo " -> no stock gst-launch-0.10 on this firmware, skipping" >&2
+      /usr/sbin/mntroot ro
+      return 1
+    fi
+    if ! mv /usr/bin/gst-launch-0.10 /usr/bin/gst-launch-0.10.real; then
+      echo " -> could not set the stock gst-launch-0.10 aside, skipping" >&2
+      /usr/sbin/mntroot ro
+      return 1
+    fi
+  fi
+  cp "$WRAPPER" /usr/bin/gst-launch-0.10
   chmod +x /usr/bin/gst-launch-0.10
   /usr/sbin/mntroot ro
   echo " -> Ready."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -168,6 +168,7 @@ installAll()
     return 1
   fi
   installUdevRules
+  installAudioWrapper
   # Auto-start is opt-in, only refresh a job the user already enabled.
   if [ -f /etc/upstart/hid-passthrough.conf ]; then
     installUpstart
@@ -261,6 +262,19 @@ installUpstart()
   # upstart only picks up a newly dropped .conf after a config reload, without
   # this the job stays unknown and the start below fails until a reboot.
   /sbin/initctl reload-configuration 2>/dev/null || true
+  echo " -> Ready."
+}
+
+installAudioWrapper()
+{
+  echo " -> Installing GST audio wrapper"
+  /usr/sbin/mntroot rw
+  if [ ! -f /usr/bin/gst-launch-0.10.real ]; then
+    mv /usr/bin/gst-launch-0.10 /usr/bin/gst-launch-0.10.real
+  fi
+  cp "$SRC_DIR/assets/audio-hack/gst-launch-wrapper.sh" /usr/bin/gst-launch-0.10
+  chmod +x /usr/bin/gst-launch-0.10
+  /usr/sbin/mntroot ro
   echo " -> Ready."
 }
 
@@ -369,6 +383,11 @@ uninstallAll()
 
   echo " -> Removing upstart config"
   rm -f /etc/upstart/hid-passthrough.conf
+
+  echo " -> Removing GST audio wrapper"
+  if [ -f /usr/bin/gst-launch-0.10.real ]; then
+    mv /usr/bin/gst-launch-0.10.real /usr/bin/gst-launch-0.10
+  fi
 
   echo " -> Removing udev rules"
   rm -f /etc/udev/rules.d/99-hid-keyboard.rules

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -168,7 +168,6 @@ installAll()
     return 1
   fi
   installUdevRules
-  installAudioWrapper
   # Auto-start is opt-in, only refresh a job the user already enabled.
   if [ -f /etc/upstart/hid-passthrough.conf ]; then
     installUpstart
@@ -262,36 +261,6 @@ installUpstart()
   # upstart only picks up a newly dropped .conf after a config reload, without
   # this the job stays unknown and the start below fails until a reboot.
   /sbin/initctl reload-configuration 2>/dev/null || true
-  echo " -> Ready."
-}
-
-installAudioWrapper()
-{
-  echo " -> Installing GST audio wrapper"
-  WRAPPER="$SRC_DIR/assets/audio-hack/gst-launch-wrapper.sh"
-  if [ ! -f "$WRAPPER" ]; then
-    echo " -> wrapper missing from the package, skipping" >&2
-    return 1
-  fi
-  /usr/sbin/mntroot rw
-  # Only wrap a stock binary we could actually set aside. Installing the
-  # wrapper without a .real to delegate to makes every gst call exit 127,
-  # and overwriting the stock binary without saving it is unrecoverable.
-  if [ ! -f /usr/bin/gst-launch-0.10.real ]; then
-    if [ ! -f /usr/bin/gst-launch-0.10 ]; then
-      echo " -> no stock gst-launch-0.10 on this firmware, skipping" >&2
-      /usr/sbin/mntroot ro
-      return 1
-    fi
-    if ! mv /usr/bin/gst-launch-0.10 /usr/bin/gst-launch-0.10.real; then
-      echo " -> could not set the stock gst-launch-0.10 aside, skipping" >&2
-      /usr/sbin/mntroot ro
-      return 1
-    fi
-  fi
-  cp "$WRAPPER" /usr/bin/gst-launch-0.10
-  chmod +x /usr/bin/gst-launch-0.10
-  /usr/sbin/mntroot ro
   echo " -> Ready."
 }
 
@@ -401,6 +370,9 @@ uninstallAll()
   echo " -> Removing upstart config"
   rm -f /etc/upstart/hid-passthrough.conf
 
+  # The audio switch installs and removes the wrapper itself. This is the
+  # net for uninstalling with the switch still on, which never runs the
+  # teardown script.
   echo " -> Removing GST audio wrapper"
   if [ -f /usr/bin/gst-launch-0.10.real ]; then
     mv /usr/bin/gst-launch-0.10.real /usr/bin/gst-launch-0.10


### PR DESCRIPTION
# A2DP audio passthrough

The Kindle becomes an A2DP source: Bluetooth headphones play whatever goes
through GStreamer — KOReader TTS, audiobook plugins, anything else.

## How

**1. LIPC mock.** `audiomgrd` is stopped; a LuaJIT script (KOReader's `luajit`)
registers `com.lab126.audiomgrd` and answers `audioOutputConnected = 1`, so
applications see an output.

**2. GStreamer wrapper.** While the switch is on, `/usr/bin/gst-launch-0.10` is
a shell wrapper, the stock ELF kept as `.real`. Pipelines containing
`mixersink` are rewritten to `filesink location=/tmp/kindle_audio.fifo`;
everything else delegates untouched. The wrapper writes the caps it saw to
`/tmp/kindle_audio.fmt` — that is how the daemon learns the source rate and
channels without a control channel, and how it follows a change mid-stream.

**3. Daemon.** Reads the FIFO, resamples to 44100 Hz stereo, encodes SBC
through `libsbc`, streams over AVDTP with Bumble's `MediaPacketPump`.

AVRCP media keys arrive as a Consumer Control HID report on the existing UHID
path; audio devices have no report map, so a 33-byte descriptor is injected.
The daemon does not act on them itself — an unmapped button does nothing.

## Pause

`/media/toggle`, `/media/play`, `/media/pause`, wrapped by
`assets/audio-hack/media.sh` and listed in the plugin's mapping picker.

Pause is backpressure, not a signal: the daemon stops draining the FIFO, the
writer blocks in `write()`, playback freezes at the sample. Nothing is
discarded and the producer needs no cooperation — verified against KOReader's
audiobook plugin, whose own progress counter froze and resumed at the same
offset.

## Opt-in

Off by default, its own switch beside the HID state, exposed at `/audio` and in
the plugin menu. **Installing changes nothing under `/usr/bin`** — the switch
owns the binary swap in both directions. A device where this does not work
keeps its own audio and still runs the HID host.

The wrapper redirects every `mixersink` pipeline unconditionally, so it must
not outlive the switch. Stock `audiomgrd` and the stock binary come back on
stop and on every failure path, and the start script aborts before touching
audio if `luajit` or the wrapper is missing.

## Known limits

With the switch on and no headphones connected there is no reader on the FIFO,
so local playback blocks until one connects. Turning the switch off restores
the stock binary and unblocks it.

SBC bitpool is fixed at 35, not negotiated against the sink's configured
maximum. `audioop` is gone in Python 3.13 — the resampler needs replacing
before the build image moves that far.

## Where to look

```
NEW  kindle_hid_passthrough/audio_pipe.py  451  FIFO, resampler, SBC encoder
NEW  assets/audio-hack/                    762  mock, wrapper, start/stop, media.sh

     host.py                               274  AVDTP session, AVRCP -> UHID, descriptor
     controller.py                         203  audio switch, bypass lifecycle
     classic.py                            179  audio connect, stale link key
     main.lua                               89  audio switch, Audio actions
     api_server.py                          54  /media/*, /audio
     install.sh                              8  restore the stock binary on uninstall
```

`libsbc-dev` in the ARM image, `libsbc.so.1` bundled and required by the
tarball check so a release cannot ship with the audio path dead.

## Tested

Kindle PW6SE (5.15.41-lab126) and Kindle PW5SE, clean install, Redmi AirDots: pairing, streaming,
and pause on a headset button with no manual step — an audio device gets the
grab/passthrough mapper mode automatically. Also run on an older-generation
Kindle.