### PR TITLE
fix(bt): stop probing /dev/stpbt with an open/close on MTK

### DIFF
--- a/kindle_hid_passthrough/bt_mtk.py
+++ b/kindle_hid_passthrough/bt_mtk.py
@@ -113,7 +113,7 @@ def _find_holders(device_path):
 def _graceful_kill(h, settle, device_path):
     """SIGTERM an unknown holder, then SIGKILL only if it clings to the node."""
     for sig in (signal.SIGTERM, signal.SIGKILL):
-        if _is_device_free(device_path):
+        if not _find_holders(device_path):
             return
         try:
             os.kill(int(h['pid']), sig)
@@ -149,18 +149,8 @@ def _evict_holders(device_path, settle):
         time.sleep(settle)
 
     for h in holders:
-        if h['comm'] not in _STOCK_BT_JOBS and not _is_device_free(device_path):
+        if h['comm'] not in _STOCK_BT_JOBS and _find_holders(device_path):
             _graceful_kill(h, settle, device_path)
-
-
-def _is_device_free(device_path):
-    """Check if the BT device can be opened."""
-    try:
-        fd = os.open(device_path, os.O_RDWR | os.O_NONBLOCK)
-        os.close(fd)
-        return True
-    except OSError:
-        return False
 
 
 class MtkChip(BtChip):
@@ -188,19 +178,19 @@ class MtkChip(BtChip):
         if not os.path.exists(device_path):
             log.warning(f"{device_path} does not exist")
             return False
-        if _is_device_free(device_path):
+        if not _find_holders(device_path):
             log.info(f"{device_path} is available")
             return True
 
         log.info(f"{device_path} is busy, identifying and evicting holders...")
         _evict_holders(device_path, settle)
-        if _is_device_free(device_path):
+        if not _find_holders(device_path):
             log.info(f"{device_path} is now available")
             return True
 
         log.warning(f"{device_path} still busy, waiting 2s...")
         time.sleep(2.0)
-        if _is_device_free(device_path):
+        if not _find_holders(device_path):
             log.info(f"{device_path} is now available")
             return True
 


### PR DESCRIPTION
`_is_device_free` answered "is /dev/stpbt free" by opening the node and closing it again. On MediaTek that open/close is a power cycle of the radio, `wmt_cdev_bt` brings the chip up on open and drops it on close, so every start cycled the chip once for nothing right before Bumble opened it for real. @qscynthia-alt caught a previous boot Oops on a PW5 in #254 with `wmt_cdev_bt+0x8b0` on the stack and a watchdog reset behind it, and that spare cycle is the most likely trigger.

`_find_holders` in the same file already answered the same question from `/proc/*/fd` for the eviction path, so the probe is gone entirely and the transport open is the first and only open. Same move as #252 on the Broadcom side. Net 16 lines deleted, 5 added.

Tested on a Basic 4 (0x957, wmt_cdev_bt). Nothing opens the node before the transport now, the busy path still finds and names the holder while the daemon owns `/dev/stpbt`, and 16 fresh daemon starts came up clean with transport open, HCI reset, controller powered on and no watchdog reset.

I cant reproduce the Oops here though, native BT is off on this device so nothing ever contends for the node and it never faulted before the change either. Needs a run on the reporter's PW5 to actually confirm, which is why this is Refs and not Fixes.

One thing this does not fix, my device reports local BD_ADDR `00:00:46:67:61:01` both before and after, so the wiped firmware patch from #179 is not caused by our probe closing the node. That one happens earlier when btmanagerd's own fd closes.

Refs #254
