### PR TITLE
feat(koplugin): serve KOReader events on a loopback port

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The **Start on boot** toggle at the bottom installs or removes the upstart job. 
 
 If you use KOReader, a bundled plugin gives you the same scan / pair / connect / disconnect / logs / cache controls from inside KOReader — no need to exit. Open via **cog icon (Settings) → Network → BT Manager - HID Passthrough**.
 
-It also maps keys. Press a button, a D-pad direction or a trigger and bind it to any KOReader action, or to one that keeps working with KOReader closed. Mappings run through the bundled Button Mapper, and the KOReader actions need KOReader's HTTP Inspector on.
+It also maps keys. Press a button, a D-pad direction or a trigger and bind it to any KOReader action, or to one that keeps working with KOReader closed. Mappings run through the bundled Button Mapper, which delivers KOReader actions straight to the plugin — no HTTP Inspector needed.
 
 <p align="center">
   <img src="koreader-plugin/screenshots/menu.png" width="48%" alt="Plugin menu">

--- a/koreader-plugin/README.md
+++ b/koreader-plugin/README.md
@@ -40,7 +40,7 @@ Open a mapping's row to change the action or remove it.
 
 This is a frontend for [kindle-button-mapper](https://github.com/zampierilucas/kindle-button-mapper-rs), which ships with the release and is what reads the device and runs the action. Mappings live in its `/mnt/us/kindle-button-mapper/config.ini`, so a binding made here is the one the Mapper Manager app shows.
 
-KOReader actions ride on KOReader's HTTP Inspector, so it needs to be enabled with auto-start on. The `auto` and Kindle reader ones don't.
+KOReader actions arrive over a loopback endpoint the plugin itself serves on `127.0.0.1:8323`, so the HTTP Inspector plugin is not needed. The endpoint only runs while the mapper config has something to send at KOReader, to keep KOReader's idle loop asleep otherwise.
 
 ### Keys that KOReader normally ignores
 

--- a/koreader-plugin/hidpassthrough.koplugin/eventserver.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/eventserver.lua
@@ -1,0 +1,99 @@
+local Event = require("ui/event")
+local UIManager = require("ui/uimanager")
+local logger = require("logger")
+local util = require("util")
+
+local M = {
+    HOST = "127.0.0.1",
+    PORT = 8323,
+}
+
+local server
+
+local function parseArgs(uri)
+    local args, n = {}, 0
+    local i, len = 1, #uri
+    while i <= len do
+        local c = uri:sub(i, i)
+        if c == "/" then
+            i = i + 1
+        elseif c == '"' or c == "'" then
+            local close = uri:find(c, i + 1, true) or len + 1
+            n = n + 1
+            args[n] = uri:sub(i + 1, close - 1)
+            i = close + 1
+        else
+            local stop = uri:find("/", i, true) or len + 1
+            local text = uri:sub(i, stop - 1)
+            n = n + 1
+            if text == "true" then
+                args[n] = true
+            elseif text == "false" then
+                args[n] = false
+            elseif text == "nil" then
+                args[n] = nil
+            else
+                args[n] = tonumber(text) or text
+            end
+            i = stop + 1
+        end
+    end
+    return args, n
+end
+
+function M.parseRequest(data)
+    local method, path = data:match("^(%u+) (%S+)")
+    if method ~= "GET" or not path then return nil end
+    local uri = util.urlDecode(path):match("^/koreader/event/(.+)$")
+    if not uri then return nil end
+    local args, n = parseArgs(uri)
+    if n == 0 or type(args[1]) ~= "string" then return nil end
+    return args, n
+end
+
+local function onRequest(data, client)
+    local args, n = M.parseRequest(data)
+    local code, body
+    if args then
+        UIManager:nextTick(function()
+            UIManager:sendEvent(Event:new(table.unpack(args, 1, n)))
+        end)
+        code, body = "200 OK", "OK"
+    else
+        code, body = "400 Bad Request", "Bad request"
+    end
+    if server then
+        server:send(string.format(
+            "HTTP/1.0 %s\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+            code, #body, body), client)
+    end
+    return Event:new("InputEvent")
+end
+
+function M.start()
+    if server then return true end
+    local SimpleTCPServer = require("ui/message/simpletcpserver")
+    server = SimpleTCPServer:new{
+        host = M.HOST,
+        port = M.PORT,
+        receiveCallback = onRequest,
+    }
+    local ok, err = server:start()
+    if not ok then
+        logger.warn("HIDPassthrough: event server:", err)
+        server = nil
+        return false
+    end
+    UIManager:insertZMQ(server)
+    logger.dbg("HIDPassthrough: event server on port", M.PORT)
+    return true
+end
+
+function M.stop()
+    if not server then return end
+    UIManager:removeZMQ(server)
+    server:stop()
+    server = nil
+end
+
+return M

--- a/koreader-plugin/hidpassthrough.koplugin/main.lua
+++ b/koreader-plugin/hidpassthrough.koplugin/main.lua
@@ -347,6 +347,26 @@ function HIDPassthrough:_mapper()
     return self._mapper_client
 end
 
+function HIDPassthrough:_eventServer()
+    if not self._event_server then
+        self._event_server = dofile(self.path .. "/eventserver.lua")
+    end
+    return self._event_server
+end
+
+function HIDPassthrough:_syncEventServer()
+    local f = io.open(self:_mapper().CONFIG, "r")
+    local text = f and f:read("*a") or ""
+    if f then f:close() end
+    if text:find("koreader.sh", 1, true)
+        or text:find("auto.sh", 1, true)
+        or text:find("keyboard_layout", 1, true) then
+        self:_eventServer().start()
+    else
+        self:_eventServer().stop()
+    end
+end
+
 function HIDPassthrough:genMapperMenu()
     local mapper = self:_mapper()
     if not mapper.installed() then
@@ -598,6 +618,7 @@ function HIDPassthrough:mapperEdit(transform)
         return false
     end
     mapper.reload()
+    self:_syncEventServer()
     return true
 end
 
@@ -1663,11 +1684,17 @@ function HIDPassthrough:init()
     -- A device may already be connected.
     self:_scanInputs()
     self:_startBatteryPoll()
+    self:_syncEventServer()
 end
 
 function HIDPassthrough:onCloseWidget()
     self:_cancelPolls()
     self:_stopBatteryPoll()
+    self:_eventServer().stop()
+end
+
+function HIDPassthrough:onResume()
+    self:_syncEventServer()
 end
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Mapped KOReader actions needed the HTTP Inspector plugin enabled, an extra setup step that also binds a debug API on every interface and pokes holes in the firewall. The plugin now serves the inspector's own /koreader/event/<Name> URI shape itself, loopback only on 127.0.0.1:8323, and dispatches the events internally through UIManager. Same coercion rules as the inspector's parser, so the mapper's whole event surface (page turns, dispatcher actions, kolayout's quoted TextInput) works unchanged.

A registered ZMQ caps UIManager's idle wait at 50ms, so the endpoint only runs while the mapper config actually has something aimed at KOReader (koreader.sh, auto.sh or a keyboard_layout), re-checked after every mapping edit and on resume.

Tested on the Basic with the inspector off. curl to 8323 opens the menu and types text, bad requests get a 400, and the listener comes up only when the gate matches.

Pairs with zampierilucas/kindle-button-mapper-rs PR that makes the mapper try 8323 first with an 8080 fallback.