### PR TITLE
fix(uhid): keep the input node alive across a reconnect

### DIFF
--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -133,10 +133,6 @@ class DeviceSession:
                 if self.uhid_loop and self.uhid_device.fd is not None:
                     self.uhid_loop.remove_reader(self.uhid_device.fd)
                     self.uhid_loop = None
-                try:
-                    self.uhid_device.destroy()
-                except Exception:
-                    pass
                 self.uhid_device = None
             if self.channels:
                 if self.is_alive():
@@ -190,6 +186,7 @@ class HIDHost(ClassicMixin, BLEMixin):
 
         self.keystore = create_keystore(config.pairing_keys_file)
         self.device_cache = DeviceCache(config.cache_dir)
+        self._uhid_nodes: dict = {}
         self.media_remote = (MediaRemote(self._notify_sessions_changed)
                              if config.media_remote_enabled else None)
         self._discoverable_task = None
@@ -347,6 +344,13 @@ class HIDHost(ClassicMixin, BLEMixin):
                 self.ble_devices.append(dev)
 
         log.info(f"Devices: {len(self.classic_devices)} Classic, {len(self.ble_devices)} BLE")
+
+        configured = {normalize_addr(d.address)
+                      for d in self.classic_devices + self.ble_devices}
+        for address in list(self._uhid_nodes):
+            if normalize_addr(address) not in configured and address not in self.sessions:
+                log.info(f"Removing UHID node for unconfigured {address}")
+                self._destroy_uhid_node(address)
 
     async def start(self, pairing: bool = False):
         """Initialize the Bumble device with both protocols."""
@@ -798,8 +802,32 @@ class HIDHost(ClassicMixin, BLEMixin):
             return True
         return False
 
+    def _destroy_uhid_node(self, address: str):
+        """Drop the node kept for an address."""
+        node = self._uhid_nodes.pop(address, None)
+        if not node:
+            return
+        if node.fd is not None:
+            try:
+                asyncio.get_event_loop().remove_reader(node.fd)
+            except Exception:
+                pass
+        try:
+            node.destroy()
+        except Exception:
+            pass
+
     def _create_uhid_device(self, session: DeviceSession):
-        """Create UHID virtual device."""
+        """Attach the session to its UHID node, creating one if needed.
+
+        The node outlives the connection. A report written to a fresh node is
+        lost: evdev only buffers for readers already attached, and X takes
+        about half a second to open a new node while KOReader takes two. A
+        page turner that wakes on a button press sends exactly one report for
+        that press, so a node built per connect eats it and the user has to
+        press twice (issue #185). Keeping the node means the readers never
+        detach and the wake-up press lands.
+        """
         if not session.report_map:
             log.warning("No report descriptor for UHID")
             return
@@ -811,20 +839,28 @@ class HIDHost(ClassicMixin, BLEMixin):
         try:
             name = self._configured_name(session.address) or session.name or "HID Device"
             descriptor = sanitize_digitizer(session.report_map)
-            session.uhid_device = UHIDDevice(
-                name=name,
-                report_descriptor=descriptor,
-                bus=Bus.BLUETOOTH,
-                vendor=0,
-                product=0,
-                uniq=session.address,
-            )
-            log.success(f"UHID device created: {name}")
+            node = self._uhid_nodes.get(session.address)
+            if node and (node.report_descriptor != descriptor or node.name != name):
+                log.info(f"UHID device changed, rebuilding: {name}")
+                self._destroy_uhid_node(session.address)
+                node = None
             session.uhid_loop = asyncio.get_event_loop()
-            session.uhid_loop.add_reader(
-                session.uhid_device.fd, self._on_uhid_output, session)
-            session.uhid_loop.call_later(
-                0.5, session.uhid_device.discover_input_paths)
+            if node:
+                log.success(f"UHID device reused: {name}")
+            else:
+                node = UHIDDevice(
+                    name=name,
+                    report_descriptor=descriptor,
+                    bus=Bus.BLUETOOTH,
+                    vendor=0,
+                    product=0,
+                    uniq=session.address,
+                )
+                self._uhid_nodes[session.address] = node
+                log.success(f"UHID device created: {name}")
+                session.uhid_loop.call_later(0.5, node.discover_input_paths)
+            session.uhid_device = node
+            session.uhid_loop.add_reader(node.fd, self._on_uhid_output, session)
             session.is_pointer = descriptor_is_pointer(descriptor)
             if session.is_pointer:
                 log.info("Pointer device: cursor overlay on")
@@ -866,6 +902,8 @@ class HIDHost(ClassicMixin, BLEMixin):
                 await session.cleanup()
             except Exception:
                 pass
+        for address in list(self._uhid_nodes):
+            self._destroy_uhid_node(address)
         if had_pointer:
             self._notify_pointer(False)
 


### PR DESCRIPTION
Fixes #185.

A report written to a fresh UHID node goes nowhere. evdev only buffers for readers that are already attached, and measuring it again on a Basic 4, X opens a new node about half a second after it appears and KOReader takes two. A page turner that wakes on a button press sends exactly one report for that press, so rebuilding the node on every connect eats it and you press twice.

The node now belongs to the host, keyed by address, and a session only borrows it. Nothing is held or replayed, which is what sank #235, the readers just never detach. Rebuilt when the descriptor or the configured name changes, pruned once the device leaves config, destroyed with the host.

Before the change, a press written at node creation never reaches a reader that attaches later.

```
create               t=0.011
wrote press+rel      t=0.011
node event3          t=0.208
opened by Xorg       t=0.436
opened by reader.lua t=0.902
early press visible to late reader: False
press with reader attached:         True
```

UHID_OPEN is still no use as a trigger, it fired at 0.007, 0.186 and 0.035 across three runs, before anything real attached.

End to end with an Xbox controller, same disconnect before and after.

```
14:05:54  Device disconnected (reason=22)
14:05:55  Destroyed UHID device: Xbox Wireless Controller

18:45:00  Device disconnected (reason=22) after 42.4s encrypted
18:49:38  UHID device reused: Xbox Wireless Controller
```

kindle-button-mapper is the better witness here. On the old code the disconnect kills its read with ENODEV and it sits waiting for the node to come back, on this one it keeps its exclusive grab through the whole outage and a mapped button fires 11 seconds after the reconnect with no re-attach in between.

```
17:32:37  event loop error: Read error: No such device (os error 19)
17:44:18  Found device at /dev/input/event3 / Grabbed device exclusively
17:45:00  (patched disconnect, nothing at all)
17:49:38  (reconnect, UHID device reused)
17:49:49  Button: BTN_EAST (code: 305) -> koreader.sh event ShowGotoDialog
```

Two devices still behave, each keeps its own node, no cross talk, one dropping does not touch the other.

What it does not fix is the first connect after a daemon start, the node cannot exist before the descriptor does. Pre creating from the cache would close that, but it leaves a keyboard node hanging around for a device that may never connect, so I left it out.
