### PR TITLE
fix(uinput): open the node to decide it is real, not stat it

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The Kindle's kernel Bluetooth stack has bugs that prevent proper HID pairing. By
 
 ### Kernel Modules
 
-8th-10th gen Kindle kernels ship without `CONFIG_UHID`. For these, prebuilt `uhid.ko` modules matching each firmware (kernel release + build number + board codename) are bundled in [`kindle_hid_passthrough/modules/`](kindle_hid_passthrough/modules/) and loaded automatically when `/dev/uhid` is missing. If no module matches your firmware, open an issue with the contents of `/etc/version.txt`.
+8th-10th gen Kindle kernels ship without `CONFIG_UHID`. For these, prebuilt `uhid.ko` modules matching each firmware (kernel release + build number + board codename) are bundled in [`kindle_hid_passthrough/modules/`](kindle_hid_passthrough/modules/) and loaded automatically when `/dev/uhid` does not open. On an installed release they live in `/mnt/us/kindle_hid_passthrough/dist/kindle_hid_passthrough/modules/`, which is the path to use for a manual `insmod`. If no module matches your firmware, open an issue with the contents of `/etc/version.txt`.
 
 The build recipe for the bundled `uhid.ko` modules is in [`docs/uhid-research.md`](docs/uhid-research.md).
 

--- a/kindle_hid_passthrough/bt_setup.py
+++ b/kindle_hid_passthrough/bt_setup.py
@@ -90,6 +90,15 @@ def _log_missing_kmod(codename, expected=None, mod='uhid', optional=False):
         say("  ^ open an issue with these lines so we can compile the module")
 
 
+def _node_ready(path):
+    """True when the node exists and the driver behind it opens."""
+    try:
+        os.close(os.open(path, os.O_RDWR | os.O_NONBLOCK))
+        return True
+    except OSError:
+        return False
+
+
 def _create_dev_node(sysfs_dev, dev_path):
     """Create a char device node from a sysfs 'major:minor' dev attribute.
 
@@ -124,7 +133,7 @@ def _ensure_hid_core(kernel, build, codename):
 
 def ensure_uhid():
     """Load bundled uhid.ko on Kindles whose stock kernel lacks CONFIG_UHID."""
-    if os.path.exists('/dev/uhid'):
+    if _node_ready('/dev/uhid'):
         return True
     codename = detect_codename()
     if not codename:
@@ -145,9 +154,9 @@ def ensure_uhid():
         if not run(['/sbin/insmod', ko]):
             continue
         # duet lacks devtmpfs, so misc_register doesn't create /dev/uhid
-        if not os.path.exists('/dev/uhid'):
+        if not _node_ready('/dev/uhid'):
             _create_dev_node('/sys/class/misc/uhid/dev', '/dev/uhid')
-        if os.path.exists('/dev/uhid'):
+        if _node_ready('/dev/uhid'):
             return True
     _log_missing_kmod(codename, expected)
     return False
@@ -155,10 +164,10 @@ def ensure_uhid():
 
 def ensure_uinput():
     """Best-effort /dev/uinput: stock module, then bundled .ko, else explain."""
-    if os.path.exists('/dev/uinput'):
+    if _node_ready('/dev/uinput'):
         return True
     # Device may ship uinput.ko itself (in /lib/modules) even if not built-in.
-    if run(['/sbin/modprobe', 'uinput']) and os.path.exists('/dev/uinput'):
+    if run(['/sbin/modprobe', 'uinput']) and _node_ready('/dev/uinput'):
         return True
     codename = detect_codename()
     build = _read_firmware_build() if codename else None
@@ -170,9 +179,9 @@ def ensure_uinput():
             log.info(f"loading {os.path.basename(ko)}")
             if not run(['/sbin/insmod', ko]):
                 continue
-            if not os.path.exists('/dev/uinput'):
+            if not _node_ready('/dev/uinput'):
                 _create_dev_node('/sys/class/misc/uinput/dev', '/dev/uinput')
-            if os.path.exists('/dev/uinput'):
+            if _node_ready('/dev/uinput'):
                 return True
     _log_missing_kmod(codename, expected, mod='uinput', optional=True)
     return False

--- a/kindle_hid_passthrough/diagnostics.py
+++ b/kindle_hid_passthrough/diagnostics.py
@@ -9,6 +9,7 @@ Safe to run at any time: nothing here writes to the chip or the UART.
 import os
 import subprocess
 
+from bt_setup import _node_ready
 from config import config, get_version
 from kindle_detect import (detect_codename, detect_kindle, read_serial,
                            _decode_device_code)
@@ -152,7 +153,8 @@ def run_diagnostics():
     _kv("daemon (main.py)", _sh(['pgrep', '-f', 'main.py --daemon']) or "not running")
 
     _hdr("UHID")
-    _kv("/dev/uhid", os.path.exists('/dev/uhid'))
+    _kv("/dev/uhid", _node_ready('/dev/uhid'))
+    _kv("/dev/uinput", _node_ready('/dev/uinput'))
     _kv("/sys/bus/hid", os.path.exists('/sys/bus/hid'))
     _kv("modules", _sh(['sh', '-c', 'lsmod | grep -iE "uhid|hidp|^hid|bt" || true']) or "<none>")
 


### PR DESCRIPTION
Fixes #259.

`ensure_uinput()` returned early on `os.path.exists('/dev/uinput')`, so any node at that path suppressed the bundled `uinput.ko` load. kindle-button-mapper up to 1.6.0 mknods `/dev/uinput c 10 223` at its own startup whether or not the driver is registered, and it starts first, so on a `rex` kernel without `CONFIG_INPUT_UINPUT` the dead node it left behind meant neither project ever loaded the module. The early return logs nothing, which is why the reporter's daemon log had no uinput lines at all. The mapper side is zampierilucas/kindle-button-mapper-rs#74, merged.

`_node_ready()` opens the node and closes it, and replaces the bare existence checks on both `/dev/uhid` and `/dev/uinput`. Unlike the `/dev/stpbt` probe removed in 8dd4bbe, an open/close on a misc node is free — `uinput_open` and `uhid_char_open` only allocate a per-fd struct, nothing is created before `UI_DEV_CREATE`/`UHID_CREATE`, and no hardware is touched. The diagnostics dump reports both nodes through the same open, so it stops calling a dead node present.

Also points the README at the installed modules directory, since a manual `insmod` from the documented repo path fails on device — the second half of the report.

Not tested on device. 35 tests pass; the probe needs a `rex` that boots without uinput to confirm.