### PR TITLE
fix(brcm): thaw btd before asking it for BTenable

### DIFF
--- a/kindle_hid_passthrough/bt_brcm.py
+++ b/kindle_hid_passthrough/bt_brcm.py
@@ -99,6 +99,10 @@ def _warm_up_chip():
         log.info("bsa_server already running; BCM chip is warm")
         return True
 
+    # BTenable goes nowhere while btd is stopped, and a prior handoff may have
+    # left it that way, so give it back before asking rather than after the
+    # 12s wait below has already been spent.
+    _thaw_btd()
     log.info("Warming BCM chip via btfd (BTenable)...")
     run(BTENABLE_LIPC)
     if _wait_for_bsa():


### PR DESCRIPTION
BTenable reaches btd through btfd, so it does nothing at all while btd is stopped, and the warm handoff stops btd on purpose. Nothing thawed it before the warm-up asked, so the request landed on a frozen process, `_wait_for_bsa` sat out its full 12s, and only then did `_recover_btd` thaw and retry, which worked immediately.

In @flamecho's log on #225 that is every warm-up, both of them.

```
13:54:21,898 Warming BCM chip via btfd (BTenable)...
13:54:34,432 bsa_server didn't start; recovering btd (attempt 1/3)
13:54:44,681 bsa_server up; BCM chip warmed
```

Twelve seconds burned, then the recovery does it properly. The recovery path had quietly become the normal path, and on his device it never once warmed on the first ask.

#246 fixed the same leak on `power_off`, this is the other side, give btd back before we want something from it rather than after the timeout has been spent.

Checked the ordering offline, the SIGCONT goes out before BTenable, and with bsa coming up on the first ask the recovery loop does not run at all.
