### PR TITLE
docs: shorten the kpm add-repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Community walkthrough by [@jencaps89](https://www.tiktok.com/@jencaps89) showing
 If you have [KPM](https://kindlemodding.org/kindle-dev/kpm/) installed ([how to get it](https://kindlemodding.org/jailbreaking/whats-next/installing-homebrew.html#kpm)), add this repository once and install:
 
 ```bash
-kpm add-repo https://raw.githubusercontent.com/zampierilucas/kindle-hid-passthrough/main/kpm/repo.json
+kpm add-repo lzampier.com/hid
 kpm install kindle-hid-passthrough
 ```
 


### PR DESCRIPTION
`kpm add-repo lzampier.com/hid` instead of the 89-character raw manifest url, since typing on the Kindle keyboard is painful.

A Cloudflare redirect rule sends `/hid` to `raw.githubusercontent.com/.../kpm/repo.json` with a 301; KPM follows redirects (`CURLOPT_FOLLOWLOCATION` in its `simpleGET.c`) and libcurl guesses https for the schemeless form. Verified with a libcurl program using KPM's exact options and with the request forced at Cloudflare's IPs: 301 then 200 on the manifest.

`kpm/repo.json` does not move, so the release workflow is unchanged.