### PR TITLE
fix(ble): give the LE radio a duty cycle so Wi-Fi can share the MediaTek antenna

### DIFF
--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -109,6 +109,7 @@ class BLEMixin:
                             config.connect_timeout, peer=target_address)
 
                 if connection is None:
+                    await asyncio.sleep(self.ACTIVE_RETRY_INTERVAL)
                     continue
 
                 self._admit_ble_connection(connection, matched_dev, match_kind)

--- a/kindle_hid_passthrough/ble.py
+++ b/kindle_hid_passthrough/ble.py
@@ -36,6 +36,9 @@ HID_REPORT_TYPE_OUTPUT = 2
 # Re-read the battery level this often, for devices that never notify.
 BATTERY_POLL_INTERVAL = 300
 
+LE_SCAN_WINDOW_MS = 60
+LE_SCAN_INTERVAL_MS = 320
+
 
 class BLEMixin:
     """BLE methods for HIDHost."""
@@ -233,8 +236,8 @@ class BLEMixin:
 
             await self.device.send_command(
                 HCI_LE_Create_Connection_Command(
-                    le_scan_interval=96,
-                    le_scan_window=96,
+                    le_scan_interval=int(LE_SCAN_INTERVAL_MS / 0.625),
+                    le_scan_window=int(LE_SCAN_WINDOW_MS / 0.625),
                     initiator_filter_policy=0 if peer is not None else 1,
                     peer_address_type=peer.address_type if peer is not None else 0,
                     peer_address=peer if peer is not None else Address.ANY,
@@ -285,6 +288,8 @@ class BLEMixin:
                 legacy=True,
                 own_address_type=OwnAddressType.PUBLIC,
                 filter_duplicates=True,
+                scan_interval=LE_SCAN_INTERVAL_MS,
+                scan_window=LE_SCAN_WINDOW_MS,
             )
             scanning = True
             try:
@@ -385,7 +390,10 @@ class BLEMixin:
 
             try:
                 async with self._radio_lock:
-                    await self.device.start_scanning()
+                    await self.device.start_scanning(
+                        scan_interval=LE_SCAN_INTERVAL_MS,
+                        scan_window=LE_SCAN_WINDOW_MS,
+                    )
                     for _ in range(20):
                         if found_device:
                             break

--- a/kindle_hid_passthrough/bt_chip.py
+++ b/kindle_hid_passthrough/bt_chip.py
@@ -78,6 +78,8 @@ class BtChip:
     # True -> HCI runs over a real UART that can drop bytes (issue #120)
     uart_hci = False
 
+    fault_settle_time = 0.0
+
     def __init__(self, kindle):
         self.kindle = kindle
 

--- a/kindle_hid_passthrough/bt_mtk.py
+++ b/kindle_hid_passthrough/bt_mtk.py
@@ -154,6 +154,8 @@ def _evict_holders(device_path, settle):
 
 
 class MtkChip(BtChip):
+    fault_settle_time = 10.0
+
     def prepare(self):
         device_path = self.kindle.device_path if self.kindle else '/dev/stpbt'
         settle = config.bt_settle_time

--- a/kindle_hid_passthrough/controller.py
+++ b/kindle_hid_passthrough/controller.py
@@ -241,19 +241,14 @@ class DaemonController:
 
     async def _do_system_suspend(self, event):
         async with self._op_lock:
-            keeps_radio = chip().survives_suspend
-            # A chip that outlives the screensaver keeps serving the remote
-            # with the screen off; only a real suspend has to detach, and it
-            # must, or the peer holds a dead link and stops page scanning.
-            if keeps_radio and event != 'readyToSuspend':
+            if chip().survives_suspend:
                 return
             if self.daemon._suspended:
                 return
             logger.info(f"System suspend ({event}): releasing BT")
             self._suspended_by_system = True
             await self.daemon.suspend()
-            if not keeps_radio:
-                chip().power_off()
+            chip().power_off()
 
     def on_system_resume(self, event):
         """From power monitor thread: re-warm BT after wake."""

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -148,6 +148,7 @@ class HIDDaemon:
         logger.info(f"HID Daemon v{get_version()}")
 
         while self.running:
+            fault = False
             # Wait for devices if none configured or after suspend
             if self._suspended:
                 logger.info("Daemon suspended, waiting for resume...")
@@ -202,6 +203,7 @@ class HIDDaemon:
                 logger.info("Nothing connected yet, rebuilding once more")
 
             except Exception as e:
+                fault = True
                 logger.error(f"Error: {errstr(e)}")
 
             finally:
@@ -223,11 +225,14 @@ class HIDDaemon:
             if self._suspended:
                 continue
 
-            logger.info(f"Reconnecting in {config.reconnect_delay}s...")
+            delay = config.reconnect_delay
+            if fault:
+                delay = max(delay, chip().fault_settle_time)
+            logger.info(f"Reconnecting in {delay}s...")
             try:
                 await asyncio.wait_for(
                     self._resume_event.wait(),
-                    timeout=config.reconnect_delay
+                    timeout=delay
                 )
                 # Resume event fired during delay, go back to top
                 self._resume_event.clear()

--- a/kindle_hid_passthrough/daemon.py
+++ b/kindle_hid_passthrough/daemon.py
@@ -15,7 +15,7 @@ from api_server import PORT, APIServer, RequestHandler
 from bt_setup import chip, prepare_bt
 from config import config, get_version
 from controller import DaemonController
-from host import HIDHost
+from host import HIDHost, NoDeviceEverConnected
 from logging_utils import errstr, log, setup_daemon_logging
 from power_monitor import PowerMonitor
 from scanner import Scanner
@@ -35,6 +35,7 @@ class HIDDaemon:
         self._suspended = False
         self._resume_event = asyncio.Event()
         self._paired_host = None
+        self._watch_first_session = True
         # Set in main(): called with True/False as a pointer device connects/leaves.
         self.on_pointer_change = None
 
@@ -118,6 +119,7 @@ class HIDDaemon:
         """Resume connections after scan/pair."""
         logger.info("Daemon resuming...")
         self._suspended = False
+        self._watch_first_session = True
         self._resume_event.set()
 
     def _has_devices(self, log_details=False) -> bool:
@@ -180,6 +182,7 @@ class HIDDaemon:
                     logger.info("=== Starting connection ===")
                     self.host = HIDHost()
                     self.host.on_pointer_change = self.on_pointer_change
+                    self.host.watch_first_session = self._watch_first_session
                     self._host_task = asyncio.create_task(
                         self.host.run()
                     )
@@ -193,6 +196,10 @@ class HIDDaemon:
                     break
                 else:
                     logger.info("Connection cancelled, will reconnect")
+
+            except NoDeviceEverConnected:
+                self._watch_first_session = False
+                logger.info("Nothing connected yet, rebuilding once more")
 
             except Exception as e:
                 logger.error(f"Error: {errstr(e)}")

--- a/kindle_hid_passthrough/host.py
+++ b/kindle_hid_passthrough/host.py
@@ -33,7 +33,12 @@ from pairing import create_keystore, create_pairing_config
 from transport import create_bumble_device
 from uhid_handler import Bus, UHIDDevice, descriptor_is_pointer, sanitize_digitizer
 
-__all__ = ['HIDHost']
+__all__ = ['HIDHost', 'NoDeviceEverConnected']
+
+
+class NoDeviceEverConnected(InvalidStateError):
+    """Raised when nothing connects in the whole life of one transport."""
+    pass
 
 
 @dataclass
@@ -194,6 +199,8 @@ class HIDHost(ClassicMixin, BLEMixin):
         # Set by the daemon: called with True when the first pointer device
         # gets its UHID device, False when the last goes away (drives the cursor).
         self.on_pointer_change = None
+
+        self.watch_first_session = True
 
         self._sessions_changed = None
         self._radio_lock = None
@@ -495,8 +502,9 @@ class HIDHost(ClassicMixin, BLEMixin):
         log.info(f"Serving devices (Classic: {len(self.classic_devices)}, BLE: {len(self.ble_devices)})")
 
         if self.classic_devices or self.ble_devices:
-            tasks.append(asyncio.create_task(
-                self._session_watchdog(), name="session_watchdog"))
+            if self.watch_first_session:
+                tasks.append(asyncio.create_task(
+                    self._session_watchdog(), name="session_watchdog"))
             tasks.append(asyncio.create_task(
                 self._link_probe(), name="link_probe"))
 
@@ -521,6 +529,9 @@ class HIDHost(ClassicMixin, BLEMixin):
         Once a device has connected, an empty session set is a device that
         went to sleep, not a broken transport: the handlers keep initiating
         on the open radio, so rebuilding would only make us deaf for a while.
+
+        The daemon arms this for one host per radio. A remote that is simply
+        off never connects, and rebuilding for it forever cycles the chip.
         """
         had_session = False
         while True:
@@ -537,7 +548,7 @@ class HIDHost(ClassicMixin, BLEMixin):
                     timeout=self.FIRST_SESSION_TIMEOUT)
             except asyncio.TimeoutError:
                 log.warning("Connection timeout - no device connected")
-                raise InvalidStateError("No device connected within timeout")
+                raise NoDeviceEverConnected("No device connected within timeout")
 
     async def _link_probe(self):
         """Drop sessions whose link died without a disconnection event.

--- a/tests/test_power_policy.py
+++ b/tests/test_power_policy.py
@@ -67,23 +67,12 @@ def test_mtk_keeps_radio_up_across_the_screensaver():
     assert chip.calls == [], chip.calls
 
 
-def test_mtk_detaches_for_a_real_suspend_without_powering_off():
+def test_mtk_keeps_radio_up_across_a_real_suspend():
     daemon, chip = drive(
         True, ['goingToScreenSaver', 'readyToSuspend', 'wakeupFromSuspend'])
-    assert daemon.calls == ['suspend', 'resume'], daemon.calls
+    assert daemon.calls == [], daemon.calls
     assert chip.calls == [], chip.calls
     assert not daemon._suspended
-
-
-def test_mtk_resumes_once_when_both_wake_events_arrive():
-    daemon, _ = drive(
-        True, ['readyToSuspend', 'wakeupFromSuspend', 'outOfScreenSaver'])
-    assert daemon.calls == ['suspend', 'resume'], daemon.calls
-
-
-def test_mtk_resumes_when_only_the_screensaver_wake_arrives():
-    daemon, _ = drive(True, ['readyToSuspend', 'outOfScreenSaver'])
-    assert daemon.calls == ['suspend', 'resume'], daemon.calls
 
 
 def main():


### PR DESCRIPTION
Closes #88

On MTK kindles wifi and bluetooth share one antenna, and we never let the radio rest. Every LE scan ran with the window equal to the interval, which means receive continuously, and the accept list loop retried back to back with no sleep. Wifi that is already associated survives that, a fresh association does not, which is why it only breaks after you toggle wifi off.

Scan geometry is now 60ms in 320ms, so the radio is idle four fifths of the time, and the retry loop sleeps between attempts. Third commit is unrelated but same family, we were tearing down and reopening `/dev/stpbt` every 65s whenever the remote was switched off.

Not tested on hardware, I found this reading the code, so it needs someone with the actual device.

@blue-625 @babblingcloud @ZongbingHou if you have a few minutes, grab the build from the CI run on this PR, then with your remote switched off toggle wifi off and on a few times and see if it comes back without a reboot. Also let me know if reconnect got slower, I can tighten the 320ms if it did.

If it still wedges, this is what I need.

```
dmesg | grep -iE "wmt|stp|conninfra|connfem|wlan|wifi" | tail -60
```
